### PR TITLE
CLI: Improve error messages

### DIFF
--- a/lxc/config_device.go
+++ b/lxc/config_device.go
@@ -792,7 +792,7 @@ func (c *cmdConfigDeviceSet) run(cmd *cobra.Command, args []string) error {
 				return errors.New(i18n.G("Device doesn't exist"))
 			}
 
-			return errors.New(i18n.G("Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"))
+			return fmt.Errorf("Device %q from profile(s) %q cannot be modified for individual instance %q: %w", devname, inst.Profiles, inst.Name, errors.New(i18n.G("Override device or modify profile instead")))
 		}
 
 		for k, v := range keys {

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -2720,7 +2720,7 @@ func (c *cmdStorageVolumeExport) run(cmd *cobra.Command, args []string) error {
 
 	volName, volType := parseVolume("custom", args[1])
 	if volType != "custom" {
-		return errors.New(i18n.G("Only \"custom\" volumes can be exported"))
+		return fmt.Errorf("Failed to create storage volume backup for volume %q: %w", volName, errors.New(i18n.G("Only \"custom\" volumes can be exported")))
 	}
 
 	req := api.StoragePoolVolumeBackupsPost{
@@ -2738,7 +2738,7 @@ func (c *cmdStorageVolumeExport) run(cmd *cobra.Command, args []string) error {
 
 	op, err := d.CreateStoragePoolVolumeBackup(name, volName, req)
 	if err != nil {
-		return fmt.Errorf("Failed to create storage volume backup: %w", err)
+		return fmt.Errorf("Failed to create storage volume backup for volume %q: %w", volName, err)
 	}
 
 	// Watch the background operation

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -103,7 +103,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -223,7 +223,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,7 +316,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -330,7 +330,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -406,7 +406,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -437,7 +437,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -468,7 +468,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -509,15 +509,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -546,11 +546,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -575,25 +575,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -605,23 +605,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -629,7 +629,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -637,11 +637,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -678,15 +678,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -745,7 +745,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -772,27 +772,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -830,7 +830,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,11 +849,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -884,14 +884,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1037,7 +1037,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1074,17 +1074,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1102,63 +1102,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1177,20 +1177,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1226,13 +1226,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1301,7 +1301,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1345,21 +1345,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1374,27 +1374,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1474,15 +1474,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,23 +1490,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1542,16 +1542,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1569,7 +1569,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1581,11 +1581,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1625,15 +1625,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1641,23 +1641,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1687,15 +1687,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1719,51 +1719,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1784,8 +1784,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1798,11 +1798,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1839,12 +1839,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1860,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1913,19 +1907,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1933,7 +1927,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1941,7 +1935,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1950,7 +1944,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1958,7 +1952,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1972,7 +1966,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1980,7 +1974,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2016,19 +2010,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2036,19 +2030,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2072,17 +2066,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2098,7 +2092,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2125,11 +2119,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2140,10 +2134,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2155,11 +2149,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2169,7 +2163,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2248,7 +2242,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2261,7 +2255,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2355,11 +2349,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2369,7 +2363,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2379,7 +2373,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2389,7 +2383,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2414,7 +2408,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2423,7 +2417,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2433,13 +2427,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2450,7 +2444,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2458,11 +2452,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2478,7 +2472,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2503,16 +2497,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2524,7 +2518,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2548,7 +2542,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2568,7 +2562,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2576,7 +2570,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2584,23 +2578,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2608,23 +2602,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2644,7 +2638,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2656,19 +2650,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2676,19 +2670,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2732,7 +2726,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2764,7 +2758,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2782,11 +2776,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2794,15 +2788,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2944,7 +2938,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2969,7 +2963,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2987,7 +2981,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2996,7 +2990,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3030,7 +3024,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3087,7 +3081,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3122,7 +3116,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3130,17 +3124,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3152,8 +3146,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3171,12 +3165,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3190,7 +3184,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3202,35 +3196,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3238,19 +3232,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3429,11 +3423,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3449,7 +3443,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3485,7 +3479,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3493,11 +3487,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3529,7 +3523,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3537,15 +3531,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3553,7 +3547,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3563,11 +3557,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3580,15 +3574,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3596,7 +3590,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3615,15 +3609,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3702,31 +3696,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3734,15 +3728,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3750,11 +3744,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3790,7 +3784,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3802,7 +3796,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3825,17 +3819,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3884,13 +3878,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3916,8 +3910,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3926,14 +3920,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3943,41 +3937,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4003,18 +3997,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4034,7 +4028,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4059,7 +4053,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4114,11 +4108,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4130,12 +4124,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4148,11 +4142,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4164,9 +4158,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4193,11 +4187,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4207,67 +4201,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4297,20 +4291,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4332,12 +4326,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4345,19 +4339,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4383,7 +4377,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4400,7 +4394,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4412,7 +4406,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4423,6 +4417,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4455,7 +4453,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4463,29 +4461,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4506,7 +4504,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4514,11 +4512,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4535,14 +4533,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4556,7 +4554,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4579,32 +4577,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4621,7 +4619,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4634,22 +4632,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4747,7 +4745,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4783,7 +4781,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4791,7 +4789,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4799,7 +4797,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4838,45 +4836,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4890,7 +4888,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4898,11 +4896,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4910,23 +4908,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4938,7 +4936,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4946,19 +4944,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4966,7 +4964,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4974,11 +4972,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4999,23 +4997,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5037,7 +5035,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5064,7 +5062,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5083,7 +5081,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5096,7 +5094,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5105,7 +5103,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5125,7 +5123,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5155,20 +5153,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5176,11 +5174,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5193,23 +5191,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5222,7 +5220,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5269,11 +5267,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5282,11 +5280,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5295,11 +5293,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5308,11 +5306,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5334,11 +5332,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5347,15 +5345,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5364,11 +5362,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5416,7 +5414,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5444,19 +5442,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5464,23 +5462,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5516,7 +5514,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5524,7 +5522,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5585,23 +5583,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5609,23 +5607,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5659,7 +5657,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5687,7 +5685,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5699,7 +5697,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5739,7 +5737,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5747,7 +5745,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5756,7 +5754,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5848,7 +5846,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5871,11 +5869,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5897,14 +5895,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5920,7 +5918,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5958,7 +5956,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5972,11 +5970,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5995,7 +5993,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6010,22 +6008,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6035,22 +6033,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6076,7 +6074,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6093,12 +6091,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6114,11 +6112,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6146,11 +6144,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6165,7 +6163,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6214,24 +6212,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6250,7 +6248,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6261,7 +6259,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6269,21 +6267,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6297,7 +6295,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6311,8 +6309,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6327,7 +6325,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6341,7 +6339,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6361,27 +6359,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6393,19 +6391,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6421,19 +6419,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6441,23 +6439,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6486,21 +6484,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6509,7 +6507,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6542,7 +6540,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6556,15 +6554,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6600,7 +6598,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6624,9 +6622,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6646,7 +6644,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6662,11 +6660,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6674,11 +6672,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6698,48 +6696,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6774,8 +6772,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6785,7 +6783,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6871,11 +6869,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6942,24 +6940,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6967,70 +6965,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7056,19 +7054,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7181,8 +7179,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7198,11 +7196,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7210,28 +7208,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7239,31 +7237,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7287,19 +7285,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7367,13 +7365,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7382,7 +7380,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7566,7 +7564,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7574,7 +7572,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7583,7 +7581,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7591,7 +7589,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7600,7 +7598,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7608,7 +7606,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7622,7 +7620,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7634,7 +7632,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7653,13 +7651,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7667,13 +7665,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7783,7 +7781,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7795,7 +7793,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7832,11 +7830,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -150,7 +150,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -323,7 +323,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -369,7 +369,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -411,7 +411,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -488,7 +488,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -514,7 +514,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -540,7 +540,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -578,7 +578,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -617,7 +617,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -656,7 +656,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -689,7 +689,7 @@ msgstr "%s ist kein Verzeichnis"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr "(kein Wert)"
 
@@ -723,7 +723,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 #, fuzzy
 msgid "--project cannot be used with the query command"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -771,15 +771,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -813,11 +813,11 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -825,7 +825,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
@@ -843,27 +843,27 @@ msgstr "Profil %s erstellt\n"
 msgid "Access the expanded configuration"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -876,24 +876,24 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -911,11 +911,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -952,15 +952,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -970,7 +970,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Add roles to a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -985,7 +985,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -1024,7 +1024,7 @@ msgstr "Aliasse:\n"
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr "Architektur: %s\n"
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1052,30 +1052,30 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 #, fuzzy
 msgid "Attach new network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
@@ -1116,7 +1116,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1135,11 +1135,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 #, fuzzy
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1172,14 +1172,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -1207,15 +1207,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1231,7 +1231,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1307,7 +1307,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1336,7 +1336,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1349,7 +1349,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1377,18 +1377,18 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1407,63 +1407,63 @@ msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1482,20 +1482,20 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1534,13 +1534,13 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, fuzzy, c-format
@@ -1611,7 +1611,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1630,7 +1630,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1659,21 +1659,21 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1688,27 +1688,27 @@ msgstr "YAML Analyse Fehler %v\n"
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1801,16 +1801,16 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1820,26 +1820,26 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new network peering"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 #, fuzzy
 msgid "Create projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1859,7 +1859,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
@@ -1869,7 +1869,7 @@ msgstr "Erstelle %s"
 msgid "Creating %s: %%s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 #, fuzzy
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1879,16 +1879,16 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1906,7 +1906,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1918,11 +1918,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1967,15 +1967,15 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Delete key from a storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -1984,25 +1984,25 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 #, fuzzy
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -2021,7 +2021,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -2035,15 +2035,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -2067,51 +2067,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2132,8 +2132,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -2147,12 +2147,12 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2191,12 +2191,6 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -2216,7 +2210,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
@@ -2277,22 +2271,22 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display instances from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2302,7 +2296,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display storage pool buckets from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2310,7 +2304,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -2319,7 +2313,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -2327,7 +2321,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "ABLAUFDATUM"
@@ -2342,7 +2336,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2350,7 +2344,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2394,21 +2388,21 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2418,21 +2412,21 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network peer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2458,17 +2452,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2484,7 +2478,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2512,11 +2506,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2527,10 +2521,10 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2542,7 +2536,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2551,7 +2545,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2561,7 +2555,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2648,7 +2642,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2661,7 +2655,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2755,11 +2749,11 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2769,7 +2763,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2779,7 +2773,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2789,7 +2783,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to find image %q on remote %q"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2814,7 +2808,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2823,7 +2817,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -2836,13 +2830,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2853,7 +2847,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2861,11 +2855,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2882,7 +2876,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2907,16 +2901,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2928,7 +2922,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2952,7 +2946,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -2982,7 +2976,7 @@ msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2990,24 +2984,24 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3017,25 +3011,25 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Get the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3058,7 +3052,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3073,21 +3067,21 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for instance or server configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3097,21 +3091,21 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network peer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3157,7 +3151,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3190,7 +3184,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3208,11 +3202,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3221,16 +3215,16 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -3376,7 +3370,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -3402,7 +3396,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3420,7 +3414,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3429,7 +3423,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3464,7 +3458,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid export version %q: %w"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3523,7 +3517,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3563,7 +3557,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3571,17 +3565,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3593,8 +3587,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3612,12 +3606,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 #, fuzzy
 msgid "Launching the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3632,7 +3626,7 @@ msgstr "Architektur: %s\n"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3646,38 +3640,38 @@ msgstr "Aliasse:\n"
 msgid "List all active certificate add tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 #, fuzzy
 msgid "List all warnings"
 msgstr "Aliasse:\n"
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3686,20 +3680,20 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3898,11 +3892,11 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "List permissions"
 msgstr "Aliasse:\n"
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3918,7 +3912,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3957,7 +3951,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3965,12 +3959,12 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 #, fuzzy
 msgid "List warnings"
 msgstr "Aliasse:\n"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -4002,7 +3996,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -4010,17 +4004,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 #, fuzzy
 msgid "Lower device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 #, fuzzy
 msgid "Lower devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4029,7 +4023,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4043,11 +4037,11 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -4060,15 +4054,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -4076,7 +4070,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4095,16 +4089,16 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -4195,36 +4189,36 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Manage instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4234,17 +4228,17 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network peerings"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4254,12 +4248,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage permissions"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 #, fuzzy
 msgid "Manage profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 #, fuzzy
 msgid "Manage projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -4302,7 +4296,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4315,7 +4309,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Veröffentliche Abbild"
@@ -4340,17 +4334,17 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Member %q does not have role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -4401,14 +4395,14 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4439,8 +4433,8 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4451,14 +4445,14 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 #, fuzzy
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4470,43 +4464,43 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4535,19 +4529,19 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4570,7 +4564,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4595,7 +4589,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4655,11 +4649,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4672,12 +4666,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4690,11 +4684,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4706,9 +4700,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4735,11 +4729,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4749,67 +4743,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, fuzzy, c-format
 msgid "Network %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, fuzzy, c-format
 msgid "Network %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -4839,22 +4833,22 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 #, fuzzy
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -4877,12 +4871,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 #, fuzzy
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4892,19 +4886,19 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 #, fuzzy
 msgid "No need to specify a warning UUID when using --all"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4932,7 +4926,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4949,7 +4943,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4961,7 +4955,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4972,6 +4966,10 @@ msgstr "Profil %s gelöscht\n"
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -5004,7 +5002,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -5012,29 +5010,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -5056,7 +5054,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
@@ -5065,12 +5063,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 #, fuzzy
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -5088,14 +5086,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -5109,7 +5107,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -5132,32 +5130,32 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, fuzzy, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -5177,7 +5175,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, fuzzy, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -5192,22 +5190,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5306,7 +5304,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -5345,7 +5343,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -5353,7 +5351,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -5361,7 +5359,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -5403,45 +5401,45 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -5455,7 +5453,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5465,11 +5463,11 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove a group from an identity"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Profil %s erstellt\n"
@@ -5479,25 +5477,25 @@ msgstr "Profil %s erstellt\n"
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5512,7 +5510,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -5521,22 +5519,22 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -5545,7 +5543,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5554,11 +5552,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5582,25 +5580,25 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Rename instances and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5624,7 +5622,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5652,7 +5650,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5674,7 +5672,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5688,7 +5686,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5698,7 +5696,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5720,7 +5718,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5750,20 +5748,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5771,11 +5769,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5788,25 +5786,25 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5820,7 +5818,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -5870,12 +5868,12 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5884,11 +5882,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5897,12 +5895,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5911,12 +5909,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5939,12 +5937,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5953,16 +5951,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5971,12 +5969,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6027,7 +6025,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6058,20 +6056,20 @@ msgstr "Setzt die uid der Datei beim Übertragen"
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -6081,25 +6079,25 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Set the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6138,7 +6136,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Profil %s erstellt\n"
@@ -6148,7 +6146,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show content of instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -6215,26 +6213,26 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Profil %s erstellt\n"
@@ -6244,26 +6242,26 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network peer configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -6301,7 +6299,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -6331,7 +6329,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -6385,7 +6383,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -6394,7 +6392,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6404,7 +6402,7 @@ msgstr ""
 msgid "State"
 msgstr "Erstellt: %s"
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Erstellt: %s"
@@ -6502,7 +6500,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Store the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6525,11 +6523,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6551,14 +6549,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -6575,7 +6573,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6617,7 +6615,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6631,11 +6629,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6655,7 +6653,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6670,22 +6668,22 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6695,22 +6693,22 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6736,7 +6734,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6753,13 +6751,13 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 #, fuzzy
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -6777,11 +6775,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6811,11 +6809,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6830,7 +6828,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6879,25 +6877,25 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6917,7 +6915,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6928,7 +6926,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6936,21 +6934,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6964,7 +6962,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
@@ -6979,8 +6977,8 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6995,7 +6993,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, fuzzy, c-format
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -7010,7 +7008,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unset UEFI variables for instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7034,31 +7032,31 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7073,21 +7071,21 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -7106,20 +7104,20 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7129,26 +7127,26 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7180,22 +7178,22 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7204,7 +7202,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 #, fuzzy
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -7238,7 +7236,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -7252,15 +7250,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -7300,7 +7298,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -7329,9 +7327,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -7354,7 +7352,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7379,11 +7377,11 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -7399,7 +7397,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -7407,7 +7405,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -7446,8 +7444,8 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -7455,7 +7453,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -7463,7 +7461,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -7471,7 +7469,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -7479,7 +7477,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -7487,7 +7485,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -7495,7 +7493,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 #, fuzzy
 msgid "[<remote>:]<API path>"
 msgstr ""
@@ -7504,7 +7502,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -7512,7 +7510,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -7520,7 +7518,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -7528,7 +7526,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -7586,8 +7584,8 @@ msgstr ""
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -7605,7 +7603,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -7779,7 +7777,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7788,7 +7786,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -7932,8 +7930,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -7942,7 +7940,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -7951,7 +7949,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -7960,7 +7958,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -7968,7 +7966,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -7985,9 +7983,9 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7995,7 +7993,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -8003,7 +8001,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -8011,7 +8009,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -8019,7 +8017,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -8027,9 +8025,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -8037,7 +8035,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -8045,7 +8043,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8055,8 +8053,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -8064,7 +8062,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8072,7 +8070,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8082,13 +8080,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -8096,7 +8094,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -8146,7 +8144,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -8154,7 +8152,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -8162,7 +8160,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -8170,7 +8168,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -8394,8 +8392,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8427,7 +8425,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8435,7 +8433,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8451,7 +8449,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8459,7 +8457,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8467,8 +8465,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8476,7 +8474,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8484,7 +8482,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8492,7 +8490,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8509,7 +8507,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -8518,7 +8516,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -8526,7 +8524,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -8534,7 +8532,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -8542,7 +8540,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -8550,7 +8548,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -8558,7 +8556,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -8608,7 +8606,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 #, fuzzy
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
@@ -8617,7 +8615,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8625,7 +8623,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -8634,7 +8632,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -8702,13 +8700,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -8717,7 +8715,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8905,7 +8903,7 @@ msgstr ""
 "\n"
 "lxc move <Quelle> <Ziel>\n"
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -8913,7 +8911,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8922,7 +8920,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8930,7 +8928,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8939,7 +8937,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -8947,7 +8945,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -8961,7 +8959,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8973,7 +8971,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8992,13 +8990,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -9006,13 +9004,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -9122,7 +9120,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -9134,7 +9132,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9171,11 +9169,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "  Χρήση δικτύου:"
@@ -609,24 +609,24 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -642,11 +642,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -683,15 +683,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -714,7 +714,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -751,7 +751,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -778,27 +778,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -836,7 +836,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -855,11 +855,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -890,14 +890,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -912,7 +912,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -925,15 +925,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,7 +1044,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1081,17 +1081,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1100,7 +1100,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1109,63 +1109,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1184,20 +1184,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1225,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1233,13 +1233,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1352,21 +1352,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1381,27 +1381,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1482,15 +1482,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -1499,24 +1499,24 @@ msgstr "  Χρήση δικτύου:"
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1543,7 +1543,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1552,16 +1552,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1591,11 +1591,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1636,15 +1636,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -1653,25 +1653,25 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 #, fuzzy
 msgid "Delete network zones"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1702,15 +1702,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1734,51 +1734,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1799,8 +1799,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1814,11 +1814,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1855,12 +1855,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1876,7 +1870,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1933,19 +1927,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1970,7 +1964,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1978,7 +1972,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1992,7 +1986,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2000,7 +1994,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2037,19 +2031,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "  Χρήση δικτύου:"
@@ -2059,21 +2053,21 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit network peer configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2098,17 +2092,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2124,7 +2118,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2151,11 +2145,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2166,10 +2160,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2181,11 +2175,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2195,7 +2189,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2274,7 +2268,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2287,7 +2281,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2381,11 +2375,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2395,7 +2389,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2405,7 +2399,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2415,7 +2409,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to find image %q on remote %q"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2440,7 +2434,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2449,7 +2443,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2459,13 +2453,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2476,7 +2470,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2484,11 +2478,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2504,7 +2498,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2529,16 +2523,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2550,7 +2544,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2574,7 +2568,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2594,7 +2588,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2602,7 +2596,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2610,24 +2604,24 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
@@ -2637,25 +2631,25 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2676,7 +2670,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -2689,20 +2683,20 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -2712,21 +2706,21 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for network peer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2771,7 +2765,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2803,7 +2797,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2821,11 +2815,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2833,15 +2827,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2983,7 +2977,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -3008,7 +3002,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3026,7 +3020,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3035,7 +3029,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3069,7 +3063,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3126,7 +3120,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3161,7 +3155,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3169,17 +3163,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3191,8 +3185,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3210,12 +3204,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3229,7 +3223,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3241,35 +3235,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -3278,20 +3272,20 @@ msgstr "  Χρήση δικτύου:"
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 #, fuzzy
 msgid "List available network zone records"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3470,11 +3464,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3490,7 +3484,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3526,7 +3520,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3534,11 +3528,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3570,7 +3564,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3578,15 +3572,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3594,7 +3588,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3604,11 +3598,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3621,15 +3615,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3637,7 +3631,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3656,15 +3650,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3746,33 +3740,33 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -3781,17 +3775,17 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 #, fuzzy
 msgid "Manage network zones"
 msgstr "  Χρήση δικτύου:"
@@ -3801,11 +3795,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage permissions"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3844,7 +3838,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3857,7 +3851,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3880,17 +3874,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3942,14 +3936,14 @@ msgstr "  Χρήση δικτύου:"
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3979,8 +3973,8 @@ msgstr "  Χρήση δικτύου:"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3990,14 +3984,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -4007,41 +4001,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "  Χρήση δικτύου:"
@@ -4068,18 +4062,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4100,7 +4094,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4125,7 +4119,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4180,11 +4174,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4196,12 +4190,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4214,11 +4208,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4230,9 +4224,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4259,11 +4253,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4273,67 +4267,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -4363,22 +4357,22 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 #, fuzzy
 msgid "Network type"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -4400,12 +4394,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4413,19 +4407,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4451,7 +4445,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4468,7 +4462,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4480,7 +4474,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4491,6 +4485,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4523,7 +4521,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4531,29 +4529,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4574,7 +4572,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4582,12 +4580,12 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4604,14 +4602,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4625,7 +4623,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4648,32 +4646,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4690,7 +4688,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4703,22 +4701,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4816,7 +4814,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4852,7 +4850,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4860,7 +4858,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4868,7 +4866,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4907,45 +4905,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4959,7 +4957,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4967,11 +4965,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "  Χρήση δικτύου:"
@@ -4980,25 +4978,25 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -5010,7 +5008,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -5018,20 +5016,20 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5048,11 +5046,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5073,23 +5071,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5111,7 +5109,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5138,7 +5136,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5157,7 +5155,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5170,7 +5168,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5180,7 +5178,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5200,7 +5198,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5230,20 +5228,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5251,11 +5249,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5268,23 +5266,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5297,7 +5295,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -5345,11 +5343,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5358,11 +5356,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5371,12 +5369,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5385,12 +5383,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5413,12 +5411,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5427,16 +5425,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5445,11 +5443,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5498,7 +5496,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5526,20 +5524,20 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
@@ -5549,25 +5547,25 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5604,7 +5602,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "  Χρήση δικτύου:"
@@ -5613,7 +5611,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5675,24 +5673,24 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "  Χρήση δικτύου:"
@@ -5702,26 +5700,26 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show network peer configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5757,7 +5755,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5785,7 +5783,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "  Χρήση δικτύου:"
@@ -5798,7 +5796,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5838,7 +5836,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5846,7 +5844,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5855,7 +5853,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5947,7 +5945,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5970,11 +5968,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5996,14 +5994,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -6019,7 +6017,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6057,7 +6055,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6071,11 +6069,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "  Χρήση δικτύου:"
@@ -6094,7 +6092,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6109,22 +6107,22 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6134,22 +6132,22 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6175,7 +6173,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6192,12 +6190,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6214,11 +6212,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6246,11 +6244,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6265,7 +6263,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6314,24 +6312,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6350,7 +6348,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6361,7 +6359,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6369,21 +6367,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6397,7 +6395,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6411,8 +6409,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6427,7 +6425,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6441,7 +6439,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -6462,30 +6460,30 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "  Χρήση δικτύου:"
@@ -6500,21 +6498,21 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset network peer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6531,20 +6529,20 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
@@ -6554,26 +6552,26 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6603,21 +6601,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6626,7 +6624,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6659,7 +6657,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6673,15 +6671,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6717,7 +6715,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6741,9 +6739,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6763,7 +6761,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6779,11 +6777,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6791,11 +6789,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6815,48 +6813,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6891,8 +6889,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6902,7 +6900,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6988,11 +6986,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7059,24 +7057,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7084,70 +7082,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7173,19 +7171,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7298,8 +7296,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7315,11 +7313,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7327,28 +7325,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7356,31 +7354,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7404,19 +7402,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7484,13 +7482,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7499,7 +7497,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7683,7 +7681,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7691,7 +7689,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7700,7 +7698,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7708,7 +7706,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7717,7 +7715,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7725,7 +7723,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7739,7 +7737,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7751,7 +7749,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7770,13 +7768,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7784,13 +7782,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7900,7 +7898,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7912,7 +7910,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7949,11 +7947,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -155,7 +155,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -328,7 +328,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -371,7 +371,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -410,7 +410,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -481,7 +481,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -510,7 +510,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -539,7 +539,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -574,7 +574,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -610,7 +610,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -646,7 +646,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -677,7 +677,7 @@ msgstr "%s no es un directorio"
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr "(ninguno)"
 
@@ -710,7 +710,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -728,7 +728,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -754,15 +754,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -792,11 +792,11 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
@@ -821,25 +821,25 @@ msgstr "Expira: %s"
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "El filtrado no está soportado aún"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
@@ -852,24 +852,24 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Perfil %s creado"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -877,7 +877,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -886,11 +886,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -927,15 +927,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -944,7 +944,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -958,7 +958,7 @@ msgstr "Expira: %s"
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -995,7 +995,7 @@ msgstr "Aliases:"
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1014,7 +1014,7 @@ msgstr "Arquitectura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1023,28 +1023,28 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1101,11 +1101,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -1136,14 +1136,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -1172,15 +1172,15 @@ msgstr "Ambas: todas y el nombre del contenedor dado"
 msgid "Brand: %v"
 msgstr "Creado: %s"
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1196,7 +1196,7 @@ msgstr "NOMBRE COMÚN"
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1264,7 +1264,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1294,7 +1294,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1307,7 +1307,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1331,18 +1331,18 @@ msgstr "Cacheado: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1351,7 +1351,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1361,63 +1361,63 @@ msgstr "Certificado del cliente almacenado en el servidor: "
 msgid "Client version: %s\n"
 msgstr "Versión del cliente: %s\n"
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1436,20 +1436,20 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Columnas"
 
@@ -1478,7 +1478,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1487,13 +1487,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1562,7 +1562,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1578,7 +1578,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1608,21 +1608,21 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1637,27 +1637,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1744,15 +1744,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Perfil %s creado"
@@ -1761,24 +1761,24 @@ msgstr "Perfil %s creado"
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1795,7 +1795,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
@@ -1805,7 +1805,7 @@ msgstr "Creando %s"
 msgid "Creating %s: %%s"
 msgstr "Creando %s"
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
@@ -1815,16 +1815,16 @@ msgstr "Creando el contenedor"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1842,7 +1842,7 @@ msgstr "CONTROLADOR"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1854,11 +1854,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1900,15 +1900,15 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Perfil %s creado"
@@ -1917,25 +1917,25 @@ msgstr "Perfil %s creado"
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1952,7 +1952,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1966,15 +1966,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1998,51 +1998,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2063,8 +2063,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr "Descripción"
 
@@ -2078,11 +2078,11 @@ msgstr "Huella dactilar: %s"
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2120,12 +2120,6 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Device doesn't exist"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -2141,7 +2135,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2197,22 +2191,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display instances from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2222,7 +2216,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display storage pool buckets from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2230,7 +2224,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -2239,7 +2233,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -2247,7 +2241,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "FECHA DE EXPIRACIÓN"
@@ -2262,7 +2256,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2270,7 +2264,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2307,19 +2301,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Perfil %s creado"
@@ -2329,21 +2323,21 @@ msgstr "Perfil %s creado"
 msgid "Edit network peer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2368,17 +2362,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2394,7 +2388,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2421,11 +2415,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2436,10 +2430,10 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2451,12 +2445,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2466,7 +2460,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -2548,7 +2542,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2561,7 +2555,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2655,11 +2649,11 @@ msgstr "Acepta certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2669,7 +2663,7 @@ msgstr "Acepta certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2679,7 +2673,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2689,7 +2683,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to find image %q on remote %q"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2714,7 +2708,7 @@ msgstr "Acepta certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2723,7 +2717,7 @@ msgstr "Acepta certificado"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
@@ -2733,13 +2727,13 @@ msgstr "El filtrado no está soportado aún"
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2750,7 +2744,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2758,11 +2752,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2779,7 +2773,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2804,16 +2798,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2825,7 +2819,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2849,7 +2843,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2869,7 +2863,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2878,7 +2872,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2886,24 +2880,24 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Nombre del contenedor es: %s"
@@ -2913,25 +2907,25 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Get the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2952,7 +2946,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Perfil %s creado"
@@ -2965,20 +2959,20 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Perfil %s creado"
@@ -2988,21 +2982,21 @@ msgstr "Perfil %s creado"
 msgid "Get values for network peer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3047,7 +3041,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3080,7 +3074,7 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3098,11 +3092,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3111,16 +3105,16 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Expira: %s"
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expira: %s"
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -3263,7 +3257,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -3290,7 +3284,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3309,7 +3303,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr "Contenedor publicado con huella digital: %s"
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3318,7 +3312,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3352,7 +3346,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid export version %q: %w"
 msgstr "Versión del cliente: %s\n"
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3410,7 +3404,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3446,7 +3440,7 @@ msgstr "Cacheado: %s"
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3454,17 +3448,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3476,8 +3470,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3495,12 +3489,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creando %s"
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creando el contenedor"
@@ -3515,7 +3509,7 @@ msgstr "Arquitectura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3529,38 +3523,38 @@ msgstr "Aliases:"
 msgid "List all active certificate add tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 #, fuzzy
 msgid "List all warnings"
 msgstr "Aliases:"
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nombre del contenedor es: %s"
@@ -3569,20 +3563,20 @@ msgstr "Nombre del contenedor es: %s"
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3765,11 +3759,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "List permissions"
 msgstr "Aliases:"
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3785,7 +3779,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3822,7 +3816,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3830,12 +3824,12 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 #, fuzzy
 msgid "List warnings"
 msgstr "Aliases:"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3867,7 +3861,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3875,15 +3869,15 @@ msgstr ""
 msgid "Log:"
 msgstr "Registro:"
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3892,7 +3886,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Expira: %s"
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3902,11 +3896,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3919,15 +3913,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3935,7 +3929,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3954,15 +3948,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -4044,33 +4038,33 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nombre del contenedor es: %s"
@@ -4079,17 +4073,17 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Nombre del contenedor es: %s"
@@ -4099,11 +4093,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage permissions"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4142,7 +4136,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4155,7 +4149,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -4179,17 +4173,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4240,14 +4234,14 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4278,8 +4272,8 @@ msgstr "Nombre del Miembro del Cluster"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
@@ -4290,14 +4284,14 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
@@ -4308,43 +4302,43 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nombre del contenedor es: %s"
@@ -4372,19 +4366,19 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4407,7 +4401,7 @@ msgstr "%s no es un directorio"
 msgid "Missing target network"
 msgstr "%s no es un directorio"
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4432,7 +4426,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4488,11 +4482,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4504,12 +4498,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4522,11 +4516,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4538,9 +4532,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4567,11 +4561,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4581,67 +4575,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Perfil %s eliminado"
@@ -4671,20 +4665,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Perfil %s eliminado"
@@ -4706,12 +4700,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4719,19 +4713,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4757,7 +4751,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4774,7 +4768,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4786,7 +4780,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4797,6 +4791,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4829,7 +4827,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4837,29 +4835,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4880,7 +4878,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4888,12 +4886,12 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4910,14 +4908,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4931,7 +4929,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4954,32 +4952,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -4999,7 +4997,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5013,22 +5011,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr "Perfil %s creado"
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5126,7 +5124,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -5162,7 +5160,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -5170,7 +5168,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -5178,7 +5176,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -5219,46 +5217,46 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Contraseña admin para %s: "
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -5272,7 +5270,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
@@ -5281,11 +5279,11 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Perfil %s creado"
@@ -5294,25 +5292,25 @@ msgstr "Perfil %s creado"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -5324,7 +5322,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -5332,20 +5330,20 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -5354,7 +5352,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5362,11 +5360,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5388,23 +5386,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5426,7 +5424,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5454,7 +5452,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -5475,7 +5473,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -5488,7 +5486,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5498,7 +5496,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
@@ -5520,7 +5518,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5550,20 +5548,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5571,11 +5569,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "Creado: %s"
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5618,7 +5616,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "Aliases:"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
@@ -5666,11 +5664,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5679,11 +5677,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5692,12 +5690,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5706,12 +5704,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5734,12 +5732,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5748,16 +5746,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5766,11 +5764,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5819,7 +5817,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5847,20 +5845,20 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Perfil %s creado"
@@ -5870,25 +5868,25 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5925,7 +5923,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Perfil %s creado"
@@ -5934,7 +5932,7 @@ msgstr "Perfil %s creado"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5997,24 +5995,24 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Perfil %s creado"
@@ -6024,26 +6022,26 @@ msgstr "Perfil %s creado"
 msgid "Show network peer configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -6079,7 +6077,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -6107,7 +6105,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -6120,7 +6118,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -6160,7 +6158,7 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6178,7 +6176,7 @@ msgstr ""
 msgid "State"
 msgstr "Auto actualización: %s"
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Auto actualización: %s"
@@ -6270,7 +6268,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6293,11 +6291,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6319,14 +6317,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Contenedor publicado con huella digital: %s"
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -6342,7 +6340,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6382,7 +6380,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6396,11 +6394,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nombre del Miembro del Cluster"
@@ -6419,7 +6417,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6434,22 +6432,22 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6459,22 +6457,22 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6500,7 +6498,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6517,12 +6515,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6539,11 +6537,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
@@ -6572,11 +6570,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6591,7 +6589,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6640,24 +6638,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6678,7 +6676,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -6689,7 +6687,7 @@ msgstr "Expira: %s"
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6697,21 +6695,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6725,7 +6723,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6739,8 +6737,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6755,7 +6753,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6770,7 +6768,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr "Aliases:"
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
@@ -6791,30 +6789,30 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Perfil %s creado"
@@ -6829,21 +6827,21 @@ msgstr "Perfil %s creado"
 msgid "Unset network peer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6860,20 +6858,20 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Perfil %s creado"
@@ -6883,26 +6881,26 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6932,22 +6930,22 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Acepta certificado"
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6956,7 +6954,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6989,7 +6987,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -7003,15 +7001,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -7047,7 +7045,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -7071,9 +7069,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -7093,7 +7091,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -7111,11 +7109,11 @@ msgid ""
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7125,12 +7123,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7154,58 +7152,58 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 #, fuzzy
 msgid "[<remote>:]<API path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7245,8 +7243,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7258,7 +7256,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7365,12 +7363,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7452,28 +7450,28 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7483,82 +7481,82 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7590,22 +7588,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7744,8 +7742,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7765,12 +7763,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7780,33 +7778,33 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7816,37 +7814,37 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7876,22 +7874,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 #, fuzzy
 msgid "[<remote>:][<warning-uuid>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7959,13 +7957,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7974,7 +7972,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8158,7 +8156,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -8166,7 +8164,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8175,7 +8173,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8183,7 +8181,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8192,7 +8190,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -8200,7 +8198,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -8214,7 +8212,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8226,7 +8224,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8245,13 +8243,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8259,13 +8257,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -8375,7 +8373,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -8387,7 +8385,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8424,11 +8422,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -148,7 +148,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -325,7 +325,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -379,7 +379,7 @@ msgstr ""
 "### Notez que seules les règles d'entrée et de sortie, la description et les "
 "clés de configuration peuvent être modifiées ."
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -421,7 +421,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -497,7 +497,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -518,7 +518,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -539,7 +539,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -577,7 +577,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -615,7 +615,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -653,7 +653,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -686,7 +686,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr "(aucun)"
 
@@ -718,7 +718,7 @@ msgstr "--console ne peut être utilisé avec --all"
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
@@ -734,7 +734,7 @@ msgstr "--instance-only ne peut être utilisé lorsque la source est un snapshot
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
@@ -761,17 +761,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -810,11 +810,11 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -823,7 +823,7 @@ msgstr "TYPE"
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
@@ -841,25 +841,25 @@ msgstr "Expire : %s"
 msgid "Access the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr "Accusé réception d'avertissement"
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -872,24 +872,24 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Création du conteneur"
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Alias :"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -957,15 +957,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Création du conteneur"
@@ -975,7 +975,7 @@ msgstr "Création du conteneur"
 msgid "Add roles to a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Création du conteneur"
@@ -990,7 +990,7 @@ msgstr "Expire : %s"
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -1028,7 +1028,7 @@ msgstr "Alias :"
 msgid "All projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr "Architecture : %s"
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1056,30 +1056,30 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1138,11 +1138,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 #, fuzzy
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
@@ -1175,14 +1175,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1197,7 +1197,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -1210,15 +1210,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Créé : %s"
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1234,7 +1234,7 @@ msgstr "COMMON NAME"
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1302,7 +1302,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1319,7 +1319,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Impossible de désaffecter la clé '%s', elle n'est pas définie actuellement."
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1347,7 +1347,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1371,18 +1371,18 @@ msgstr "Créé : %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1391,7 +1391,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1401,63 +1401,63 @@ msgstr "Certificat client enregistré sur le serveur : "
 msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1476,20 +1476,20 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1526,7 +1526,7 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Config key/value to apply to the new instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -1536,13 +1536,13 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1632,7 +1632,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1662,21 +1662,21 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
@@ -1691,27 +1691,27 @@ msgstr "Erreur lors de la lecture de la configuration : %s"
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1720,7 +1720,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1821,16 +1821,16 @@ msgstr "Copie de l'image : %s"
 msgid "Create new instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Copie de l'image : %s"
@@ -1840,26 +1840,26 @@ msgstr "Copie de l'image : %s"
 msgid "Create new network peering"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 #, fuzzy
 msgid "Create projects"
 msgstr "Créé : %s"
@@ -1879,7 +1879,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
@@ -1889,7 +1889,7 @@ msgstr "Création de %s"
 msgid "Creating %s: %%s"
 msgstr "Création de %s"
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Création du conteneur"
@@ -1899,16 +1899,16 @@ msgstr "Création du conteneur"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1926,7 +1926,7 @@ msgstr "PILOTE"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1939,11 +1939,11 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 #, fuzzy
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
@@ -1991,15 +1991,15 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Delete key from a storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Récupération de l'image : %s"
@@ -2009,25 +2009,25 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete network peerings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 #, fuzzy
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
@@ -2046,7 +2046,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 #, fuzzy
 msgid "Delete warning"
 msgstr "Récupération de l'image : %s"
@@ -2061,15 +2061,15 @@ msgstr "Récupération de l'image : %s"
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -2093,51 +2093,51 @@ msgstr "Récupération de l'image : %s"
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2158,8 +2158,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -2173,11 +2173,11 @@ msgstr "Empreinte : %s"
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2216,12 +2216,6 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Device doesn't exist"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -2237,7 +2231,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
@@ -2297,22 +2291,22 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display instances from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2322,7 +2316,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display storage pool buckets from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2331,7 +2325,7 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -2340,7 +2334,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -2348,7 +2342,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATE D'EXPIRATION"
@@ -2363,7 +2357,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2371,7 +2365,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2415,21 +2409,21 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2439,21 +2433,21 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network peer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2480,17 +2474,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2506,7 +2500,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2534,11 +2528,11 @@ msgstr "Récupération de l'image : %s"
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2549,10 +2543,10 @@ msgstr "Récupération de l'image : %s"
 msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2564,7 +2558,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2576,7 +2570,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2586,7 +2580,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2680,7 +2674,7 @@ msgstr "Import de l'image : %s"
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2694,7 +2688,7 @@ msgstr "NOM"
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2788,12 +2782,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 #, fuzzy
 msgid "Failed to add remote"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2803,7 +2797,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, fuzzy, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2813,7 +2807,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2823,7 +2817,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to find image %q on remote %q"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2848,7 +2842,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2858,7 +2852,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2868,13 +2862,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2885,7 +2879,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 #, fuzzy
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2894,11 +2888,11 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 #, fuzzy
 msgid "Force restoration without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2917,7 +2911,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2942,16 +2936,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2963,7 +2957,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2987,7 +2981,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -3007,7 +3001,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -3016,7 +3010,7 @@ msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3024,24 +3018,24 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Copie de l'image : %s"
@@ -3051,25 +3045,25 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3092,7 +3086,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3107,22 +3101,22 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 #, fuzzy
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3132,22 +3126,22 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network peer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 #, fuzzy
 msgid "HOSTNAME"
 msgstr "NOM"
@@ -3227,7 +3221,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 #, fuzzy
 msgid "ID"
 msgstr "PID"
@@ -3246,11 +3240,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3259,16 +3253,16 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Expire : %s"
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expire : %s"
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr "IPv6"
 
@@ -3420,7 +3414,7 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -3448,7 +3442,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3467,7 +3461,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr "Conteneur publié avec l'empreinte : %s"
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3476,7 +3470,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3510,7 +3504,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid export version %q: %w"
 msgstr "Afficher la version du client"
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Cible invalide %s"
@@ -3569,7 +3563,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -3605,7 +3599,7 @@ msgstr "Créé : %s"
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 #, fuzzy
 msgid "LAST SEEN"
 msgstr "DERNIÈRE UTILISATION À"
@@ -3614,17 +3608,17 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3636,8 +3630,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3655,12 +3649,12 @@ msgstr "Dernière utilisation : %s"
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Création de %s"
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Création du conteneur"
@@ -3675,7 +3669,7 @@ msgstr "Architecture : %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3689,38 +3683,38 @@ msgstr "Alias :"
 msgid "List all active certificate add tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 #, fuzzy
 msgid "List all warnings"
 msgstr "Alias :"
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nom du réseau"
@@ -3729,20 +3723,20 @@ msgstr "Nom du réseau"
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3987,11 +3981,11 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "List permissions"
 msgstr "Alias :"
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -4007,7 +4001,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -4046,7 +4040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -4054,12 +4048,12 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 #, fuzzy
 msgid "List warnings"
 msgstr "Alias :"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -4091,7 +4085,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -4099,17 +4093,17 @@ msgstr ""
 msgid "Log:"
 msgstr "Journal : "
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 #, fuzzy
 msgid "Lower device"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 #, fuzzy
 msgid "Lower devices"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4118,7 +4112,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Expire : %s"
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4128,11 +4122,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -4145,15 +4139,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -4161,7 +4155,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4180,16 +4174,16 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -4279,37 +4273,37 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Manage instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 #, fuzzy
 msgid "Manage network ACLs"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nom du réseau"
@@ -4319,17 +4313,17 @@ msgstr "Nom du réseau"
 msgid "Manage network peerings"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Nom du réseau"
@@ -4339,11 +4333,11 @@ msgstr "Nom du réseau"
 msgid "Manage permissions"
 msgstr "Rendre l'image publique"
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 #, fuzzy
 msgid "Manage projects"
 msgstr "Rendre l'image publique"
@@ -4386,7 +4380,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4399,7 +4393,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr "Copie de l'image : %s"
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Rendre l'image publique"
@@ -4424,17 +4418,17 @@ msgstr "Profil %s ajouté à %s"
 msgid "Member %q does not have role %q"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -4487,14 +4481,14 @@ msgstr "Résumé manquant."
 msgid "Missing certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4525,8 +4519,8 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4537,14 +4531,14 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing key name"
 msgstr "Résumé manquant."
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4556,27 +4550,27 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing name"
 msgstr "Résumé manquant."
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
@@ -4584,16 +4578,16 @@ msgstr "Nom du réseau"
 msgid "Missing network name"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nom du réseau"
@@ -4622,19 +4616,19 @@ msgstr "Résumé manquant."
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4658,7 +4652,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "Missing target network"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 #, fuzzy
 msgid "Mode"
 msgstr "Publié : %s"
@@ -4684,7 +4678,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 #, fuzzy
 msgid "More than one device matches, specify the device name"
@@ -4745,11 +4739,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4762,12 +4756,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr "NOM"
@@ -4780,11 +4774,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4796,9 +4790,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr "NON"
 
@@ -4826,11 +4820,11 @@ msgstr ""
 msgid "Name"
 msgstr "Nom : %s"
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -4840,67 +4834,67 @@ msgstr "Nom : %s"
 msgid "Name: %v"
 msgstr "Nom : %s"
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -4930,22 +4924,22 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 #, fuzzy
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -4969,12 +4963,12 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
@@ -4983,19 +4977,19 @@ msgstr "Aucun périphérique existant pour ce réseau"
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 #, fuzzy
 msgid "No need to specify a warning UUID when using --all"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -5023,7 +5017,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -5046,7 +5040,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -5061,7 +5055,7 @@ msgid "Only instance or custom volumes are supported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 #, fuzzy
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
@@ -5073,6 +5067,10 @@ msgstr "Le réseau %s a été supprimé"
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -5106,7 +5104,7 @@ msgstr "Pid : %d"
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -5114,29 +5112,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -5159,7 +5157,7 @@ msgstr "Création du conteneur"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
@@ -5168,12 +5166,12 @@ msgstr "Chemin vers un dossier de configuration serveur alternatif"
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 #, fuzzy
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr "Image importée avec l'empreinte : %s"
@@ -5191,14 +5189,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 #, fuzzy
@@ -5213,7 +5211,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -5236,32 +5234,32 @@ msgstr "l'analyse des alias a échoué %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -5281,7 +5279,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
@@ -5296,22 +5294,22 @@ msgstr "Profils : %s"
 msgid "Profiles: "
 msgstr "Profils : %s"
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s créé"
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5409,7 +5407,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
@@ -5448,7 +5446,7 @@ msgstr "Création du conteneur"
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -5456,7 +5454,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 #, fuzzy
 msgid "RESOURCE"
 msgstr "SOURCE"
@@ -5465,7 +5463,7 @@ msgstr "SOURCE"
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -5509,45 +5507,45 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Ajouter de nouveaux clients de confiance"
@@ -5562,7 +5560,7 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5572,11 +5570,11 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove a group from an identity"
 msgstr "Création du conteneur"
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Clé de configuration invalide"
@@ -5586,25 +5584,25 @@ msgstr "Clé de configuration invalide"
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
@@ -5619,7 +5617,7 @@ msgstr "Création du conteneur"
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -5628,22 +5626,22 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "Création du conteneur"
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -5652,7 +5650,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Création du conteneur"
@@ -5662,11 +5660,11 @@ msgstr "Création du conteneur"
 msgid "Remove trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5690,24 +5688,24 @@ msgstr "Copie de l'image : %s"
 msgid "Rename instances and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5731,7 +5729,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5760,7 +5758,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5798,7 +5796,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5812,7 +5810,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5822,7 +5820,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Revoke certificate add token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5844,7 +5842,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5874,21 +5872,21 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr "STATIQUE"
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 #, fuzzy
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 #, fuzzy
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -5897,12 +5895,12 @@ msgstr "ENSEMBLE DE STOCKAGE"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5915,25 +5913,25 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "Créé : %s"
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
@@ -5947,7 +5945,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "Création du conteneur"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -5997,12 +5995,12 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6011,12 +6009,12 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 #, fuzzy
 msgid "Set network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6025,12 +6023,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6039,12 +6037,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6067,12 +6065,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6081,17 +6079,17 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6100,12 +6098,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6156,7 +6154,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6187,20 +6185,20 @@ msgstr "Définir l'uid du fichier lors de l'envoi"
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Nom du réseau"
@@ -6210,25 +6208,25 @@ msgstr "Nom du réseau"
 msgid "Set the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6267,7 +6265,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Afficher la configuration étendue"
@@ -6277,7 +6275,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show content of instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -6346,27 +6344,27 @@ msgstr "Afficher les commandes moins communes"
 msgid "Show local and remote versions"
 msgstr "Afficher la version du client"
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 #, fuzzy
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Afficher la configuration étendue"
@@ -6376,27 +6374,27 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network peer configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 #, fuzzy
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
@@ -6435,7 +6433,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6466,7 +6464,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6479,7 +6477,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -6520,7 +6518,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Source:"
 msgstr "Source :"
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -6529,7 +6527,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "Création du conteneur"
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr "Démarrage de %s"
@@ -6539,7 +6537,7 @@ msgstr "Démarrage de %s"
 msgid "State"
 msgstr "État : %s"
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "État : %s"
@@ -6638,7 +6636,7 @@ msgstr "Image copiée avec succès !"
 msgid "Store the instance state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6661,12 +6659,12 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6689,14 +6687,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -6713,7 +6711,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6752,7 +6750,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6771,13 +6769,13 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6797,7 +6795,7 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6812,22 +6810,22 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6837,22 +6835,22 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6878,7 +6876,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6895,12 +6893,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
@@ -6917,11 +6915,11 @@ msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
@@ -6951,12 +6949,12 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 #, fuzzy
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
@@ -6973,7 +6971,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -7022,25 +7020,25 @@ msgstr "Transfert de l'image : %s"
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
@@ -7061,7 +7059,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -7072,7 +7070,7 @@ msgstr "Expire : %s"
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7080,21 +7078,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -7108,7 +7106,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
@@ -7123,8 +7121,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7139,7 +7137,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7154,7 +7152,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7178,32 +7176,32 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 #, fuzzy
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Nom du réseau"
@@ -7218,22 +7216,22 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network peer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 #, fuzzy
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7253,20 +7251,20 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Nom du réseau"
@@ -7276,26 +7274,26 @@ msgstr "Nom du réseau"
 msgid "Unset the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7327,22 +7325,22 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7351,7 +7349,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 #, fuzzy
 msgid "Upper devices"
 msgstr "Création du conteneur"
@@ -7385,7 +7383,7 @@ msgstr "Publié : %s"
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
@@ -7400,15 +7398,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -7445,7 +7443,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr "Nom : %s"
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -7474,9 +7472,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr "OUI"
 
@@ -7499,7 +7497,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -7524,11 +7522,11 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Serveur distant : %s"
@@ -7541,7 +7539,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -7549,7 +7547,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -7597,13 +7595,13 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -7611,7 +7609,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -7619,7 +7617,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -7627,7 +7625,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -7635,7 +7633,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -7643,7 +7641,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 #, fuzzy
 msgid "[<remote>:]<API path>"
 msgstr ""
@@ -7655,7 +7653,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -7663,7 +7661,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -7671,7 +7669,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -7679,7 +7677,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -7746,8 +7744,8 @@ msgstr ""
 "(configuration, instantanés, …)."
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -7765,7 +7763,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -7951,7 +7949,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7963,7 +7961,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -8143,8 +8141,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -8156,7 +8154,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -8168,7 +8166,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -8180,7 +8178,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -8188,7 +8186,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -8208,9 +8206,9 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8218,7 +8216,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -8226,7 +8224,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -8234,7 +8232,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -8242,7 +8240,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -8250,9 +8248,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -8260,7 +8258,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -8268,7 +8266,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8278,8 +8276,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -8287,7 +8285,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8295,7 +8293,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8305,13 +8303,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -8319,7 +8317,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -8369,7 +8367,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -8377,7 +8375,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -8385,7 +8383,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -8393,7 +8391,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -8638,8 +8636,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8671,7 +8669,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8679,7 +8677,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8695,7 +8693,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8703,7 +8701,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8711,8 +8709,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8720,7 +8718,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8728,7 +8726,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8736,7 +8734,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8756,7 +8754,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -8768,7 +8766,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -8776,7 +8774,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -8784,7 +8782,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -8792,7 +8790,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -8800,7 +8798,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -8808,7 +8806,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -8864,7 +8862,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 #, fuzzy
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
@@ -8876,7 +8874,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8884,7 +8882,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -8896,7 +8894,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -8965,13 +8963,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -8980,7 +8978,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -9186,7 +9184,7 @@ msgstr ""
 "lxc move <container>/<old snapshot name> <container>/<new snapshot name>\n"
 "    Renomme un instantané."
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -9194,7 +9192,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -9203,7 +9201,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -9211,7 +9209,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9220,7 +9218,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -9228,7 +9226,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -9242,7 +9240,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9254,7 +9252,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -9273,13 +9271,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -9287,13 +9285,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -9403,7 +9401,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -9416,7 +9414,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9453,11 +9451,11 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "oui"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -107,7 +107,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -227,7 +227,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -320,7 +320,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -334,7 +334,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -410,7 +410,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -441,7 +441,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -513,15 +513,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -550,11 +550,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -562,7 +562,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -579,25 +579,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -609,23 +609,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -641,11 +641,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -682,15 +682,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -712,7 +712,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -749,7 +749,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -776,27 +776,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -834,7 +834,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -853,11 +853,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -888,14 +888,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -947,7 +947,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1078,17 +1078,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1106,63 +1106,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1181,20 +1181,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1222,7 +1222,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1230,13 +1230,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1349,21 +1349,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1378,27 +1378,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1478,15 +1478,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1494,23 +1494,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1546,16 +1546,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1585,11 +1585,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1629,15 +1629,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1645,23 +1645,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1677,7 +1677,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1691,15 +1691,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1723,51 +1723,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1788,8 +1788,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1802,11 +1802,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1843,12 +1843,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1864,7 +1858,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1917,19 +1911,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1937,7 +1931,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1945,7 +1939,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1954,7 +1948,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1962,7 +1956,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1976,7 +1970,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1984,7 +1978,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2020,19 +2014,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2040,19 +2034,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2076,17 +2070,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2102,7 +2096,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2129,11 +2123,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2144,10 +2138,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2159,11 +2153,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2173,7 +2167,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2252,7 +2246,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2265,7 +2259,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2359,11 +2353,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2373,7 +2367,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2383,7 +2377,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2393,7 +2387,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2418,7 +2412,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2427,7 +2421,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2437,13 +2431,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2454,7 +2448,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2462,11 +2456,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2482,7 +2476,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2507,16 +2501,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2528,7 +2522,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2552,7 +2546,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2572,7 +2566,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2580,7 +2574,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2588,23 +2582,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2612,23 +2606,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2648,7 +2642,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2660,19 +2654,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2680,19 +2674,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2736,7 +2730,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2768,7 +2762,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2786,11 +2780,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2798,15 +2792,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2948,7 +2942,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2973,7 +2967,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2991,7 +2985,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3000,7 +2994,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3034,7 +3028,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3091,7 +3085,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3126,7 +3120,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3134,17 +3128,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3156,8 +3150,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3175,12 +3169,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3194,7 +3188,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3206,35 +3200,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3242,19 +3236,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3433,11 +3427,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3453,7 +3447,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3489,7 +3483,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3497,11 +3491,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3533,7 +3527,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3541,15 +3535,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3557,7 +3551,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3567,11 +3561,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3584,15 +3578,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3600,7 +3594,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3619,15 +3613,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3706,31 +3700,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3738,15 +3732,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3754,11 +3748,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3794,7 +3788,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3806,7 +3800,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3829,17 +3823,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3888,13 +3882,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3920,8 +3914,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3930,14 +3924,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3947,41 +3941,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4007,18 +4001,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4038,7 +4032,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4063,7 +4057,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4118,11 +4112,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4134,12 +4128,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4152,11 +4146,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4168,9 +4162,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4197,11 +4191,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4211,67 +4205,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4301,20 +4295,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4336,12 +4330,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4349,19 +4343,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4387,7 +4381,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4404,7 +4398,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4416,7 +4410,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4427,6 +4421,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4459,7 +4457,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4467,29 +4465,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4510,7 +4508,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4518,11 +4516,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4539,14 +4537,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4560,7 +4558,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4583,32 +4581,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4625,7 +4623,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4638,22 +4636,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4751,7 +4749,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4787,7 +4785,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4795,7 +4793,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4803,7 +4801,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4842,45 +4840,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4894,7 +4892,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4902,11 +4900,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4914,23 +4912,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4942,7 +4940,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4950,19 +4948,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4970,7 +4968,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4978,11 +4976,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5003,23 +5001,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5041,7 +5039,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5068,7 +5066,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5087,7 +5085,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5100,7 +5098,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5109,7 +5107,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5129,7 +5127,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5159,20 +5157,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5180,11 +5178,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5197,23 +5195,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5226,7 +5224,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5273,11 +5271,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5286,11 +5284,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5299,11 +5297,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5312,11 +5310,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5338,11 +5336,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5351,15 +5349,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5368,11 +5366,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5420,7 +5418,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5448,19 +5446,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5468,23 +5466,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5520,7 +5518,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5528,7 +5526,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5589,23 +5587,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5613,23 +5611,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5663,7 +5661,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5691,7 +5689,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5703,7 +5701,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5743,7 +5741,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5751,7 +5749,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5760,7 +5758,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5852,7 +5850,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5875,11 +5873,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5901,14 +5899,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5924,7 +5922,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5962,7 +5960,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5976,11 +5974,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5999,7 +5997,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6014,22 +6012,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6039,22 +6037,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6080,7 +6078,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6097,12 +6095,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6118,11 +6116,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6150,11 +6148,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6169,7 +6167,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6218,24 +6216,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6254,7 +6252,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6265,7 +6263,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6273,21 +6271,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6301,7 +6299,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6315,8 +6313,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6331,7 +6329,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6345,7 +6343,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6365,27 +6363,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6397,19 +6395,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6425,19 +6423,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6445,23 +6443,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6490,21 +6488,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6513,7 +6511,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6546,7 +6544,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6560,15 +6558,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6604,7 +6602,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6628,9 +6626,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6650,7 +6648,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6666,11 +6664,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6678,11 +6676,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6702,48 +6700,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6778,8 +6776,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6789,7 +6787,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6875,11 +6873,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6946,24 +6944,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6971,70 +6969,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7060,19 +7058,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7185,8 +7183,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7202,11 +7200,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7214,28 +7212,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7243,31 +7241,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7291,19 +7289,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7371,13 +7369,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7386,7 +7384,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7570,7 +7568,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7578,7 +7576,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7587,7 +7585,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7595,7 +7593,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7604,7 +7602,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7612,7 +7610,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7626,7 +7624,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7638,7 +7636,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7657,13 +7655,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7671,13 +7669,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7787,7 +7785,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7799,7 +7797,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7836,11 +7834,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -159,7 +159,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -333,7 +333,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -376,7 +376,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -415,7 +415,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -486,7 +486,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -515,7 +515,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -544,7 +544,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -579,7 +579,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -615,7 +615,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -651,7 +651,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -682,7 +682,7 @@ msgstr "%s non è una directory"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr "(nessuno)"
 
@@ -714,7 +714,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -756,15 +756,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -794,11 +794,11 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
@@ -823,25 +823,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
@@ -854,24 +854,24 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Il nome del container è: %s"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -888,11 +888,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -929,15 +929,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -997,7 +997,7 @@ msgstr "Alias:"
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr "Architettura: %s"
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1025,28 +1025,28 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -1084,7 +1084,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1103,11 +1103,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -1138,14 +1138,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -1173,15 +1173,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1197,7 +1197,7 @@ msgstr "NOME COMUNE"
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1263,7 +1263,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1292,7 +1292,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1329,18 +1329,18 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1349,7 +1349,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1359,63 +1359,63 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1434,20 +1434,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Colonne"
 
@@ -1475,7 +1475,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1483,13 +1483,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1559,7 +1559,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1603,21 +1603,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1632,27 +1632,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1660,7 +1660,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1741,15 +1741,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Creazione del container in corso"
@@ -1758,24 +1758,24 @@ msgstr "Creazione del container in corso"
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
@@ -1802,7 +1802,7 @@ msgstr "Creazione di %s in corso"
 msgid "Creating %s: %%s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
@@ -1812,16 +1812,16 @@ msgstr "Creazione del container in corso"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1839,7 +1839,7 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1851,11 +1851,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1897,15 +1897,15 @@ msgstr "Creazione del container in corso"
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Il nome del container è: %s"
@@ -1914,24 +1914,24 @@ msgstr "Il nome del container è: %s"
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1948,7 +1948,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1962,15 +1962,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1994,51 +1994,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2059,8 +2059,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -2074,11 +2074,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2116,12 +2116,6 @@ msgstr "La periferica esiste già: %s"
 msgid "Device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -2137,7 +2131,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2195,22 +2189,22 @@ msgstr "Creazione del container in corso"
 msgid "Display instances from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Creazione del container in corso"
@@ -2220,7 +2214,7 @@ msgstr "Creazione del container in corso"
 msgid "Display storage pool buckets from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2228,7 +2222,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -2237,7 +2231,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -2245,7 +2239,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DI SCADENZA"
@@ -2260,7 +2254,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2268,7 +2262,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2306,19 +2300,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Il nome del container è: %s"
@@ -2327,21 +2321,21 @@ msgstr "Il nome del container è: %s"
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2366,17 +2360,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2392,7 +2386,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2419,11 +2413,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2434,10 +2428,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2449,12 +2443,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2464,7 +2458,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -2545,7 +2539,7 @@ msgstr "Creazione del container in corso"
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2558,7 +2552,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2652,11 +2646,11 @@ msgstr "Accetta certificato"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2666,7 +2660,7 @@ msgstr "Accetta certificato"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2676,7 +2670,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Il nome del container è: %s"
@@ -2686,7 +2680,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to find image %q on remote %q"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2711,7 +2705,7 @@ msgstr "Accetta certificato"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2720,7 +2714,7 @@ msgstr "Accetta certificato"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -2731,13 +2725,13 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2748,7 +2742,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2756,11 +2750,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2777,7 +2771,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2802,16 +2796,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2823,7 +2817,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2847,7 +2841,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2867,7 +2861,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2876,7 +2870,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2884,23 +2878,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Creazione del container in corso"
@@ -2909,25 +2903,25 @@ msgstr "Creazione del container in corso"
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2948,7 +2942,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Il nome del container è: %s"
@@ -2961,19 +2955,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
@@ -2983,21 +2977,21 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network peer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3042,7 +3036,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3075,7 +3069,7 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3093,11 +3087,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3105,15 +3099,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -3257,7 +3251,7 @@ msgstr "Creazione del container in corso"
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -3283,7 +3277,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -3302,7 +3296,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Il nome del container è: %s"
@@ -3311,7 +3305,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3345,7 +3339,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid export version %q: %w"
 msgstr "Proprietà errata: %s"
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Proprietà errata: %s"
@@ -3404,7 +3398,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3440,7 +3434,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3448,17 +3442,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3470,8 +3464,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3489,12 +3483,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creazione del container in corso"
@@ -3509,7 +3503,7 @@ msgstr "Architettura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3523,38 +3517,38 @@ msgstr "Alias:"
 msgid "List all active certificate add tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 #, fuzzy
 msgid "List all warnings"
 msgstr "Alias:"
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Creazione del container in corso"
@@ -3563,20 +3557,20 @@ msgstr "Creazione del container in corso"
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3760,11 +3754,11 @@ msgstr "Creazione del container in corso"
 msgid "List permissions"
 msgstr "Alias:"
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3780,7 +3774,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3817,7 +3811,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3825,12 +3819,12 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 #, fuzzy
 msgid "List warnings"
 msgstr "Alias:"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3862,7 +3856,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3870,17 +3864,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 #, fuzzy
 msgid "Lower device"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 #, fuzzy
 msgid "Lower devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3888,7 +3882,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3898,11 +3892,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3915,15 +3909,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3931,7 +3925,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3950,15 +3944,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -4044,33 +4038,33 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Creazione del container in corso"
@@ -4080,17 +4074,17 @@ msgstr "Creazione del container in corso"
 msgid "Manage network peerings"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Creazione del container in corso"
@@ -4100,11 +4094,11 @@ msgstr "Creazione del container in corso"
 msgid "Manage permissions"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4143,7 +4137,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4156,7 +4150,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr "Il nome del container è: %s"
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Creazione del container in corso"
@@ -4180,17 +4174,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4240,14 +4234,14 @@ msgstr "Il nome del container è: %s"
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4278,8 +4272,8 @@ msgstr "Il nome del container è: %s"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
@@ -4290,14 +4284,14 @@ msgstr "Il nome del container è: %s"
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
@@ -4308,43 +4302,43 @@ msgstr "Il nome del container è: %s"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Il nome del container è: %s"
@@ -4372,19 +4366,19 @@ msgstr "Il nome del container è: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4406,7 +4400,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4431,7 +4425,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4487,11 +4481,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4503,12 +4497,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4521,11 +4515,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4537,9 +4531,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4566,11 +4560,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4580,67 +4574,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4670,20 +4664,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4705,12 +4699,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4718,19 +4712,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 #, fuzzy
 msgid "No need to specify a warning UUID when using --all"
 msgstr "Occorre specificare un nome di container come origine"
@@ -4758,7 +4752,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4775,7 +4769,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4787,7 +4781,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4798,6 +4792,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4830,7 +4828,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4838,29 +4836,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4882,7 +4880,7 @@ msgstr "Creazione del container in corso"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4890,12 +4888,12 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4912,14 +4910,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4933,7 +4931,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4956,32 +4954,32 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -5000,7 +4998,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5013,22 +5011,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5126,7 +5124,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -5163,7 +5161,7 @@ msgstr "Creazione del container in corso"
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -5171,7 +5169,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -5179,7 +5177,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -5220,46 +5218,46 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -5273,7 +5271,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
@@ -5282,11 +5280,11 @@ msgstr "Il nome del container è: %s"
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Il nome del container è: %s"
@@ -5295,25 +5293,25 @@ msgstr "Il nome del container è: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -5326,7 +5324,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -5334,20 +5332,20 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -5356,7 +5354,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5364,11 +5362,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5390,23 +5388,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5428,7 +5426,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5456,7 +5454,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
@@ -5477,7 +5475,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -5490,7 +5488,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5500,7 +5498,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
@@ -5522,7 +5520,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5552,20 +5550,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5573,11 +5571,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5590,23 +5588,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5620,7 +5618,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -5668,11 +5666,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5681,11 +5679,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5694,11 +5692,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5707,12 +5705,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5734,12 +5732,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5748,16 +5746,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5766,11 +5764,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5819,7 +5817,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5847,19 +5845,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
@@ -5868,25 +5866,25 @@ msgstr "Il nome del container è: %s"
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Il nome del container è: %s"
@@ -5932,7 +5930,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5995,24 +5993,24 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Il nome del container è: %s"
@@ -6022,26 +6020,26 @@ msgstr "Il nome del container è: %s"
 msgid "Show network peer configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -6077,7 +6075,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -6106,7 +6104,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Il nome del container è: %s"
@@ -6119,7 +6117,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -6159,7 +6157,7 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6178,7 +6176,7 @@ msgstr ""
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6271,7 +6269,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6294,11 +6292,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6320,14 +6318,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6382,7 +6380,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "La periferica esiste già"
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6396,11 +6394,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Il nome del container è: %s"
@@ -6420,7 +6418,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6435,22 +6433,22 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6460,22 +6458,22 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6501,7 +6499,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6518,12 +6516,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6540,11 +6538,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
@@ -6573,11 +6571,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6592,7 +6590,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6641,24 +6639,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6678,7 +6676,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6689,7 +6687,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6697,21 +6695,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6725,7 +6723,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
@@ -6740,8 +6738,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6756,7 +6754,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6771,7 +6769,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -6793,28 +6791,28 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Il nome del container è: %s"
@@ -6828,21 +6826,21 @@ msgstr "Il nome del container è: %s"
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6859,19 +6857,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
@@ -6880,25 +6878,25 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6928,22 +6926,22 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accetta certificato"
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6952,7 +6950,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 #, fuzzy
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
@@ -6986,7 +6984,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -7000,15 +6998,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -7044,7 +7042,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -7068,9 +7066,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -7092,7 +7090,7 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
@@ -7111,11 +7109,11 @@ msgid ""
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Creazione del container in corso"
@@ -7125,12 +7123,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
@@ -7154,58 +7152,58 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 #, fuzzy
 msgid "[<remote>:]<API path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7245,8 +7243,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Creazione del container in corso"
@@ -7258,7 +7256,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7365,12 +7363,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "Creazione del container in corso"
@@ -7452,28 +7450,28 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7483,82 +7481,82 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7590,22 +7588,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7744,8 +7742,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -7765,12 +7763,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7780,33 +7778,33 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7816,37 +7814,37 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7876,22 +7874,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 #, fuzzy
 msgid "[<remote>:][<warning-uuid>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7959,13 +7957,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7974,7 +7972,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8158,7 +8156,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -8166,7 +8164,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8175,7 +8173,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8183,7 +8181,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8192,7 +8190,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -8200,7 +8198,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -8214,7 +8212,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8226,7 +8224,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8245,13 +8243,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8259,13 +8257,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -8375,7 +8373,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -8388,7 +8386,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8425,11 +8423,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "si"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -142,7 +142,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -312,7 +312,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgstr ""
 "### Note that only the ingress and egress rules, description and "
 "configuration keys can be changed."
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -409,7 +409,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -484,7 +484,7 @@ msgstr ""
 "### Note that the name, target_project, target_network and status fields "
 "cannot be changed."
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -508,7 +508,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -532,7 +532,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -568,7 +568,7 @@ msgstr ""
 "###\n"
 "### Note that only the configuration can be changed."
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -606,7 +606,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -641,7 +641,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -674,7 +674,7 @@ msgstr "%s はディレクトリではありません"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr "(none)"
 
@@ -705,7 +705,7 @@ msgstr "--console と --all は同時に指定できません"
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
@@ -721,7 +721,7 @@ msgstr "--instance-only はコピー元がスナップショットの場合は�
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles と --refresh は同時に指定できません"
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr "--project は query コマンドでは使えません"
 
@@ -746,15 +746,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -785,11 +785,11 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
@@ -797,7 +797,7 @@ msgstr "AUTH TYPE"
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
@@ -814,25 +814,25 @@ msgstr "アクセスキー: %s"
 msgid "Access the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr "警告を確認します"
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "%q はこのツールではサポートされていません"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスタグループからメンバを削除します"
@@ -845,23 +845,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr "ネットワークゾーンレコードのエントリを追加します"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr "ネットワークゾーンレコードにエントリを追加します"
 
@@ -869,7 +869,7 @@ msgstr "ネットワークゾーンレコードにエントリを追加します
 msgid "Add instance devices"
 msgstr "インスタンスにデバイスを追加します"
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 #, fuzzy
 msgid "Add member to group"
 msgstr "グループからメンバーを削除します"
@@ -878,11 +878,11 @@ msgstr "グループからメンバーを削除します"
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -938,15 +938,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr "フォワードにポートを追加します"
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr "インスタンスにプロファイルを追加します"
 
@@ -954,7 +954,7 @@ msgstr "インスタンスにプロファイルを追加します"
 msgid "Add roles to a cluster member"
 msgstr "クラスターメンバーにロールを追加します"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr "ACLにルールを追加します"
 
@@ -968,7 +968,7 @@ msgstr "アドレス: %s"
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
@@ -1005,7 +1005,7 @@ msgstr "エイリアス:"
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
@@ -1023,7 +1023,7 @@ msgstr "アーキテクチャ: %s"
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1033,27 +1033,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr "クラスターメンバーにグループの組を割り当てます"
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr "インスタンスにプロファイルを割り当てます"
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr "インスタンスにネットワークインターフェースを追加します"
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr "プロファイルにネットワークインターフェースを追加します"
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr "新たなネットワークインターフェースをインスタンスに追加します"
 
@@ -1095,7 +1095,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1114,11 +1114,11 @@ msgstr "自動更新は pull モードのときのみ有効です"
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
@@ -1151,14 +1151,14 @@ msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1173,7 +1173,7 @@ msgstr "不適切な キー=値 のペア: %s"
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr "ボンディング:"
 
@@ -1186,15 +1186,15 @@ msgstr "--all とインスタンス名を両方同時に指定することはで
 msgid "Brand: %v"
 msgstr "ブランド: %v"
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr "ブリッジ:"
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1210,7 +1210,7 @@ msgstr "COMMON NAME"
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr "COUNT"
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1292,7 +1292,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -1305,7 +1305,7 @@ msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
@@ -1345,19 +1345,19 @@ msgstr "カード: %s (%s)"
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr "Chassis"
 
@@ -1366,7 +1366,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1375,63 +1375,63 @@ msgstr "クライアント証明書がサーバに信頼されました:"
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "クラスターグループ %s が削除されました"
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "クラスターグループ %s は現在 %s に適用されていません"
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスタグループ名 %s を %s に変更しました"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "クラスターメンバー %s がクラスターグループ %s に追加されました"
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "クラスターメンバー %s がクラスターグループ %s に追加されました"
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1450,20 +1450,20 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1495,7 +1495,7 @@ msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない�
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
@@ -1503,13 +1503,13 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1594,7 +1594,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
@@ -1610,7 +1610,7 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
@@ -1638,21 +1638,21 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "証明書のファイルパスが見つかりません: %s"
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
@@ -1667,27 +1667,27 @@ msgstr "設定の構文エラー: %s"
 msgid "Could not parse identity: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "証明書ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr "一致するエントリを見つけられませんでした"
 
@@ -1696,7 +1696,7 @@ msgstr "一致するエントリを見つけられませんでした"
 msgid "Create a TLS identity"
 msgstr "警告を削除します"
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr "クラスターグループを作成します"
 
@@ -1776,15 +1776,15 @@ msgstr "新たにカスタムストレージボリュームを作成します"
 msgid "Create new instance file templates"
 msgstr "新たにインスタンスのファイルテンプレートを作成します"
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr "新たにネットワーク ACL を作成します"
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr "新たにネットワークフォワードを作成します"
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr "新たにネットワークロードバランサーを作成します"
 
@@ -1792,23 +1792,23 @@ msgstr "新たにネットワークロードバランサーを作成します"
 msgid "Create new network peering"
 msgstr "新たにネットワークピアリングを作成します"
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr "新たにネットワークゾーンを作成します"
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr "プロジェクトを作成します"
 
@@ -1825,7 +1825,7 @@ msgstr "プロファイルを適用しないインスタンスを作成します
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
@@ -1835,7 +1835,7 @@ msgstr "%s を作成中"
 msgid "Creating %s: %%s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
@@ -1844,16 +1844,16 @@ msgstr "インスタンスを作成中"
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1871,7 +1871,7 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr "DRM:"
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
@@ -1883,11 +1883,11 @@ msgstr "圧縮アルゴリズムを指定します: backup or none"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "バックグラウンドの操作を削除します（キャンセルを試みます）"
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr "クラスタグループを削除します"
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
@@ -1930,15 +1930,15 @@ msgstr "インスタンスとスナップショットを削除します"
 msgid "Delete key from a storage bucket"
 msgstr "ストレージバケットからキーを削除します"
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr "ネットワークフォワードを削除します"
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr "ネットワークロードバランサーを削除します"
 
@@ -1946,23 +1946,23 @@ msgstr "ネットワークロードバランサーを削除します"
 msgid "Delete network peerings"
 msgstr "ネットワークピアリングを削除します"
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr "ネットワークゾーンレコードを削除します"
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr "ネットワークゾーンを削除します"
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
@@ -1978,7 +1978,7 @@ msgstr "ストレージプールを削除します"
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr "警告を削除します"
 
@@ -1992,15 +1992,15 @@ msgstr "警告を削除します"
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -2024,51 +2024,51 @@ msgstr "警告を削除します"
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2089,8 +2089,8 @@ msgstr "警告を削除します"
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr "説明"
 
@@ -2103,11 +2103,11 @@ msgstr "説明: %s"
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr "インスタンスからネットワークインターフェースを取り外します"
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
@@ -2144,14 +2144,6 @@ msgstr "デバイスは既に存在します: %s"
 msgid "Device doesn't exist"
 msgstr "デバイスが存在しません"
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-"プロファイルのデバイスは個々のインスタンスでは変更できません。デバイスを上書"
-"きするかプロファイルを変更してください"
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -2169,7 +2161,7 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
@@ -2226,22 +2218,22 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
@@ -2251,7 +2243,7 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Display storage pool buckets from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
@@ -2259,7 +2251,7 @@ msgstr "--force を使う際にユーザーの確認を必要としない"
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr "Down delay"
 
@@ -2268,7 +2260,7 @@ msgstr "Down delay"
 msgid "Driver: %v (%v)"
 msgstr "ドライバ: %v (%v)"
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr "ENTRIES"
 
@@ -2276,7 +2268,7 @@ msgstr "ENTRIES"
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr "EXPIRES AT"
 
@@ -2292,7 +2284,7 @@ msgstr ""
 "ファイル転送のサーバ側の初期処理はキャンセルできません（強制的に中断するには"
 "あと2回行ってください）"
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
@@ -2301,7 +2293,7 @@ msgstr "クラスタグループを編集します"
 msgid "Edit an identity as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
@@ -2340,19 +2332,19 @@ msgstr "インスタンスのメタデータファイルを編集します"
 msgid "Edit instance or server configurations as YAML"
 msgstr "インスタンスもしくはサーバの設定をYAMLファイルで編集します"
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr "ネットワーク ACL をYAMLで編集します"
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr "ネットワークフォワード設定をYAMLで編集します"
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr "ネットワークロードバランサー設定をYAMLで編集します"
 
@@ -2360,19 +2352,19 @@ msgstr "ネットワークロードバランサー設定をYAMLで編集しま�
 msgid "Edit network peer configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr "ネットワークゾーン設定をYAMLで編集します"
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
@@ -2396,19 +2388,19 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 "クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 #, fuzzy
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
@@ -2434,7 +2426,7 @@ msgstr ""
 "  これは 'lxc config get core.https_address' コマンドでチェックできます。\n"
 "  まだ使用可能でない場合は、アドレスを設定することもできます。"
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr "TTLを指定します"
 
@@ -2461,11 +2453,11 @@ msgstr "イメージの取得中: %s"
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2476,10 +2468,10 @@ msgstr "イメージの取得中: %s"
 msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2491,11 +2483,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr "クラスターのメンバーを待避させます"
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2505,7 +2497,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
@@ -2599,7 +2591,7 @@ msgstr "バックアップのエクスポート中: %s"
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr "FAILURE DOMAIN"
 
@@ -2612,7 +2604,7 @@ msgstr "FILENAME"
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
@@ -2706,11 +2698,11 @@ msgstr "sshfs の起動に失敗しました: %w"
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
@@ -2720,7 +2712,7 @@ msgstr "サーバー証明書ファイル %q のクローズに失敗しまし�
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -2730,7 +2722,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
@@ -2740,7 +2732,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to find image %q on remote %q"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
@@ -2765,7 +2757,7 @@ msgstr "エイリアス %s の削除に失敗しました: %w"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
@@ -2774,7 +2766,7 @@ msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
@@ -2784,14 +2776,14 @@ msgstr "情報表示のフィルタリングはまだサポートされていま
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 #, fuzzy
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr "特定の待避アクションを強制します"
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2802,7 +2794,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
@@ -2810,11 +2802,11 @@ msgstr "ユーザーの確認なしで強制的に待避させます"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 #, fuzzy
 msgid "Force restoration without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
@@ -2831,7 +2823,7 @@ msgstr "稼働中のインスタンスを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2871,16 +2863,16 @@ msgstr ""
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -2892,7 +2884,7 @@ msgstr "フォーマット (json|pretty|yaml)"
 msgid "Format (man|md|rest|yaml)"
 msgstr "フォーマット (man|md|rest|yaml)"
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr "Forward delay"
 
@@ -2916,7 +2908,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2936,7 +2928,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -2945,7 +2937,7 @@ msgstr "クライアント証明書を生成します。1分ぐらいかかり�
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
@@ -2953,25 +2945,25 @@ msgstr "リソース割当の状況を表示します"
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 #, fuzzy
 msgid "Get the key as a cluster property"
 msgstr "クラスターグループを作成します"
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "ネットワークロードバランサーのポートを管理します"
@@ -2981,25 +2973,25 @@ msgstr "ネットワークロードバランサーのポートを管理します
 msgid "Get the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3022,7 +3014,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr "クラスターメンバーの設定値を取得します"
 
@@ -3034,19 +3026,19 @@ msgstr "デバイスの設定値を取得します"
 msgid "Get values for instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr "ネットワーク ACL の設定値を取得します"
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr "ネットワークフォワードの設定値を取得します"
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定値を取得します"
 
@@ -3054,19 +3046,19 @@ msgstr "ネットワークロードバランサーの設定値を取得します
 msgid "Get values for network peer configuration keys"
 msgstr "ネットワークピアの設定値を取得します"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr "ネットワークゾーンの設定値を取得します"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
@@ -3111,7 +3103,7 @@ msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 
 msgid "HARDWARE ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -3143,7 +3135,7 @@ msgstr "インスタンスから sshfs への I/O コピーに失敗しました
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr "ID"
 
@@ -3161,11 +3153,11 @@ msgstr "ID: %s"
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr "IMAGES"
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
@@ -3173,15 +3165,15 @@ msgstr "IP ADDRESS"
 msgid "IP addresses"
 msgstr "IP アドレス"
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr "IP アドレス:"
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -3336,7 +3328,7 @@ msgstr "インスタンスのインポート中: %s"
 msgid "Infiniband:"
 msgstr "Infiniband:"
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr "入力するデータ"
 
@@ -3361,7 +3353,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -3380,7 +3372,7 @@ msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用
 msgid "Instance published with fingerprint: %s"
 msgstr "インスタンスは以下のフィンガープリントで publish されます: %s"
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "インスタンス名: %s"
@@ -3389,7 +3381,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3424,7 +3416,7 @@ msgstr "不正なフォーマット %q"
 msgid "Invalid export version %q: %w"
 msgstr "クライアントバージョン: %s\n"
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr "不正なフォーマット %s"
@@ -3488,7 +3480,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -3523,7 +3515,7 @@ msgstr "IsSM: %s (%s)"
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr "LAST SEEN"
 
@@ -3531,17 +3523,17 @@ msgstr "LAST SEEN"
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr "LIMIT"
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3555,8 +3547,8 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -3574,12 +3566,12 @@ msgstr "最終使用: %s"
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 #, fuzzy
 msgid "Launching the instance"
 msgstr "インスタンスを作成中"
@@ -3594,7 +3586,7 @@ msgstr "リンクを検出: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
@@ -3606,35 +3598,35 @@ msgstr "エイリアスを一覧表示します"
 msgid "List all active certificate add tokens"
 msgstr "有効な証明書追加トークンをすべて一覧表示します"
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr "クラスタグループをすべて一覧表示します"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr "警告を一覧表示します"
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr "利用可能なネットワークフォワードを一覧表示します"
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr "利用可能なネットワークロードバランサーを一覧表示します"
 
@@ -3642,19 +3634,19 @@ msgstr "利用可能なネットワークロードバランサーを一覧表示
 msgid "List available network peers"
 msgstr "利用可能なネットワークピアを一覧表示します"
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr "利用可能なネットワークゾーンレコードを一覧表示します"
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr "利用可能なネットワークを一覧表示します"
 
@@ -3944,11 +3936,11 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "List permissions"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 #, fuzzy
 msgid ""
 "List profiles\n"
@@ -3983,7 +3975,7 @@ msgstr ""
 "    u - UUID\n"
 "    t - タイプ"
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
@@ -4034,7 +4026,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -4042,11 +4034,11 @@ msgstr "利用可能なリモートサーバを一覧表示します"
 msgid "List trusted clients"
 msgstr "信頼済みクライアントを一覧表示します"
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr "警告を一覧表示します"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -4096,7 +4088,7 @@ msgstr "バックグラウンド操作の一覧表示、表示、削除を行い
 msgid "Location: %s"
 msgstr "ロケーション: %s"
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
@@ -4104,15 +4096,15 @@ msgstr "ログレベルのフィルタリングは pretty フォーマットで�
 msgid "Log:"
 msgstr "ログ:"
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr "Lower device"
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr "Lower devices"
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
@@ -4120,7 +4112,7 @@ msgstr "MAC ADDRESS"
 msgid "MAC address"
 msgstr "MAC アドレス"
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
@@ -4130,11 +4122,11 @@ msgstr "MAC アドレス: %s"
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr "MANAGED"
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr "MEMBERS"
 
@@ -4147,15 +4139,15 @@ msgstr "MEMORY USAGE"
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr "MII 監視頻度"
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr "MII 状態"
 
@@ -4163,7 +4155,7 @@ msgstr "MII 状態"
 msgid "MTU"
 msgstr "MTU"
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr "MTU: %d"
@@ -4182,15 +4174,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr "ネットワークを管理し、インスタンスをネットワークに接続します"
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr "クラスタグループを管理します"
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr "クラスタのメンバを管理します"
 
@@ -4286,31 +4278,31 @@ msgstr "インスタンスのファイルテンプレートを管理します"
 msgid "Manage instance metadata files"
 msgstr "インスタンスのメタデータファイルを管理します"
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr "ネットワーク ACL ルールを管理します"
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr "ネットワーク ACL を管理します"
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr "ネットワークフォワードを管理します"
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr "ネットワークロードバランサーのバックエンドを管理します"
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr "ネットワークロードバランサーを管理します"
 
@@ -4318,15 +4310,15 @@ msgstr "ネットワークロードバランサーを管理します"
 msgid "Manage network peerings"
 msgstr "ネットワークピアリングを管理します"
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr "ネットワークゾーンレコードのエントリを管理します"
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr "ネットワークゾーンレコードを管理します"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr "ネットワークゾーンを管理します"
 
@@ -4335,11 +4327,11 @@ msgstr "ネットワークゾーンを管理します"
 msgid "Manage permissions"
 msgstr "プロファイルを管理します"
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr "プロファイルを管理します"
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr "プロジェクトを管理します"
 
@@ -4379,7 +4371,7 @@ msgstr ""
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
@@ -4392,7 +4384,7 @@ msgstr "信頼済みのクライアントを管理します"
 msgid "Manage user authorization"
 msgstr "クラスタロールを管理します"
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr "警告を管理します"
 
@@ -4415,17 +4407,17 @@ msgstr "メンバー %q はすでにロール %q を持っています"
 msgid "Member %q does not have role %q"
 msgstr "メンバー %q はロール %q を持っていません"
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr "メンバ %s の join トークン:"
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
@@ -4474,13 +4466,13 @@ msgstr "バケット名を指定する必要があります"
 msgid "Missing certificate fingerprint"
 msgstr "証明書のフィンガープリントがありません"
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
@@ -4510,8 +4502,8 @@ msgstr "クラスターグループ名がありません"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
@@ -4520,14 +4512,14 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr "リッスンアドレスを指定する必要があります"
 
@@ -4537,41 +4529,41 @@ msgstr "リッスンアドレスを指定する必要があります"
 msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr "ネットワーク ACL 名を指定する必要があります"
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr "ネットワークゾーンレコード名を指定する必要があります"
 
@@ -4597,18 +4589,18 @@ msgstr "ピア名を指定する必要があります"
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
@@ -4628,7 +4620,7 @@ msgstr "コピー先のディレクトリを指定する必要があります"
 msgid "Missing target network"
 msgstr "作成するネットワーク名を指定する必要があります"
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr "モード"
 
@@ -4656,7 +4648,7 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
@@ -4724,12 +4716,12 @@ msgstr "コピー／移動元とは異なるプロジェクトに移動します
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
@@ -4742,12 +4734,12 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr "NAME"
@@ -4761,11 +4753,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr "NETWORKS"
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr "NETWORK ZONES"
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
@@ -4777,9 +4769,9 @@ msgstr "NIC:"
 msgid "NICs:"
 msgstr "NICs:"
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr "NO"
 
@@ -4806,11 +4798,11 @@ msgstr "NVRM バージョン: %v"
 msgid "Name"
 msgstr "名前"
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -4820,67 +4812,67 @@ msgstr "名前: %s"
 msgid "Name: %v"
 msgstr "名前: %v"
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr "ネットワーク %s を作成しました"
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr "ネットワーク %s を削除しました"
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr "ネットワーク %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr "ネットワーク ACL %s を作成しました"
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr "ネットワーク ACL %s を削除しました"
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "ネットワーク ACL 名 %s を %s に変更しました"
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr "ネットワークゾーン %s を作成しました"
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr "ネットワークフォワード %s を作成しました"
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr "ネットワークフォワード %s を削除しました"
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr "ネットワークロードバランサー %s を作成しました"
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr "ネットワークロードバランサー %s を削除しました"
@@ -4912,20 +4904,20 @@ msgstr ""
 "ネットワークピア %s はピアリング状態です (ピアネットワーク上で相互ピアリング"
 "を完了させてください)"
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr "ネットワークゾーンレコード %s を作成しました"
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr "ネットワークゾーンレコード %s を削除しました"
@@ -4947,13 +4939,13 @@ msgstr "指定するデバイスに適用する新しいキー/値"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr "メンバー %s に対する証明書追加トークンがリモートにありません: %s"
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 "メンバー %s に対するクラスターへの join トークンがリモート %s にありません"
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
@@ -4961,19 +4953,19 @@ msgstr "このネットワークに対するデバイスがありません"
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr "マッチするバックエンドが見つかりません"
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr "マッチするルールが見つかりません"
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 #, fuzzy
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
@@ -5001,7 +4993,7 @@ msgstr "ノード %d:\n"
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr "OVN:"
 
@@ -5019,7 +5011,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -5031,7 +5023,7 @@ msgstr "リモートイメージのインポートは https:// のみをサポ�
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
@@ -5043,6 +5035,10 @@ msgstr "バックグラウンド操作 %s を削除しました"
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
+msgstr ""
 
 #: lxc/main.go:97
 msgid "Override the source project"
@@ -5074,7 +5070,7 @@ msgstr "PID: %d"
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr "PORTS"
 
@@ -5082,29 +5078,29 @@ msgstr "PORTS"
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -5125,7 +5121,7 @@ msgstr "インスタンスを一時停止します"
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバアドレスを指定してください（空の場合は中止）:"
 
@@ -5133,11 +5129,11 @@ msgstr "別のサーバアドレスを指定してください（空の場合は
 msgid "Please provide client name: "
 msgstr "クライアント名を入力してください: "
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 #, fuzzy
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
@@ -5155,14 +5151,14 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -5178,7 +5174,7 @@ msgstr "Pretty レンダリング（--format=pretty の短縮系）"
 msgid "Print help"
 msgstr "ヘルプを表示します"
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
@@ -5201,32 +5197,32 @@ msgstr "エイリアスの処理が失敗しました: %s"
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -5243,7 +5239,7 @@ msgstr "新しいインスタンスに適用するプロファイル"
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
@@ -5256,22 +5252,22 @@ msgstr "プロファイル:"
 msgid "Profiles: "
 msgstr "プロファイル: "
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr "プロジェクト %s を作成しました"
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
@@ -5375,7 +5371,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
@@ -5411,7 +5407,7 @@ msgstr "インスタンス内にファイルをコピーします"
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
@@ -5419,7 +5415,7 @@ msgstr "query のパスは / で始める必要があります"
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
@@ -5427,7 +5423,7 @@ msgstr "RESOURCE"
 msgid "ROLE"
 msgstr "ROLE"
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr "ROLES"
 
@@ -5468,45 +5464,45 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 #, fuzzy
 msgid "Remote trust token"
 msgstr "信頼済みクライアントを削除します"
@@ -5521,7 +5517,7 @@ msgstr "リムーバブルディスク: %v"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
@@ -5530,11 +5526,11 @@ msgstr "クラスタグループからメンバを削除します"
 msgid "Remove a group from an identity"
 msgstr "ACL からルールを削除します"
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
@@ -5542,23 +5538,23 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
@@ -5571,7 +5567,7 @@ msgstr "グループからメンバーを削除します"
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
@@ -5580,19 +5576,19 @@ msgstr "グループからメンバーを削除します"
 msgid "Remove permissions from groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5600,7 +5596,7 @@ msgstr "リモートサーバを削除します"
 msgid "Remove roles from a cluster member"
 msgstr "クラスタメンバからロールを削除します"
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr "ACL からルールを削除します"
 
@@ -5608,11 +5604,11 @@ msgstr "ACL からルールを削除します"
 msgid "Remove trusted client"
 msgstr "信頼済みクライアントを削除します"
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr "クラスタグループの名前を変更します"
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
@@ -5635,23 +5631,23 @@ msgstr "クラスタグループの名前を変更します"
 msgid "Rename instances and snapshots"
 msgstr "インスタンスまたはインスタンスのスナップショットの名前を変更します"
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr "ネットワーク ACL 名を変更します"
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -5674,7 +5670,7 @@ msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しまし�
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
@@ -5704,7 +5700,7 @@ msgstr ""
 "\n"
 "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
@@ -5726,7 +5722,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
@@ -5740,7 +5736,7 @@ msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 msgid "Retrieve the container's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -5749,7 +5745,7 @@ msgstr "イメージの取得中: %s"
 msgid "Revoke certificate add token"
 msgstr "証明書追加トークンを失効（Revoke）させます"
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
@@ -5770,7 +5766,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "Run against all projects"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
@@ -5800,20 +5796,20 @@ msgstr "SSH クライアントが %q に接続されました"
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr "STATIC"
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr "STATUS"
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
@@ -5821,11 +5817,11 @@ msgstr "STORAGE BUCKETS"
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr "STP"
 
@@ -5838,24 +5834,24 @@ msgstr "秘密鍵（空白の場合自動生成）"
 msgid "Secret key: %s"
 msgstr "秘密鍵: %s"
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 #, fuzzy
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
@@ -5869,7 +5865,7 @@ msgstr "サーバのバージョン: %s\n"
 msgid "Set UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
@@ -5928,11 +5924,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr "ネットワーク ACL の設定項目を設定します"
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5945,11 +5941,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5962,11 +5958,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5979,11 +5975,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6013,11 +6009,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr "ネットワークゾーンの設定を行います"
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6030,15 +6026,15 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6051,11 +6047,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6120,7 +6116,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -6151,21 +6147,21 @@ msgstr "プッシュ時にファイルのuidを設定します"
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 #, fuzzy
 msgid "Set the key as a cluster property"
 msgstr "クラスターグループを作成します"
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を行います"
@@ -6175,25 +6171,25 @@ msgstr "ネットワークロードバランサーの設定を行います"
 msgid "Set the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6233,7 +6229,7 @@ msgstr "詳細な情報を出力します"
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr "クラスタグループの設定を表示します"
 
@@ -6241,7 +6237,7 @@ msgstr "クラスタグループの設定を表示します"
 msgid "Show content of instance file templates"
 msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
@@ -6304,23 +6300,23 @@ msgstr "全てのコマンドを表示します (主なコマンドだけでは�
 msgid "Show local and remote versions"
 msgstr "ローカルとリモートのバージョンを表示します"
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr "ネットワーク ACL の設定を表示します"
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr "ネットワーク ACL ログを表示します"
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr "ネットワークフォワードの設定を表示します"
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr "ネットワークロードバランサーの設定を表示します"
 
@@ -6328,23 +6324,23 @@ msgstr "ネットワークロードバランサーの設定を表示します"
 msgid "Show network peer configurations"
 msgstr "ネットワークピアの設定を表示します"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr "ネットワークゾーンの設定を表示します"
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
@@ -6378,7 +6374,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -6407,7 +6403,7 @@ msgstr "使用量と空き容量を byte で表示します"
 msgid "Show trust configurations"
 msgstr "信頼済みクライアントの設定を表示します"
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr "クラスターメンバーについての情報を表示します"
 
@@ -6419,7 +6415,7 @@ msgstr "イメージについての情報を表示します"
 msgid "Show useful information about storage pools"
 msgstr "ストレージプールの情報を表示します"
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr "警告を表示します"
 
@@ -6459,7 +6455,7 @@ msgstr "一部のインスタンスで %s が失敗しました"
 msgid "Source:"
 msgstr "取得元:"
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -6467,7 +6463,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "インスタンスを起動します"
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr "%s を起動中"
@@ -6476,7 +6472,7 @@ msgstr "%s を起動中"
 msgid "State"
 msgstr "状態"
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr "状態: %s"
@@ -6568,7 +6564,7 @@ msgstr "ストレージボリュームの移動が成功しました!"
 msgid "Store the instance state"
 msgstr "インスタンスの状態を保存します"
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr "リモート %s に対するクラスター証明書の更新に成功しました"
@@ -6591,11 +6587,11 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -6617,14 +6613,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr "TOKEN"
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -6640,7 +6636,7 @@ msgstr "ターゲットのパスと --listen オプションは同時に指定�
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6679,7 +6675,7 @@ msgstr "移動先の LXD サーバはクラスタに属していません"
 msgid "The device already exists"
 msgstr "デバイスはすでに存在します"
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr "direction 引数は次のいずれかでなければなりません: ingress, egress"
 
@@ -6695,11 +6691,11 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6721,7 +6717,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6736,22 +6732,22 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6761,22 +6757,22 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6802,7 +6798,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 #, fuzzy
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
@@ -6821,12 +6817,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
@@ -6845,11 +6841,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr "LXD サーバはすでにクラスターに属しています"
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
@@ -6886,13 +6882,13 @@ msgstr "インスタンスがクリーンにシャットダウンするまで待
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -6912,7 +6908,7 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
@@ -6963,25 +6959,25 @@ msgstr "イメージを転送中: %s"
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--project は query コマンドでは使えません"
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
@@ -7002,7 +6998,7 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -7013,7 +7009,7 @@ msgstr "タイプ: %s"
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
@@ -7021,21 +7017,21 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr "USAGE"
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr "USED BY"
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr "UUID"
 
@@ -7049,7 +7045,7 @@ msgstr "UUID: %v"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
@@ -7063,8 +7059,8 @@ msgstr "未知の証明書タイプ %q"
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -7079,7 +7075,7 @@ msgstr "未知のコンソールタイプ %q"
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
@@ -7094,7 +7090,7 @@ msgstr "未知の出力タイプ: %q"
 msgid "Unset UEFI variables for instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
@@ -7114,27 +7110,27 @@ msgstr "イメージのプロパティを削除します"
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr "ネットワーク ACL の設定を削除します"
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
@@ -7146,19 +7142,19 @@ msgstr "ネットワークピアの設定を削除します"
 msgid "Unset network peer keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr "ネットワークゾーンの設定を削除します"
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
@@ -7174,20 +7170,20 @@ msgstr "ストレージプールの設定を削除します"
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を削除します"
@@ -7197,26 +7193,26 @@ msgstr "ネットワークロードバランサーの設定を削除します"
 msgid "Unset the key as a network peer property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7248,22 +7244,22 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr "Up delay"
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr "クラスター証明書を更新します"
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 "入力ファイルから読み込んだ PEM 証明書と鍵でクラスター証明書を更新します。"
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 #, fuzzy
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
@@ -7273,7 +7269,7 @@ msgstr "コピー元の全てのプロファイルがターゲットに存在し
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr "上位デバイス"
 
@@ -7308,7 +7304,7 @@ msgstr "使用済: %v"
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
@@ -7324,15 +7320,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr "VFs: %d"
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr "VLAN ID"
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr "VLAN フィルタリング"
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr "VLAN:"
 
@@ -7369,7 +7365,7 @@ msgstr "Volume Only"
 msgid "WWN: %s"
 msgstr "WWN: %s"
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr "処理が完全に終わるまで待ちます"
 
@@ -7395,9 +7391,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr "YES"
 
@@ -7418,7 +7414,7 @@ msgstr "コピー元のインスタンス名を指定してください"
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr ""
@@ -7438,11 +7434,11 @@ msgid ""
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
@@ -7450,11 +7446,11 @@ msgstr "[<remote>:]"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "[<remote>:] <backup file> [<instance name>]"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.key>"
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
@@ -7474,48 +7470,48 @@ msgstr "[<remote>:] [<filters>...]"
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr "[<remote>:]<ACL>"
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <direction> <key>=<value>..."
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<remote>:]<ACL> <key>"
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <key>=<value>..."
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "[<remote>:]<ACL> <new-name>"
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "[<remote>:]<ACL> [key=value...]"
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr "[<remote>:]<API path>"
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr "[<remote>:]<Zone>"
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr "[<remote>:]<Zone> <key>"
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <key>=<value>..."
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zone> [key=value...]"
 
@@ -7550,8 +7546,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
 
@@ -7562,7 +7558,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
@@ -7655,11 +7651,11 @@ msgstr "[<remote>:][<instance>] <key>=<value>..."
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instance> <name>..."
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instance> <profile>"
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instance> <profiles>"
 
@@ -7730,24 +7726,24 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr "[<remote>:]<member> <key>"
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "[<remote>:]<member> <key>=<value>..."
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
@@ -7755,39 +7751,39 @@ msgstr "[<remote>:]<member> <new-name>"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "[<remote>:]<member> <role[,role...]>"
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>]"
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr "[<remote>:]<network> <key>"
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "[<remote>:]<network> <listen_address>"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "[<remote>:]<network> <listen_address> <backend_name>"
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
@@ -7795,16 +7791,16 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <listen_address> <key>"
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <listen_address> <key>=<value>..."
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -7812,7 +7808,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
@@ -7820,11 +7816,11 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr "[<remote>:]<network> <new-name>"
 
@@ -7852,20 +7848,20 @@ msgstr "[<remote>:]<network> <peer_name> <key>"
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "[<remote>:]<network> <peer_name> <key>=<value>..."
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>]"
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "[<remote>:]<network> <listen_address> [key=value...]"
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "[<remote>:]<network> [key=value...]"
 
@@ -7987,8 +7983,8 @@ msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
@@ -8004,11 +8000,11 @@ msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "[<remote>:]<profile> <device> <type> [key=value...]"
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr "[<remote>:]<profile> <key>"
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
@@ -8017,28 +8013,28 @@ msgstr "[<remote>:]<profile> <key><value>..."
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "[<remote>:]<profile> <new-name>"
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr "[<remote>:]<project>"
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr "[<remote>:]<project> <key>"
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
@@ -8047,31 +8043,31 @@ msgstr "[<remote>:]<project> <new-name>"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr "[<remote>:]<warning-uuid>"
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr "[<remote>:]<zone>"
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr "[<remote>:]<zone> <record>"
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "[<remote>:]<zone> <record> <key>"
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "[<remote>:]<zone> <record> <key>=<value>..."
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "[<remote>:]<zone> <record> <type> <value>"
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
@@ -8096,20 +8092,20 @@ msgstr "[<remote>:][<instance>] <key>=<value>..."
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 #, fuzzy
 msgid "[<remote>:][<warning-uuid>]"
 msgstr "[<remote>:]<warning-uuid>"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr "現在値"
 
@@ -8192,7 +8188,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8200,7 +8196,7 @@ msgstr ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    member.yaml の内容でクラスターメンバーを更新します"
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -8214,7 +8210,7 @@ msgstr ""
 "lxc cluster group assign foo default\n"
 "    \"foo\" を \"default\" クラスタグループのみ使用するように再設定します。"
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 #, fuzzy
 msgid ""
 "lxc cluster group create g1\n"
@@ -8493,7 +8489,7 @@ msgstr ""
 "lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    スナップショットをリネームします。"
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 #, fuzzy
 msgid ""
 "lxc network acl create a1\n"
@@ -8506,7 +8502,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8515,7 +8511,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 #, fuzzy
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
@@ -8528,7 +8524,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 #, fuzzy
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
@@ -8542,7 +8538,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 #, fuzzy
 msgid ""
 "lxc network zone create z1\n"
@@ -8555,7 +8551,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 #, fuzzy
 msgid ""
 "lxc network zone record create z1 r1\n"
@@ -8576,7 +8572,7 @@ msgstr ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    上記のオペレーション UUID の詳細を表示します"
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8597,7 +8593,7 @@ msgstr ""
 "lxc profile assign foo ''\n"
 "    \"foo\" からすべてのプロファイルを削除します。"
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 #, fuzzy
 msgid ""
 "lxc profile create p1\n"
@@ -8629,7 +8625,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンスの /opt にマウントしま"
 "す。"
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -8637,7 +8633,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 #, fuzzy
 msgid ""
 "lxc project create p1\n"
@@ -8650,7 +8646,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8658,7 +8654,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -8808,7 +8804,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr "n"
 
@@ -8820,7 +8816,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -8859,14 +8855,21 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "yes"
+
+#~ msgid ""
+#~ "Device from profile(s) cannot be modified for individual instance. "
+#~ "Override device or modify profile instead"
+#~ msgstr ""
+#~ "プロファイルのデバイスは個々のインスタンスでは変更できません。デバイスを上"
+#~ "書きするかプロファイルを変更してください"
 
 #, fuzzy
 #~ msgid ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -103,7 +103,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -223,7 +223,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,7 +316,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -330,7 +330,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -406,7 +406,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -437,7 +437,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -468,7 +468,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -509,15 +509,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -546,11 +546,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -575,25 +575,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -605,23 +605,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -629,7 +629,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -637,11 +637,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -678,15 +678,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -745,7 +745,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -772,27 +772,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -830,7 +830,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,11 +849,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -884,14 +884,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1037,7 +1037,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1074,17 +1074,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1102,63 +1102,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1177,20 +1177,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1226,13 +1226,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1301,7 +1301,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1345,21 +1345,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1374,27 +1374,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1474,15 +1474,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,23 +1490,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1542,16 +1542,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1569,7 +1569,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1581,11 +1581,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1625,15 +1625,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1641,23 +1641,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1687,15 +1687,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1719,51 +1719,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1784,8 +1784,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1798,11 +1798,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1839,12 +1839,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1860,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1913,19 +1907,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1933,7 +1927,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1941,7 +1935,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1950,7 +1944,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1958,7 +1952,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1972,7 +1966,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1980,7 +1974,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2016,19 +2010,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2036,19 +2030,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2072,17 +2066,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2098,7 +2092,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2125,11 +2119,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2140,10 +2134,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2155,11 +2149,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2169,7 +2163,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2248,7 +2242,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2261,7 +2255,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2355,11 +2349,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2369,7 +2363,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2379,7 +2373,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2389,7 +2383,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2414,7 +2408,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2423,7 +2417,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2433,13 +2427,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2450,7 +2444,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2458,11 +2452,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2478,7 +2472,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2503,16 +2497,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2524,7 +2518,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2548,7 +2542,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2568,7 +2562,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2576,7 +2570,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2584,23 +2578,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2608,23 +2602,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2644,7 +2638,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2656,19 +2650,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2676,19 +2670,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2732,7 +2726,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2764,7 +2758,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2782,11 +2776,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2794,15 +2788,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2944,7 +2938,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2969,7 +2963,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2987,7 +2981,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2996,7 +2990,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3030,7 +3024,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3087,7 +3081,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3122,7 +3116,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3130,17 +3124,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3152,8 +3146,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3171,12 +3165,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3190,7 +3184,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3202,35 +3196,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3238,19 +3232,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3429,11 +3423,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3449,7 +3443,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3485,7 +3479,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3493,11 +3487,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3529,7 +3523,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3537,15 +3531,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3553,7 +3547,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3563,11 +3557,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3580,15 +3574,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3596,7 +3590,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3615,15 +3609,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3702,31 +3696,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3734,15 +3728,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3750,11 +3744,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3790,7 +3784,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3802,7 +3796,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3825,17 +3819,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3884,13 +3878,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3916,8 +3910,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3926,14 +3920,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3943,41 +3937,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4003,18 +3997,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4034,7 +4028,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4059,7 +4053,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4114,11 +4108,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4130,12 +4124,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4148,11 +4142,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4164,9 +4158,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4193,11 +4187,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4207,67 +4201,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4297,20 +4291,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4332,12 +4326,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4345,19 +4339,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4383,7 +4377,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4400,7 +4394,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4412,7 +4406,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4423,6 +4417,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4455,7 +4453,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4463,29 +4461,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4506,7 +4504,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4514,11 +4512,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4535,14 +4533,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4556,7 +4554,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4579,32 +4577,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4621,7 +4619,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4634,22 +4632,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4747,7 +4745,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4783,7 +4781,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4791,7 +4789,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4799,7 +4797,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4838,45 +4836,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4890,7 +4888,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4898,11 +4896,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4910,23 +4908,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4938,7 +4936,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4946,19 +4944,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4966,7 +4964,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4974,11 +4972,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4999,23 +4997,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5037,7 +5035,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5064,7 +5062,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5083,7 +5081,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5096,7 +5094,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5105,7 +5103,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5125,7 +5123,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5155,20 +5153,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5176,11 +5174,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5193,23 +5191,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5222,7 +5220,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5269,11 +5267,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5282,11 +5280,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5295,11 +5293,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5308,11 +5306,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5334,11 +5332,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5347,15 +5345,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5364,11 +5362,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5416,7 +5414,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5444,19 +5442,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5464,23 +5462,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5516,7 +5514,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5524,7 +5522,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5585,23 +5583,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5609,23 +5607,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5659,7 +5657,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5687,7 +5685,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5699,7 +5697,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5739,7 +5737,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5747,7 +5745,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5756,7 +5754,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5848,7 +5846,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5871,11 +5869,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5897,14 +5895,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5920,7 +5918,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5958,7 +5956,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5972,11 +5970,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5995,7 +5993,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6010,22 +6008,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6035,22 +6033,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6076,7 +6074,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6093,12 +6091,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6114,11 +6112,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6146,11 +6144,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6165,7 +6163,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6214,24 +6212,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6250,7 +6248,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6261,7 +6259,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6269,21 +6267,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6297,7 +6295,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6311,8 +6309,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6327,7 +6325,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6341,7 +6339,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6361,27 +6359,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6393,19 +6391,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6421,19 +6419,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6441,23 +6439,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6486,21 +6484,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6509,7 +6507,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6542,7 +6540,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6556,15 +6554,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6600,7 +6598,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6624,9 +6622,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6646,7 +6644,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6662,11 +6660,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6674,11 +6672,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6698,48 +6696,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6774,8 +6772,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6785,7 +6783,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6871,11 +6869,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6942,24 +6940,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6967,70 +6965,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7056,19 +7054,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7181,8 +7179,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7198,11 +7196,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7210,28 +7208,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7239,31 +7237,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7287,19 +7285,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7367,13 +7365,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7382,7 +7380,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7566,7 +7564,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7574,7 +7572,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7583,7 +7581,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7591,7 +7589,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7600,7 +7598,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7608,7 +7606,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7622,7 +7620,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7634,7 +7632,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7653,13 +7651,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7667,13 +7665,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7783,7 +7781,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7795,7 +7793,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7832,11 +7830,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-04-29 07:41-0600\n"
+        "POT-Creation-Date: 2025-05-08 12:32-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -97,7 +97,7 @@ msgid   "### This is a YAML representation of the certificate.\n"
         "### Note that the fingerprint is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid   "### This is a YAML representation of the cluster group.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -208,7 +208,7 @@ msgid   "### This is a YAML representation of the instance metadata.\n"
         "###     properties: {}"
 msgstr  ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid   "### This is a YAML representation of the network ACL.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -234,7 +234,7 @@ msgid   "### This is a YAML representation of the network ACL.\n"
         "### Note that only the ingress and egress rules, description and configuration keys can be changed."
 msgstr  ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid   "### This is a YAML representation of the network forward.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -256,7 +256,7 @@ msgid   "### This is a YAML representation of the network forward.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -293,7 +293,7 @@ msgid   "### This is a YAML representation of the network peer.\n"
         "### Note that the name, target_project, target_network and status fields cannot be changed."
 msgstr  ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid   "### This is a YAML representation of the network zone record.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -306,7 +306,7 @@ msgid   "### This is a YAML representation of the network zone record.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid   "### This is a YAML representation of the network zone.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -319,7 +319,7 @@ msgid   "### This is a YAML representation of the network zone.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid   "### This is a YAML representation of the network.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -338,7 +338,7 @@ msgid   "### This is a YAML representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid   "### This is a YAML representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -358,7 +358,7 @@ msgid   "### This is a YAML representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid   "### This is a YAML representation of the project.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -378,7 +378,7 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -408,7 +408,7 @@ msgstr  ""
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid   "(none)"
 msgstr  ""
 
@@ -439,7 +439,7 @@ msgstr  ""
 msgid   "--console only works with a single instance"
 msgstr  ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
@@ -455,7 +455,7 @@ msgstr  ""
 msgid   "--no-profiles cannot be used with --refresh"
 msgstr  ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid   "--project cannot be used with the query command"
 msgstr  ""
 
@@ -479,15 +479,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -515,11 +515,11 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -527,7 +527,7 @@ msgstr  ""
 msgid   "AUTHENTICATION METHOD"
 msgstr  ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid   "Accept certificate"
 msgstr  ""
 
@@ -544,24 +544,24 @@ msgstr  ""
 msgid   "Access the expanded configuration"
 msgstr  ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid   "Acknowledge warning"
 msgstr  ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid   "Action"
 msgstr  ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid   "Action %q isn't supported by this tool"
 msgstr  ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid   "Add a NIC device to the default profile connected to the specified network"
 msgstr  ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
 
@@ -573,23 +573,23 @@ msgstr  ""
 msgid   "Add a group to an identity provider group"
 msgstr  ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid   "Add a network zone record entry"
 msgstr  ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid   "Add a storage pool to be used as the root device in the default profile"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid   "Add backend to a load balancer"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid   "Add backends to a load balancer"
 msgstr  ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid   "Add entries to a network zone record"
 msgstr  ""
 
@@ -597,7 +597,7 @@ msgstr  ""
 msgid   "Add instance devices"
 msgstr  ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid   "Add member to group"
 msgstr  ""
 
@@ -605,11 +605,11 @@ msgstr  ""
 msgid   "Add new aliases"
 msgstr  ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -639,15 +639,15 @@ msgstr  ""
 msgid   "Add permissions to groups"
 msgstr  ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid   "Add ports to a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid   "Add profiles to instances"
 msgstr  ""
 
@@ -655,7 +655,7 @@ msgstr  ""
 msgid   "Add roles to a cluster member"
 msgstr  ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid   "Add rules to an ACL"
 msgstr  ""
 
@@ -669,7 +669,7 @@ msgstr  ""
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -706,7 +706,7 @@ msgstr  ""
 msgid   "All projects"
 msgstr  ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
@@ -724,7 +724,7 @@ msgstr  ""
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
@@ -733,27 +733,27 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid   "Assign sets of groups to cluster members"
 msgstr  ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid   "Assign sets of profiles to instances"
 msgstr  ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid   "Attach network interfaces to instances"
 msgstr  ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid   "Attach network interfaces to profiles"
 msgstr  ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid   "Attach new network interfaces to instances"
 msgstr  ""
 
@@ -788,7 +788,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -807,11 +807,11 @@ msgstr  ""
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid   "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr  ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid   "Available projects:"
 msgstr  ""
 
@@ -842,12 +842,12 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327 lxc/network_load_balancer.go:322 lxc/network_peer.go:309 lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328 lxc/network_load_balancer.go:323 lxc/network_peer.go:309 lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -862,7 +862,7 @@ msgstr  ""
 msgid   "Bad property: %s"
 msgstr  ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid   "Bond:"
 msgstr  ""
 
@@ -875,15 +875,15 @@ msgstr  ""
 msgid   "Brand: %v"
 msgstr  ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid   "Bridge:"
 msgstr  ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -899,7 +899,7 @@ msgstr  ""
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid   "COUNT"
 msgstr  ""
 
@@ -964,7 +964,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -980,7 +980,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -993,7 +993,7 @@ msgstr  ""
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
@@ -1005,7 +1005,7 @@ msgstr  ""
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid   "Cannot set key: %s"
 msgstr  ""
@@ -1029,16 +1029,16 @@ msgstr  ""
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid   "Certificate fingerprint"
 msgstr  ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid   "Chassis"
 msgstr  ""
 
@@ -1047,7 +1047,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1056,68 +1056,68 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid   "Cluster group %s created"
 msgstr  ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid   "Cluster group %s deleted"
 msgstr  ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid   "Cluster group %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid   "Cluster group %s renamed to %s"
 msgstr  ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid   "Cluster member %s added to cluster groups %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid   "Cluster member %s added to group %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid   "Cluster member %s is already in group %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797 lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887 lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381 lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265 lxc/network_forward.go:506 lxc/network_forward.go:658 lxc/network_forward.go:812 lxc/network_forward.go:901 lxc/network_forward.go:987 lxc/network_load_balancer.go:185 lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485 lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775 lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:561 lxc/storage_bucket.go:654 lxc/storage_bucket.go:720 lxc/storage_bucket.go:795 lxc/storage_bucket.go:881 lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046 lxc/storage_bucket.go:1182 lxc/storage_volume.go:399 lxc/storage_volume.go:627 lxc/storage_volume.go:732 lxc/storage_volume.go:1034 lxc/storage_volume.go:1260 lxc/storage_volume.go:1389 lxc/storage_volume.go:1880 lxc/storage_volume.go:1982 lxc/storage_volume.go:2121 lxc/storage_volume.go:2281 lxc/storage_volume.go:2397 lxc/storage_volume.go:2458 lxc/storage_volume.go:2585 lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797 lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888 lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382 lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266 lxc/network_forward.go:507 lxc/network_forward.go:659 lxc/network_forward.go:813 lxc/network_forward.go:902 lxc/network_forward.go:988 lxc/network_load_balancer.go:186 lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486 lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776 lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940 lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:561 lxc/storage_bucket.go:654 lxc/storage_bucket.go:720 lxc/storage_bucket.go:795 lxc/storage_bucket.go:881 lxc/storage_bucket.go:981 lxc/storage_bucket.go:1046 lxc/storage_bucket.go:1182 lxc/storage_volume.go:399 lxc/storage_volume.go:627 lxc/storage_volume.go:732 lxc/storage_volume.go:1034 lxc/storage_volume.go:1260 lxc/storage_volume.go:1389 lxc/storage_volume.go:1880 lxc/storage_volume.go:1982 lxc/storage_volume.go:2121 lxc/storage_volume.go:2281 lxc/storage_volume.go:2397 lxc/storage_volume.go:2458 lxc/storage_volume.go:2585 lxc/storage_volume.go:2676 lxc/storage_volume.go:2845
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid   "Cluster member name (alternative to passing it as an argument)"
 msgstr  ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid   "Cluster member name was provided as both a flag and as an argument"
 msgstr  ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734 lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735 lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid   "Columns"
 msgstr  ""
 
@@ -1144,7 +1144,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
@@ -1152,7 +1152,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322 lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156 lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769 lxc/network_acl.go:716 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610 lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179 lxc/storage_volume.go:1211
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322 lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156 lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770 lxc/network_acl.go:717 lxc/network_forward.go:777 lxc/network_load_balancer.go:740 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611 lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179 lxc/storage_volume.go:1211
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1213,7 +1213,7 @@ msgstr  ""
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid   "Copy profiles"
 msgstr  ""
 
@@ -1229,7 +1229,7 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288 lxc/storage_volume.go:402
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289 lxc/storage_volume.go:402
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1256,21 +1256,21 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid   "Could not find certificate file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
@@ -1285,27 +1285,27 @@ msgstr  ""
 msgid   "Could not parse identity: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid   "Could not read certificate file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid   "Could not read certificate key file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid   "Couldn't find a matching entry"
 msgstr  ""
 
@@ -1313,7 +1313,7 @@ msgstr  ""
 msgid   "Create a TLS identity"
 msgstr  ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid   "Create a cluster group"
 msgstr  ""
 
@@ -1384,15 +1384,15 @@ msgstr  ""
 msgid   "Create new instance file templates"
 msgstr  ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid   "Create new network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid   "Create new network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid   "Create new network load balancers"
 msgstr  ""
 
@@ -1400,23 +1400,23 @@ msgstr  ""
 msgid   "Create new network peering"
 msgstr  ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid   "Create new network zone record"
 msgstr  ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid   "Create new network zones"
 msgstr  ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid   "Create new networks"
 msgstr  ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid   "Create profiles"
 msgstr  ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid   "Create projects"
 msgstr  ""
 
@@ -1433,7 +1433,7 @@ msgstr  ""
 msgid   "Created: %s"
 msgstr  ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
@@ -1443,7 +1443,7 @@ msgstr  ""
 msgid   "Creating %s: %%s"
 msgstr  ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid   "Creating the instance"
 msgstr  ""
 
@@ -1452,11 +1452,11 @@ msgstr  ""
 msgid   "Current number of VFs: %d"
 msgstr  ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509 lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119 lxc/network_acl.go:171 lxc/network_forward.go:158 lxc/network_load_balancer.go:161 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723 lxc/storage_bucket.go:528 lxc/storage_bucket.go:852 lxc/storage_volume.go:1764
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510 lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_forward.go:159 lxc/network_load_balancer.go:162 lxc/network_peer.go:149 lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173 lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723 lxc/storage_bucket.go:528 lxc/storage_bucket.go:852 lxc/storage_volume.go:1764
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1472,7 +1472,7 @@ msgstr  ""
 msgid   "DRM:"
 msgstr  ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid   "Default VLAN ID"
 msgstr  ""
 
@@ -1484,11 +1484,11 @@ msgstr  ""
 msgid   "Delete a background operation (will attempt to cancel)"
 msgstr  ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid   "Delete a cluster group"
 msgstr  ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid   "Delete all warnings"
 msgstr  ""
 
@@ -1528,15 +1528,15 @@ msgstr  ""
 msgid   "Delete key from a storage bucket"
 msgstr  ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid   "Delete network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid   "Delete network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid   "Delete network load balancers"
 msgstr  ""
 
@@ -1544,23 +1544,23 @@ msgstr  ""
 msgid   "Delete network peerings"
 msgstr  ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid   "Delete network zone record"
 msgstr  ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid   "Delete network zones"
 msgstr  ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid   "Delete networks"
 msgstr  ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid   "Delete profiles"
 msgstr  ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid   "Delete projects"
 msgstr  ""
 
@@ -1576,11 +1576,11 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783 lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062 lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175 lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445 lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673 lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172 lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483 lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702 lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348 lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578 lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135 lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695 lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473 lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884 lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222 lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450 lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192 lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382 lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53 lxc/network_forward.go:34 lxc/network_forward.go:91 lxc/network_forward.go:180 lxc/network_forward.go:257 lxc/network_forward.go:413 lxc/network_forward.go:498 lxc/network_forward.go:608 lxc/network_forward.go:655 lxc/network_forward.go:809 lxc/network_forward.go:883 lxc/network_forward.go:898 lxc/network_forward.go:983 lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477 lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548 lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286 lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644 lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030 lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:461 lxc/storage_bucket.go:555 lxc/storage_bucket.go:649 lxc/storage_bucket.go:718 lxc/storage_bucket.go:752 lxc/storage_bucket.go:793 lxc/storage_bucket.go:872 lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042 lxc/storage_bucket.go:1177 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:314 lxc/storage_volume.go:395 lxc/storage_volume.go:620 lxc/storage_volume.go:729 lxc/storage_volume.go:816 lxc/storage_volume.go:921 lxc/storage_volume.go:1025 lxc/storage_volume.go:1246 lxc/storage_volume.go:1377 lxc/storage_volume.go:1539 lxc/storage_volume.go:1623 lxc/storage_volume.go:1876 lxc/storage_volume.go:1979 lxc/storage_volume.go:2106 lxc/storage_volume.go:2264 lxc/storage_volume.go:2385 lxc/storage_volume.go:2447 lxc/storage_volume.go:2583 lxc/storage_volume.go:2667 lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783 lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062 lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124 lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405 lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682 lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093 lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342 lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176 lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446 lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674 lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:25 lxc/config_device.go:172 lxc/config_device.go:303 lxc/config_device.go:400 lxc/config_device.go:483 lxc/config_device.go:579 lxc/config_device.go:695 lxc/config_device.go:702 lxc/config_device.go:835 lxc/config_device.go:926 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:234 lxc/config_trust.go:348 lxc/config_trust.go:430 lxc/config_trust.go:532 lxc/config_trust.go:578 lxc/config_trust.go:649 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:88 lxc/file.go:135 lxc/file.go:323 lxc/file.go:376 lxc/file.go:462 lxc/file.go:695 lxc/file.go:1222 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137 lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474 lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885 lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223 lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451 lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193 lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383 lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611 lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864 lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53 lxc/network_forward.go:35 lxc/network_forward.go:92 lxc/network_forward.go:181 lxc/network_forward.go:258 lxc/network_forward.go:414 lxc/network_forward.go:499 lxc/network_forward.go:609 lxc/network_forward.go:656 lxc/network_forward.go:810 lxc/network_forward.go:884 lxc/network_forward.go:899 lxc/network_forward.go:984 lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96 lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260 lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478 lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846 lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937 lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050 lxc/network_load_balancer.go:1123 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548 lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30 lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247 lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191 lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429 lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287 lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645 lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031 lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98 lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479 lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796 lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750 lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019 lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:461 lxc/storage_bucket.go:555 lxc/storage_bucket.go:649 lxc/storage_bucket.go:718 lxc/storage_bucket.go:752 lxc/storage_bucket.go:793 lxc/storage_bucket.go:872 lxc/storage_bucket.go:978 lxc/storage_bucket.go:1042 lxc/storage_bucket.go:1177 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:314 lxc/storage_volume.go:395 lxc/storage_volume.go:620 lxc/storage_volume.go:729 lxc/storage_volume.go:816 lxc/storage_volume.go:921 lxc/storage_volume.go:1025 lxc/storage_volume.go:1246 lxc/storage_volume.go:1377 lxc/storage_volume.go:1539 lxc/storage_volume.go:1623 lxc/storage_volume.go:1876 lxc/storage_volume.go:1979 lxc/storage_volume.go:2106 lxc/storage_volume.go:2264 lxc/storage_volume.go:2385 lxc/storage_volume.go:2447 lxc/storage_volume.go:2583 lxc/storage_volume.go:2667 lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31 lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid   "Description"
 msgstr  ""
 
@@ -1593,11 +1593,11 @@ msgstr  ""
 msgid   "Destination cluster member name"
 msgstr  ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid   "Detach network interfaces from instances"
 msgstr  ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
@@ -1633,10 +1633,6 @@ msgstr  ""
 msgid   "Device doesn't exist"
 msgstr  ""
 
-#: lxc/config_device.go:795
-msgid   "Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"
-msgstr  ""
-
 #: lxc/config_device.go:658
 msgid   "Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"
 msgstr  ""
@@ -1650,7 +1646,7 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
@@ -1703,19 +1699,19 @@ msgstr  ""
 msgid   "Display instances from all projects"
 msgstr  ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid   "Display network ACLs from all projects"
 msgstr  ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid   "Display network zones from all projects"
 msgstr  ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid   "Display networks from all projects"
 msgstr  ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid   "Display profiles from all projects"
 msgstr  ""
 
@@ -1723,7 +1719,7 @@ msgstr  ""
 msgid   "Display storage pool buckets from all projects"
 msgstr  ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
@@ -1731,7 +1727,7 @@ msgstr  ""
 msgid   "Don't show progress information"
 msgstr  ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid   "Down delay"
 msgstr  ""
 
@@ -1740,7 +1736,7 @@ msgstr  ""
 msgid   "Driver: %v (%v)"
 msgstr  ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid   "ENTRIES"
 msgstr  ""
 
@@ -1748,7 +1744,7 @@ msgstr  ""
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid   "EXPIRES AT"
 msgstr  ""
 
@@ -1760,7 +1756,7 @@ msgstr  ""
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid   "Edit a cluster group"
 msgstr  ""
 
@@ -1768,7 +1764,7 @@ msgstr  ""
 msgid   "Edit an identity as YAML"
 msgstr  ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
@@ -1804,19 +1800,19 @@ msgstr  ""
 msgid   "Edit instance or server configurations as YAML"
 msgstr  ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid   "Edit network ACL configurations as YAML"
 msgstr  ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid   "Edit network forward configurations as YAML"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid   "Edit network load balancer configurations as YAML"
 msgstr  ""
 
@@ -1824,19 +1820,19 @@ msgstr  ""
 msgid   "Edit network peer configurations as YAML"
 msgstr  ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid   "Edit network zone configurations as YAML"
 msgstr  ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
@@ -1860,16 +1856,16 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776 lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777 lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid   "Enable clustering on a single non-clustered LXD server"
 msgstr  ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid   "Enable clustering on a single non-clustered LXD server\n"
         "\n"
         "  This command turns a non-clustered LXD server into the first member of a new\n"
@@ -1881,7 +1877,7 @@ msgid   "Enable clustering on a single non-clustered LXD server\n"
         "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr  ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid   "Entry TTL"
 msgstr  ""
 
@@ -1908,7 +1904,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356 lxc/network_acl.go:542 lxc/network_forward.go:581 lxc/network_load_balancer.go:560 lxc/network_peer.go:523 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097 lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622 lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357 lxc/network_acl.go:543 lxc/network_forward.go:582 lxc/network_load_balancer.go:561 lxc/network_peer.go:523 lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098 lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622 lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1918,7 +1914,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536 lxc/network_forward.go:575 lxc/network_load_balancer.go:554 lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806 lxc/storage_bucket.go:616 lxc/storage_volume.go:2191 lxc/storage_volume.go:2229
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537 lxc/network_forward.go:576 lxc/network_load_balancer.go:555 lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160 lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806 lxc/storage_bucket.go:616 lxc/storage_volume.go:2191 lxc/storage_volume.go:2229
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1928,11 +1924,11 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid   "Evacuate cluster member\n"
         "\n"
         "Evacuation actions:\n"
@@ -1941,7 +1937,7 @@ msgid   "Evacuate cluster member\n"
         " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr  ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
@@ -2016,7 +2012,7 @@ msgstr  ""
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid   "FAILURE DOMAIN"
 msgstr  ""
 
@@ -2028,7 +2024,7 @@ msgstr  ""
 msgid   "FINGERPRINT"
 msgstr  ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid   "FIRST SEEN"
 msgstr  ""
 
@@ -2122,11 +2118,11 @@ msgstr  ""
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid   "Failed to add remote"
 msgstr  ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
@@ -2136,7 +2132,7 @@ msgstr  ""
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
@@ -2146,7 +2142,7 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid   "Failed to decode trust token: %w"
 msgstr  ""
@@ -2156,7 +2152,7 @@ msgstr  ""
 msgid   "Failed to find image %q on remote %q"
 msgstr  ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
@@ -2181,7 +2177,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
@@ -2190,7 +2186,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126 lxc/operation.go:137
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127 lxc/operation.go:137
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -2199,11 +2195,11 @@ msgstr  ""
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid   "Force a particular instance evacuation action. One of stop, migrate or live-migrate"
 msgstr  ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid   "Force a particular instance restore action. Use \"skip\" to restore only the cluster member status without starting local instances or migrating back evacuated instances"
 msgstr  ""
 
@@ -2211,7 +2207,7 @@ msgstr  ""
 msgid   "Force creating files or directories"
 msgstr  ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
@@ -2219,11 +2215,11 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid   "Force restoration without user confirmation"
 msgstr  ""
 
@@ -2239,7 +2235,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -2258,7 +2254,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906 lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447 lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021 lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59 lxc/network_forward.go:94 lxc/network_load_balancer.go:98 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480 lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:462 lxc/storage_bucket.go:794 lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906 lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448 lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022 lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59 lxc/network_forward.go:95 lxc/network_load_balancer.go:99 lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789 lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481 lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657 lxc/storage_bucket.go:462 lxc/storage_bucket.go:794 lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2270,7 +2266,7 @@ msgstr  ""
 msgid   "Format (man|md|rest|yaml)"
 msgstr  ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid   "Forward delay"
 msgstr  ""
 
@@ -2294,7 +2290,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2314,7 +2310,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2322,7 +2318,7 @@ msgstr  ""
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
@@ -2330,23 +2326,23 @@ msgstr  ""
 msgid   "Get image properties"
 msgstr  ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid   "Get runtime information on networks"
 msgstr  ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid   "Get the key as a cluster property"
 msgstr  ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid   "Get the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid   "Get the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid   "Get the key as a network load balancer property"
 msgstr  ""
 
@@ -2354,23 +2350,23 @@ msgstr  ""
 msgid   "Get the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid   "Get the key as a network property"
 msgstr  ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid   "Get the key as a network zone property"
 msgstr  ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid   "Get the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid   "Get the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid   "Get the key as a project property"
 msgstr  ""
 
@@ -2390,7 +2386,7 @@ msgstr  ""
 msgid   "Get the key as an instance property"
 msgstr  ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid   "Get values for cluster member configuration keys"
 msgstr  ""
 
@@ -2402,19 +2398,19 @@ msgstr  ""
 msgid   "Get values for instance or server configuration keys"
 msgstr  ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid   "Get values for network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid   "Get values for network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid   "Get values for network load balancer configuration keys"
 msgstr  ""
 
@@ -2422,19 +2418,19 @@ msgstr  ""
 msgid   "Get values for network peer configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid   "Get values for network zone configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
@@ -2478,7 +2474,7 @@ msgstr  ""
 msgid   "HARDWARE ADDRESS"
 msgstr  ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid   "HOSTNAME"
 msgstr  ""
 
@@ -2510,7 +2506,7 @@ msgstr  ""
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid   "ID"
 msgstr  ""
 
@@ -2528,11 +2524,11 @@ msgstr  ""
 msgid   "IDENTIFIER"
 msgstr  ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid   "IMAGES"
 msgstr  ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid   "IP ADDRESS"
 msgstr  ""
 
@@ -2540,15 +2536,15 @@ msgstr  ""
 msgid   "IP addresses"
 msgstr  ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid   "IP addresses:"
 msgstr  ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid   "IPV6"
 msgstr  ""
 
@@ -2686,7 +2682,7 @@ msgstr  ""
 msgid   "Infiniband:"
 msgstr  ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid   "Input data"
 msgstr  ""
 
@@ -2711,7 +2707,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -2729,7 +2725,7 @@ msgstr  ""
 msgid   "Instance published with fingerprint: %s"
 msgstr  ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid   "Instance snapshots cannot be rebuilt: %s"
 msgstr  ""
@@ -2738,7 +2734,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2772,7 +2768,7 @@ msgstr  ""
 msgid   "Invalid export version %q: %w"
 msgstr  ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid   "Invalid format: %s"
 msgstr  ""
@@ -2828,7 +2824,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -2861,7 +2857,7 @@ msgstr  ""
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid   "LAST SEEN"
 msgstr  ""
 
@@ -2869,15 +2865,15 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid   "LIMIT"
 msgstr  ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164 lxc/network_load_balancer.go:166 lxc/operation.go:178 lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165 lxc/network_load_balancer.go:167 lxc/operation.go:178 lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2889,7 +2885,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128 lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129 lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -2907,12 +2903,12 @@ msgstr  ""
 msgid   "Last used: never"
 msgstr  ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid   "Launching %s"
 msgstr  ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid   "Launching the instance"
 msgstr  ""
 
@@ -2926,7 +2922,7 @@ msgstr  ""
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid   "List DHCP leases"
 msgstr  ""
 
@@ -2938,35 +2934,35 @@ msgstr  ""
 msgid   "List all active certificate add tokens"
 msgstr  ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid   "List all the cluster groups"
 msgstr  ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid   "List all the cluster members"
 msgstr  ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid   "List all warnings"
 msgstr  ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid   "List available network ACL"
 msgstr  ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid   "List available network ACLS"
 msgstr  ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid   "List available network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid   "List available network load balancers"
 msgstr  ""
 
@@ -2974,19 +2970,19 @@ msgstr  ""
 msgid   "List available network peers"
 msgstr  ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid   "List available network zone"
 msgstr  ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid   "List available network zone records"
 msgstr  ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid   "List available network zoneS"
 msgstr  ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid   "List available networks"
 msgstr  ""
 
@@ -3154,11 +3150,11 @@ msgstr  ""
 msgid   "List permissions"
 msgstr  ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid   "List profiles"
 msgstr  ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid   "List profiles\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3173,7 +3169,7 @@ msgid   "List profiles\n"
         "u - Used By"
 msgstr  ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid   "List projects"
 msgstr  ""
 
@@ -3208,7 +3204,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3216,11 +3212,11 @@ msgstr  ""
 msgid   "List trusted clients"
 msgstr  ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid   "List warnings"
 msgstr  ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid   "List warnings\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3251,7 +3247,7 @@ msgstr  ""
 msgid   "Location: %s"
 msgstr  ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
@@ -3259,15 +3255,15 @@ msgstr  ""
 msgid   "Log:"
 msgstr  ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid   "Lower device"
 msgstr  ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid   "Lower devices"
 msgstr  ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid   "MAC ADDRESS"
 msgstr  ""
 
@@ -3275,7 +3271,7 @@ msgstr  ""
 msgid   "MAC address"
 msgstr  ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid   "MAC address: %s"
 msgstr  ""
@@ -3285,11 +3281,11 @@ msgstr  ""
 msgid   "MAD: %s (%s)"
 msgstr  ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid   "MANAGED"
 msgstr  ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid   "MEMBERS"
 msgstr  ""
 
@@ -3302,15 +3298,15 @@ msgstr  ""
 msgid   "MEMORY USAGE%"
 msgstr  ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid   "MESSAGE"
 msgstr  ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid   "MII Frequency"
 msgstr  ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid   "MII state"
 msgstr  ""
 
@@ -3318,7 +3314,7 @@ msgstr  ""
 msgid   "MTU"
 msgstr  ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid   "MTU: %d"
 msgstr  ""
@@ -3335,15 +3331,15 @@ msgstr  ""
 msgid   "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, got "
 msgstr  ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid   "Manage and attach instances to networks"
 msgstr  ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid   "Manage cluster groups"
 msgstr  ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid   "Manage cluster members"
 msgstr  ""
 
@@ -3421,31 +3417,31 @@ msgstr  ""
 msgid   "Manage instance metadata files"
 msgstr  ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid   "Manage network ACL rules"
 msgstr  ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid   "Manage network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid   "Manage network forward ports"
 msgstr  ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid   "Manage network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid   "Manage network load balancer backends"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid   "Manage network load balancer ports"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid   "Manage network load balancers"
 msgstr  ""
 
@@ -3453,15 +3449,15 @@ msgstr  ""
 msgid   "Manage network peerings"
 msgstr  ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid   "Manage network zone record entries"
 msgstr  ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid   "Manage network zone records"
 msgstr  ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid   "Manage network zones"
 msgstr  ""
 
@@ -3469,11 +3465,11 @@ msgstr  ""
 msgid   "Manage permissions"
 msgstr  ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid   "Manage profiles"
 msgstr  ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid   "Manage projects"
 msgstr  ""
 
@@ -3507,7 +3503,7 @@ msgid   "Manage storage volumes\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
@@ -3519,7 +3515,7 @@ msgstr  ""
 msgid   "Manage user authorization"
 msgstr  ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid   "Manage warnings"
 msgstr  ""
 
@@ -3542,17 +3538,17 @@ msgstr  ""
 msgid   "Member %q does not have role %q"
 msgstr  ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid   "Member %s join token:"
 msgstr  ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
@@ -3595,11 +3591,11 @@ msgstr  ""
 msgid   "Missing certificate fingerprint"
 msgstr  ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354 lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355 lxc/cluster_group.go:707
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134 lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82 lxc/cluster_role.go:150
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135 lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82 lxc/cluster_role.go:150
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -3619,7 +3615,7 @@ msgstr  ""
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
-#: lxc/config_metadata.go:112 lxc/config_metadata.go:221 lxc/config_template.go:100 lxc/config_template.go:155 lxc/config_template.go:209 lxc/config_template.go:306 lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237 lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_metadata.go:112 lxc/config_metadata.go:221 lxc/config_template.go:100 lxc/config_template.go:155 lxc/config_template.go:209 lxc/config_template.go:306 lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238 lxc/profile.go:919 lxc/rebuild.go:73
 msgid   "Missing instance name"
 msgstr  ""
 
@@ -3627,7 +3623,7 @@ msgstr  ""
 msgid   "Missing key name"
 msgstr  ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458 lxc/network_forward.go:543 lxc/network_forward.go:718 lxc/network_forward.go:849 lxc/network_forward.go:946 lxc/network_forward.go:1032 lxc/network_load_balancer.go:222 lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522 lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812 lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459 lxc/network_forward.go:544 lxc/network_forward.go:719 lxc/network_forward.go:850 lxc/network_forward.go:947 lxc/network_forward.go:1033 lxc/network_load_balancer.go:223 lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523 lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813 lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977 lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid   "Missing listen address"
 msgstr  ""
 
@@ -3635,19 +3631,19 @@ msgstr  ""
 msgid   "Missing name"
 msgstr  ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345 lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668 lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972 lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346 lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669 lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973 lxc/network_acl.go:1057
 msgid   "Missing network ACL name"
 msgstr  ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509 lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918 lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320 lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216 lxc/network_forward.go:293 lxc/network_forward.go:454 lxc/network_forward.go:539 lxc/network_forward.go:714 lxc/network_forward.go:845 lxc/network_forward.go:942 lxc/network_forward.go:1028 lxc/network_load_balancer.go:132 lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287 lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518 lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159 lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266 lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645 lxc/network_peer.go:766
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510 lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919 lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321 lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217 lxc/network_forward.go:294 lxc/network_forward.go:455 lxc/network_forward.go:540 lxc/network_forward.go:715 lxc/network_forward.go:846 lxc/network_forward.go:943 lxc/network_forward.go:1029 lxc/network_load_balancer.go:133 lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288 lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519 lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809 lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973 lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160 lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266 lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645 lxc/network_peer.go:766
 msgid   "Missing network name"
 msgstr  ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354 lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702 lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041 lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477 lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355 lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703 lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042 lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478 lxc/network_zone.go:1535
 msgid   "Missing network zone name"
 msgstr  ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid   "Missing network zone record name"
 msgstr  ""
 
@@ -3659,15 +3655,15 @@ msgstr  ""
 msgid   "Missing pool name"
 msgstr  ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002 lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003 lxc/profile.go:1071 lxc/profile.go:1152
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324 lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827 lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325 lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828 lxc/project.go:957
 msgid   "Missing project name"
 msgstr  ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid   "Missing source profile name"
 msgstr  ""
 
@@ -3687,7 +3683,7 @@ msgstr  ""
 msgid   "Missing target network"
 msgstr  ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid   "Mode"
 msgstr  ""
 
@@ -3711,7 +3707,7 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883 lxc/storage_volume.go:987
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883 lxc/storage_volume.go:987
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -3760,11 +3756,11 @@ msgstr  ""
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
@@ -3776,7 +3772,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192 lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407 lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114 lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527 lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193 lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407 lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115 lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574 lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527 lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid   "NAME"
 msgstr  ""
 
@@ -3788,11 +3784,11 @@ msgstr  ""
 msgid   "NETWORK"
 msgstr  ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid   "NETWORK ZONES"
 msgstr  ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid   "NETWORKS"
 msgstr  ""
 
@@ -3804,7 +3800,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551 lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552 lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid   "NO"
 msgstr  ""
 
@@ -3830,11 +3826,11 @@ msgstr  ""
 msgid   "Name"
 msgstr  ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -3844,67 +3840,67 @@ msgstr  ""
 msgid   "Name: %v"
 msgstr  ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid   "Network %s created"
 msgstr  ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid   "Network %s deleted"
 msgstr  ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid   "Network %s pending on member %s"
 msgstr  ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid   "Network %s renamed to %s"
 msgstr  ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid   "Network ACL %s created"
 msgstr  ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid   "Network ACL %s deleted"
 msgstr  ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid   "Network ACL %s renamed to %s"
 msgstr  ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid   "Network Zone %s created"
 msgstr  ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid   "Network Zone %s deleted"
 msgstr  ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid   "Network forward %s created"
 msgstr  ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid   "Network forward %s deleted"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid   "Network load balancer %s created"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid   "Network load balancer %s deleted"
 msgstr  ""
@@ -3933,20 +3929,20 @@ msgstr  ""
 msgid   "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr  ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid   "Network type"
 msgstr  ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid   "Network usage:"
 msgstr  ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid   "Network zone record %s created"
 msgstr  ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid   "Network zone record %s deleted"
 msgstr  ""
@@ -3968,12 +3964,12 @@ msgstr  ""
 msgid   "No certificate add token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid   "No device found for this network"
 msgstr  ""
 
@@ -3981,19 +3977,19 @@ msgstr  ""
 msgid   "No device found for this storage volume"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid   "No matching backend found"
 msgstr  ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid   "No matching port(s) found"
 msgstr  ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid   "No matching rule(s) found"
 msgstr  ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid   "No need to specify a warning UUID when using --all"
 msgstr  ""
 
@@ -4019,7 +4015,7 @@ msgstr  ""
 msgid   "Not a snapshot name"
 msgstr  ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid   "OVN:"
 msgstr  ""
 
@@ -4035,7 +4031,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -4047,7 +4043,7 @@ msgstr  ""
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
@@ -4058,6 +4054,10 @@ msgstr  ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid   "Optimized Storage"
+msgstr  ""
+
+#: lxc/config_device.go:795
+msgid   "Override device or modify profile instead"
 msgstr  ""
 
 #: lxc/main.go:97
@@ -4090,7 +4090,7 @@ msgstr  ""
 msgid   "POOL"
 msgstr  ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid   "PORTS"
 msgstr  ""
 
@@ -4098,27 +4098,27 @@ msgstr  ""
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176 lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536 lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177 lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536 lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid   "Packets sent"
 msgstr  ""
 
@@ -4139,7 +4139,7 @@ msgstr  ""
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
@@ -4147,11 +4147,11 @@ msgstr  ""
 msgid   "Please provide client name: "
 msgstr  ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid   "Please type 'y', 'n' or the fingerprint: "
 msgstr  ""
 
@@ -4168,7 +4168,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398 lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770 lxc/network_acl.go:717 lxc/network_forward.go:777 lxc/network_load_balancer.go:740 lxc/network_peer.go:700 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611 lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180 lxc/storage_volume.go:1212
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866 lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398 lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771 lxc/network_acl.go:718 lxc/network_forward.go:778 lxc/network_load_balancer.go:741 lxc/network_peer.go:700 lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612 lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180 lxc/storage_volume.go:1212
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4180,7 +4180,7 @@ msgstr  ""
 msgid   "Print help"
 msgstr  ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid   "Print the raw response"
 msgstr  ""
 
@@ -4203,32 +4203,32 @@ msgstr  ""
 msgid   "Product: %v (%v)"
 msgstr  ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid   "Profile %s renamed to %s"
 msgstr  ""
@@ -4245,7 +4245,7 @@ msgstr  ""
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid   "Profiles %s applied to %s"
 msgstr  ""
@@ -4258,22 +4258,22 @@ msgstr  ""
 msgid   "Profiles: "
 msgstr  ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid   "Project %s created"
 msgstr  ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid   "Project to use for the remote"
 msgstr  ""
 
@@ -4355,7 +4355,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Removes the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid   "Public image server"
 msgstr  ""
 
@@ -4391,7 +4391,7 @@ msgstr  ""
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid   "Query path must start with /"
 msgstr  ""
 
@@ -4399,7 +4399,7 @@ msgstr  ""
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid   "RESOURCE"
 msgstr  ""
 
@@ -4407,7 +4407,7 @@ msgstr  ""
 msgid   "ROLE"
 msgstr  ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid   "ROLES"
 msgstr  ""
 
@@ -4446,44 +4446,44 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048 lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049 lxc/remote.go:1097
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid   "Remote address must not be empty"
 msgstr  ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid   "Remote trust token"
 msgstr  ""
 
@@ -4497,7 +4497,7 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
@@ -4505,11 +4505,11 @@ msgstr  ""
 msgid   "Remove a group from an identity"
 msgstr  ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid   "Remove a network zone record entry"
 msgstr  ""
 
@@ -4517,23 +4517,23 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid   "Remove all ports that match"
 msgstr  ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid   "Remove all rules that match"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid   "Remove backend from a load balancer"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid   "Remove backends from a load balancer"
 msgstr  ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
@@ -4545,7 +4545,7 @@ msgstr  ""
 msgid   "Remove instance devices"
 msgstr  ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid   "Remove member from group"
 msgstr  ""
 
@@ -4553,19 +4553,19 @@ msgstr  ""
 msgid   "Remove permissions from groups"
 msgstr  ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid   "Remove ports from a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4573,7 +4573,7 @@ msgstr  ""
 msgid   "Remove roles from a cluster member"
 msgstr  ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid   "Remove rules from an ACL"
 msgstr  ""
 
@@ -4581,11 +4581,11 @@ msgstr  ""
 msgid   "Remove trusted client"
 msgstr  ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid   "Rename a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid   "Rename a cluster member"
 msgstr  ""
 
@@ -4605,23 +4605,23 @@ msgstr  ""
 msgid   "Rename instances and snapshots"
 msgstr  ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid   "Rename network ACLs"
 msgstr  ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid   "Rename networks"
 msgstr  ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -4643,7 +4643,7 @@ msgstr  ""
 msgid   "Render: %s (%s)"
 msgstr  ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
@@ -4669,7 +4669,7 @@ msgid   "Restart instances\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid   "Restore cluster member"
 msgstr  ""
 
@@ -4687,7 +4687,7 @@ msgstr  ""
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
@@ -4700,7 +4700,7 @@ msgstr  ""
 msgid   "Retrieve the container's console log"
 msgstr  ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -4709,7 +4709,7 @@ msgstr  ""
 msgid   "Revoke certificate add token"
 msgstr  ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
@@ -4729,7 +4729,7 @@ msgstr  ""
 msgid   "Run against all projects"
 msgstr  ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid   "SEVERITY"
 msgstr  ""
 
@@ -4759,19 +4759,19 @@ msgstr  ""
 msgid   "SSH client disconnected %q"
 msgstr  ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121 lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122 lxc/network_peer.go:151 lxc/storage.go:725
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid   "STATIC"
 msgstr  ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
@@ -4779,11 +4779,11 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid   "STP"
 msgstr  ""
 
@@ -4796,23 +4796,23 @@ msgstr  ""
 msgid   "Secret key: %s"
 msgstr  ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid   "Send a raw query to LXD"
 msgstr  ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
@@ -4825,7 +4825,7 @@ msgstr  ""
 msgid   "Set UEFI variables for instance"
 msgstr  ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
@@ -4866,44 +4866,44 @@ msgid   "Set instance or server configuration keys\n"
         "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr  ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid   "Set network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid   "Set network ACL configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr  ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid   "Set network configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid   "Set network configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid   "Set network forward keys"
 msgstr  ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid   "Set network forward keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid   "Set network load balancer keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid   "Set network load balancer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4921,37 +4921,37 @@ msgid   "Set network peer keys\n"
         "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr  ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid   "Set network zone configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid   "Set network zone configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr  ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4991,7 +4991,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -5019,19 +5019,19 @@ msgstr  ""
 msgid   "Set the file's uid on push"
 msgstr  ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid   "Set the key as a cluster property"
 msgstr  ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid   "Set the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid   "Set the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid   "Set the key as a network load balancer property"
 msgstr  ""
 
@@ -5039,23 +5039,23 @@ msgstr  ""
 msgid   "Set the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid   "Set the key as a network property"
 msgstr  ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid   "Set the key as a network zone property"
 msgstr  ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid   "Set the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid   "Set the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid   "Set the key as a project property"
 msgstr  ""
 
@@ -5091,7 +5091,7 @@ msgstr  ""
 msgid   "Show an identity provider group"
 msgstr  ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid   "Show cluster group configurations"
 msgstr  ""
 
@@ -5099,7 +5099,7 @@ msgstr  ""
 msgid   "Show content of instance file templates"
 msgstr  ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid   "Show details of a cluster member"
 msgstr  ""
 
@@ -5156,23 +5156,23 @@ msgstr  ""
 msgid   "Show local and remote versions"
 msgstr  ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid   "Show network ACL configurations"
 msgstr  ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid   "Show network ACL log"
 msgstr  ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid   "Show network configurations"
 msgstr  ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid   "Show network forward configurations"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid   "Show network load balancer configurations"
 msgstr  ""
 
@@ -5180,23 +5180,23 @@ msgstr  ""
 msgid   "Show network peer configurations"
 msgstr  ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid   "Show network zone configurations"
 msgstr  ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid   "Show network zone record configuration"
 msgstr  ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid   "Show network zone record configurations"
 msgstr  ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid   "Show project options"
 msgstr  ""
 
@@ -5228,7 +5228,7 @@ msgid   "Show the current identity\n"
         "that are granted via identity provider group mappings. \n"
 msgstr  ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -5256,7 +5256,7 @@ msgstr  ""
 msgid   "Show trust configurations"
 msgstr  ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid   "Show useful information about a cluster member"
 msgstr  ""
 
@@ -5268,7 +5268,7 @@ msgstr  ""
 msgid   "Show useful information about storage pools"
 msgstr  ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid   "Show warning"
 msgstr  ""
 
@@ -5308,7 +5308,7 @@ msgstr  ""
 msgid   "Source:"
 msgstr  ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid   "Specify a warning UUID or use --all"
 msgstr  ""
 
@@ -5316,7 +5316,7 @@ msgstr  ""
 msgid   "Start instances"
 msgstr  ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid   "Starting %s"
 msgstr  ""
@@ -5325,7 +5325,7 @@ msgstr  ""
 msgid   "State"
 msgstr  ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid   "State: %s"
 msgstr  ""
@@ -5417,7 +5417,7 @@ msgstr  ""
 msgid   "Store the instance state"
 msgstr  ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid   "Successfully updated cluster certificates for remote %s"
 msgstr  ""
@@ -5440,11 +5440,11 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5466,11 +5466,11 @@ msgstr  ""
 msgid   "TLS identity %q created with fingerprint %q"
 msgstr  ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115 lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116 lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid   "TYPE"
 msgstr  ""
 
@@ -5486,7 +5486,7 @@ msgstr  ""
 msgid   "Target path must be a directory"
 msgstr  ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid   "The --accept-certificate flag is not supported when adding a remote using a trust token"
 msgstr  ""
 
@@ -5522,7 +5522,7 @@ msgstr  ""
 msgid   "The device already exists"
 msgstr  ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid   "The direction argument must be one of: ingress, egress"
 msgstr  ""
 
@@ -5534,11 +5534,11 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid   "The key %q does not exist on cluster member %q"
 msgstr  ""
@@ -5557,7 +5557,7 @@ msgstr  ""
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid   "The property %q does not exist on the cluster member %q: %v"
 msgstr  ""
@@ -5572,22 +5572,22 @@ msgstr  ""
 msgid   "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid   "The property %q does not exist on the load balancer %q: %v"
 msgstr  ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid   "The property %q does not exist on the network %q: %v"
 msgstr  ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid   "The property %q does not exist on the network ACL %q: %v"
 msgstr  ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid   "The property %q does not exist on the network forward %q: %v"
 msgstr  ""
@@ -5597,22 +5597,22 @@ msgstr  ""
 msgid   "The property %q does not exist on the network peer %q: %v"
 msgstr  ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid   "The property %q does not exist on the network zone %q: %v"
 msgstr  ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid   "The property %q does not exist on the network zone record %q: %v"
 msgstr  ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid   "The property %q does not exist on the project %q: %v"
 msgstr  ""
@@ -5637,7 +5637,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid   "The provided fingerprint does not match the server certificate fingerprint"
 msgstr  ""
 
@@ -5653,11 +5653,11 @@ msgstr  ""
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897 lxc/storage_volume.go:1001
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897 lxc/storage_volume.go:1001
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
@@ -5673,11 +5673,11 @@ msgstr  ""
 msgid   "There is no config key to set on an instance snapshot."
 msgstr  ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid   "This LXD server is already clustered"
 msgstr  ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
@@ -5701,11 +5701,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid   "To attach a network to an instance, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -5718,7 +5718,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -5767,24 +5767,24 @@ msgstr  ""
 msgid   "Transferring instance: %s"
 msgstr  ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid   "Transmit policy"
 msgstr  ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid   "Trust token cannot be used for public remotes"
 msgstr  ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid   "Trust token cannot be used with OIDC authentication"
 msgstr  ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid   "Trust token for %s: "
 msgstr  ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
@@ -5801,7 +5801,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940 lxc/storage_volume.go:1484
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941 lxc/storage_volume.go:1484
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5811,7 +5811,7 @@ msgstr  ""
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid   "UNLIMITED"
 msgstr  ""
 
@@ -5819,19 +5819,19 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:724 lxc/storage_volume.go:1766
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24 lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582 lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid   "USED BY"
 msgstr  ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid   "UUID"
 msgstr  ""
 
@@ -5845,7 +5845,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid   "Unavailable remote server"
 msgstr  ""
 
@@ -5859,7 +5859,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782 lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783 lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5874,7 +5874,7 @@ msgstr  ""
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid   "Unknown key: %s"
 msgstr  ""
@@ -5888,7 +5888,7 @@ msgstr  ""
 msgid   "Unset UEFI variables for instance"
 msgstr  ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
@@ -5908,27 +5908,27 @@ msgstr  ""
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid   "Unset network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid   "Unset network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid   "Unset network forward keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid   "Unset network load balancer configuration keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid   "Unset network load balancer keys"
 msgstr  ""
 
@@ -5940,19 +5940,19 @@ msgstr  ""
 msgid   "Unset network peer keys"
 msgstr  ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid   "Unset network zone configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid   "Unset project configuration keys"
 msgstr  ""
 
@@ -5968,19 +5968,19 @@ msgstr  ""
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid   "Unset the key as a cluster property"
 msgstr  ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid   "Unset the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid   "Unset the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid   "Unset the key as a network load balancer property"
 msgstr  ""
 
@@ -5988,23 +5988,23 @@ msgstr  ""
 msgid   "Unset the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid   "Unset the key as a network property"
 msgstr  ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid   "Unset the key as a network zone property"
 msgstr  ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid   "Unset the key as a network zone record property"
 msgstr  ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid   "Unset the key as a project property"
 msgstr  ""
 
@@ -6033,19 +6033,19 @@ msgstr  ""
 msgid   "Unsupported instance type: %s"
 msgstr  ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid   "Up delay"
 msgstr  ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid   "Update cluster certificate"
 msgstr  ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
@@ -6054,7 +6054,7 @@ msgstr  ""
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid   "Upper devices"
 msgstr  ""
 
@@ -6084,7 +6084,7 @@ msgstr  ""
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -6097,15 +6097,15 @@ msgstr  ""
 msgid   "VFs: %d"
 msgstr  ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid   "VLAN ID"
 msgstr  ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid   "VLAN filtering"
 msgstr  ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid   "VLAN:"
 msgstr  ""
 
@@ -6141,7 +6141,7 @@ msgstr  ""
 msgid   "WWN: %s"
 msgstr  ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid   "Wait for the operation to complete"
 msgstr  ""
 
@@ -6161,7 +6161,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553 lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554 lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid   "YES"
 msgstr  ""
 
@@ -6181,7 +6181,7 @@ msgstr  ""
 msgid   "You must specify a source instance name"
 msgstr  ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
@@ -6193,7 +6193,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899 lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442 lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32 lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899 lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443 lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32 lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85 lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6201,11 +6201,11 @@ msgstr  ""
 msgid   "[<remote>:] <backup file> [<instance name>]"
 msgstr  ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid   "[<remote>:] <cert.crt> <cert.key>"
 msgstr  ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
@@ -6225,47 +6225,47 @@ msgstr  ""
 msgid   "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr  ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608 lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609 lxc/network_acl.go:804
 msgid   "[<remote>:]<ACL>"
 msgstr  ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid   "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid   "[<remote>:]<ACL> <key>"
 msgstr  ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid   "[<remote>:]<ACL> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid   "[<remote>:]<ACL> <new-name>"
 msgstr  ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid   "[<remote>:]<ACL> [key=value...]"
 msgstr  ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid   "[<remote>:]<API path>"
 msgstr  ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid   "[<remote>:]<Zone>"
 msgstr  ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid   "[<remote>:]<Zone> <key>"
 msgstr  ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid   "[<remote>:]<Zone> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid   "[<remote>:]<Zone> [key=value...]"
 msgstr  ""
 
@@ -6297,7 +6297,7 @@ msgstr  ""
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443 lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173 lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443 lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174 lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
@@ -6305,7 +6305,7 @@ msgstr  ""
 msgid   "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> [<key>=<value>...]"
 msgstr  ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid   "[<remote>:]<group> <new-name>"
 msgstr  ""
 
@@ -6389,11 +6389,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid   "[<remote>:]<instance> <profile>"
 msgstr  ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid   "[<remote>:]<instance> <profiles>"
 msgstr  ""
 
@@ -6457,23 +6457,23 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773 lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774 lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid   "[<remote>:]<member> <group>"
 msgstr  ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid   "[<remote>:]<member> <key>"
 msgstr  ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid   "[<remote>:]<member> <key>=<value>..."
 msgstr  ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
@@ -6481,59 +6481,59 @@ msgstr  ""
 msgid   "[<remote>:]<member> <role[,role...]>"
 msgstr  ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141 lxc/network.go:1376 lxc/network_forward.go:88 lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142 lxc/network.go:1377 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid   "[<remote>:]<network> <instance> [<device name>]"
 msgstr  ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid   "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid   "[<remote>:]<network> <key>"
 msgstr  ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653 lxc/network_forward.go:806 lxc/network_load_balancer.go:180 lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654 lxc/network_forward.go:807 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid   "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid   "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
 msgstr  ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid   "[<remote>:]<network> <new-name>"
 msgstr  ""
 
@@ -6557,19 +6557,19 @@ msgstr  ""
 msgid   "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid   "[<remote>:]<network> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid   "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid   "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr  ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid   "[<remote>:]<network> [key=value...]"
 msgstr  ""
 
@@ -6673,7 +6673,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366 lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367 lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
@@ -6689,11 +6689,11 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid   "[<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid   "[<remote>:]<profile> <key>=<value>..."
 msgstr  ""
 
@@ -6701,27 +6701,27 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid   "[<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793 lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794 lxc/project.go:855 lxc/project.go:922
 msgid   "[<remote>:]<project>"
 msgstr  ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid   "[<remote>:]<project> <key>"
 msgstr  ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid   "[<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
@@ -6729,31 +6729,31 @@ msgstr  ""
 msgid   "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid   "[<remote>:]<warning-uuid>"
 msgstr  ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid   "[<remote>:]<zone>"
 msgstr  ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid   "[<remote>:]<zone> <record>"
 msgstr  ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid   "[<remote>:]<zone> <record> <key>"
 msgstr  ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid   "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid   "[<remote>:]<zone> <record> <type> <value>"
 msgstr  ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
@@ -6777,19 +6777,19 @@ msgstr  ""
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid   "[<remote>:][<warning-uuid>]"
 msgstr  ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid   "current"
 msgstr  ""
 
@@ -6848,12 +6848,12 @@ msgid   "lxc auth identity-provider-group edit <identity_provider_group> < ident
         "   Update an identity provider group using the content of identity-provider-group.yaml"
 msgstr  ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid   "lxc cluster group assign foo default,bar\n"
         "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -6861,7 +6861,7 @@ msgid   "lxc cluster group assign foo default,bar\n"
         "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr  ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid   "lxc cluster group create g1\n"
         "\n"
         "lxc cluster group create g1 < config.yaml\n"
@@ -7010,14 +7010,14 @@ msgid   "lxc move [<remote>:]<source instance> [<remote>:][<destination instance
         "    Rename a snapshot."
 msgstr  ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid   "lxc network acl create a1\n"
         "\n"
         "lxc network acl create a1 < config.yaml\n"
         "    Create network acl with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid   "lxc network create foo\n"
         "    Create a new network called foo\n"
         "\n"
@@ -7025,28 +7025,28 @@ msgid   "lxc network create foo\n"
         "    Create a new OVN network called bar using baz as its uplink network"
 msgstr  ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid   "lxc network forward create n1 127.0.0.1\n"
         "\n"
         "lxc network forward create n1 127.0.0.1 < config.yaml\n"
         "    Create a new network forward for network n1 from config.yaml"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid   "lxc network load-balancer create n1 127.0.0.1\n"
         "\n"
         "lxc network load-balancer create n1 127.0.0.1 < config.yaml\n"
         "    Create network load-balancer for network n1 with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid   "lxc network zone create z1\n"
         "\n"
         "lxc network zone create z1 < config.yaml\n"
         "    Create network zone z1 with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid   "lxc network zone record create z1 r1\n"
         "\n"
         "lxc network zone record create z1 r1 < config.yaml\n"
@@ -7058,7 +7058,7 @@ msgid   "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
         "    Show details on that operation UUID"
 msgstr  ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid   "lxc profile assign foo default,bar\n"
         "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -7069,7 +7069,7 @@ msgid   "lxc profile assign foo default,bar\n"
         "    Remove all profile from \"foo\""
 msgstr  ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid   "lxc profile create p1\n"
         "\n"
         "lxc profile create p1 < config.yaml\n"
@@ -7084,24 +7084,24 @@ msgid   "lxc profile device add [<remote>:]profile1 <device-name> disk source=/s
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid   "lxc project create p1\n"
         "\n"
         "lxc project create p1 < config.yaml\n"
         "    Create a project with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid   "lxc project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid   "lxc query -X DELETE --wait /1.0/instances/c1\n"
         "    Delete local instance \"c1\"."
 msgstr  ""
@@ -7191,7 +7191,7 @@ msgid   "lxc storage volume snapshot default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with the configuration from \"config.yaml\"."
 msgstr  ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid   "n"
 msgstr  ""
 
@@ -7203,7 +7203,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -7240,11 +7240,11 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002 lxc/image.go:1207
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002 lxc/image.go:1207
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -149,7 +149,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -326,7 +326,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -368,7 +368,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -406,7 +406,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -475,7 +475,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -500,7 +500,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -525,7 +525,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -559,7 +559,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -598,7 +598,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -633,7 +633,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -664,7 +664,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr "(geen)"
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -736,15 +736,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -773,11 +773,11 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -785,7 +785,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -802,25 +802,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -832,23 +832,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -864,11 +864,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -905,15 +905,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -921,7 +921,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -972,7 +972,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -999,27 +999,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1076,11 +1076,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -1111,14 +1111,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -1146,15 +1146,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1235,7 +1235,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1301,17 +1301,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,63 +1329,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1404,20 +1404,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1445,7 +1445,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1453,13 +1453,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1572,21 +1572,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1601,27 +1601,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1629,7 +1629,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1701,15 +1701,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1717,23 +1717,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1750,7 +1750,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1769,16 +1769,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1796,7 +1796,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1808,11 +1808,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1852,15 +1852,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1868,23 +1868,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1914,15 +1914,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1946,51 +1946,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2011,8 +2011,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -2025,11 +2025,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2066,12 +2066,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -2087,7 +2081,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2140,19 +2134,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2160,7 +2154,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2168,7 +2162,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -2177,7 +2171,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -2185,7 +2179,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2199,7 +2193,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2207,7 +2201,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2243,19 +2237,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2263,19 +2257,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2299,17 +2293,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2325,7 +2319,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2352,11 +2346,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2367,10 +2361,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2382,11 +2376,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2396,7 +2390,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2475,7 +2469,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2488,7 +2482,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2582,11 +2576,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2596,7 +2590,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2606,7 +2600,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2616,7 +2610,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2641,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2650,7 +2644,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2660,13 +2654,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2677,7 +2671,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2685,11 +2679,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2705,7 +2699,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2730,16 +2724,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2751,7 +2745,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2775,7 +2769,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2795,7 +2789,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2803,7 +2797,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2811,23 +2805,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2835,23 +2829,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2871,7 +2865,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2883,19 +2877,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2903,19 +2897,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2959,7 +2953,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2991,7 +2985,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3009,11 +3003,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3021,15 +3015,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -3171,7 +3165,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -3196,7 +3190,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3214,7 +3208,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3223,7 +3217,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3257,7 +3251,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3314,7 +3308,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3349,7 +3343,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3357,17 +3351,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3379,8 +3373,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3398,12 +3392,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3417,7 +3411,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3429,35 +3423,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3465,19 +3459,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3656,11 +3650,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3676,7 +3670,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3712,7 +3706,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3720,11 +3714,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3756,7 +3750,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3764,15 +3758,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3780,7 +3774,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3790,11 +3784,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3807,15 +3801,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3823,7 +3817,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3842,15 +3836,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3929,31 +3923,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3961,15 +3955,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3977,11 +3971,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4017,7 +4011,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4029,7 +4023,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -4052,17 +4046,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4111,13 +4105,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -4143,8 +4137,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -4153,14 +4147,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -4170,41 +4164,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4230,18 +4224,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4261,7 +4255,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4286,7 +4280,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4341,11 +4335,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4357,12 +4351,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4375,11 +4369,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4391,9 +4385,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4420,11 +4414,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4434,67 +4428,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4524,20 +4518,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4559,12 +4553,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4572,19 +4566,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4610,7 +4604,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4627,7 +4621,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4639,7 +4633,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4650,6 +4644,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4682,7 +4680,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4690,29 +4688,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4733,7 +4731,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4741,11 +4739,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4762,14 +4760,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4783,7 +4781,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4806,32 +4804,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4848,7 +4846,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4861,22 +4859,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4974,7 +4972,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -5010,7 +5008,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -5018,7 +5016,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -5026,7 +5024,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -5065,45 +5063,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -5117,7 +5115,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -5125,11 +5123,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5137,23 +5135,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -5165,7 +5163,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -5173,19 +5171,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -5193,7 +5191,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5201,11 +5199,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5226,23 +5224,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5264,7 +5262,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5291,7 +5289,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5310,7 +5308,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5323,7 +5321,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5332,7 +5330,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5352,7 +5350,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5382,20 +5380,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5403,11 +5401,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5420,23 +5418,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5449,7 +5447,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5496,11 +5494,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5509,11 +5507,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5522,11 +5520,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5535,11 +5533,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5561,11 +5559,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5574,15 +5572,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5591,11 +5589,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5643,7 +5641,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5671,19 +5669,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5691,23 +5689,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5743,7 +5741,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5751,7 +5749,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5812,23 +5810,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5836,23 +5834,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5886,7 +5884,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5914,7 +5912,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5926,7 +5924,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5966,7 +5964,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5974,7 +5972,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5983,7 +5981,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -6075,7 +6073,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6098,11 +6096,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6124,14 +6122,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -6147,7 +6145,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6185,7 +6183,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6199,11 +6197,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -6222,7 +6220,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6237,22 +6235,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6262,22 +6260,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6303,7 +6301,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6320,12 +6318,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6341,11 +6339,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6373,11 +6371,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6392,7 +6390,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6441,24 +6439,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6477,7 +6475,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6488,7 +6486,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6496,21 +6494,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6524,7 +6522,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6538,8 +6536,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6554,7 +6552,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6568,7 +6566,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6588,27 +6586,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6620,19 +6618,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6648,19 +6646,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6668,23 +6666,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6713,21 +6711,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6736,7 +6734,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6769,7 +6767,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6783,15 +6781,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6827,7 +6825,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6851,9 +6849,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6873,7 +6871,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6889,11 +6887,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6901,11 +6899,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6925,48 +6923,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -7001,8 +6999,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -7012,7 +7010,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -7098,11 +7096,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7169,24 +7167,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7194,70 +7192,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7283,19 +7281,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7408,8 +7406,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7425,11 +7423,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7437,28 +7435,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7466,31 +7464,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7514,19 +7512,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7594,13 +7592,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7609,7 +7607,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7793,7 +7791,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7801,7 +7799,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7810,7 +7808,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7818,7 +7816,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7827,7 +7825,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7835,7 +7833,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7849,7 +7847,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7861,7 +7859,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7880,13 +7878,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7894,13 +7892,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -8010,7 +8008,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -8022,7 +8020,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8059,11 +8057,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -151,7 +151,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -340,7 +340,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -386,7 +386,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -428,7 +428,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -505,7 +505,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -530,7 +530,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -555,7 +555,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -593,7 +593,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -632,7 +632,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -671,7 +671,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -702,7 +702,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -733,7 +733,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -749,7 +749,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -774,15 +774,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -823,7 +823,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -840,25 +840,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -870,23 +870,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -943,15 +943,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -959,7 +959,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1037,27 +1037,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -1095,7 +1095,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1114,11 +1114,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -1149,14 +1149,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1171,7 +1171,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -1184,15 +1184,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -1208,7 +1208,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1273,7 +1273,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1302,7 +1302,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1339,17 +1339,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1367,63 +1367,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1442,20 +1442,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1491,13 +1491,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1610,21 +1610,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1639,27 +1639,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1667,7 +1667,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1739,15 +1739,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1755,23 +1755,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1788,7 +1788,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1798,7 +1798,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1807,16 +1807,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1846,11 +1846,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1890,15 +1890,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1906,23 +1906,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1938,7 +1938,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1952,15 +1952,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1984,51 +1984,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2049,8 +2049,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -2063,11 +2063,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2104,12 +2104,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -2125,7 +2119,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2178,19 +2172,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2198,7 +2192,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2206,7 +2200,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -2215,7 +2209,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -2223,7 +2217,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2237,7 +2231,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2245,7 +2239,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2281,19 +2275,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2301,19 +2295,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2337,17 +2331,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2363,7 +2357,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2390,11 +2384,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2405,10 +2399,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2420,11 +2414,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2434,7 +2428,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2513,7 +2507,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2526,7 +2520,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2620,11 +2614,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2634,7 +2628,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2644,7 +2638,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2654,7 +2648,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2679,7 +2673,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2688,7 +2682,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2698,13 +2692,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2715,7 +2709,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2723,11 +2717,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2743,7 +2737,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2768,16 +2762,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2789,7 +2783,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2813,7 +2807,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2833,7 +2827,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2841,7 +2835,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2849,23 +2843,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2873,23 +2867,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2909,7 +2903,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2921,19 +2915,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2941,19 +2935,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2997,7 +2991,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3029,7 +3023,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3047,11 +3041,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3059,15 +3053,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -3209,7 +3203,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -3234,7 +3228,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3252,7 +3246,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3261,7 +3255,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3295,7 +3289,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3352,7 +3346,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3387,7 +3381,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3395,17 +3389,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3417,8 +3411,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3436,12 +3430,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3455,7 +3449,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3467,35 +3461,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3503,19 +3497,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3694,11 +3688,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3714,7 +3708,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3750,7 +3744,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3758,11 +3752,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3794,7 +3788,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3802,15 +3796,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3818,7 +3812,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3828,11 +3822,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3845,15 +3839,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3861,7 +3855,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3880,15 +3874,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3967,31 +3961,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3999,15 +3993,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -4015,11 +4009,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4055,7 +4049,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4067,7 +4061,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -4090,17 +4084,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4149,13 +4143,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -4181,8 +4175,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -4191,14 +4185,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -4208,41 +4202,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4268,18 +4262,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4299,7 +4293,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4324,7 +4318,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4379,11 +4373,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4395,12 +4389,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4413,11 +4407,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4429,9 +4423,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4458,11 +4452,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4472,67 +4466,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4562,20 +4556,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4597,12 +4591,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4610,19 +4604,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4648,7 +4642,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4665,7 +4659,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4677,7 +4671,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4688,6 +4682,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4720,7 +4718,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4728,29 +4726,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4771,7 +4769,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4779,11 +4777,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4800,14 +4798,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4821,7 +4819,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4844,32 +4842,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4886,7 +4884,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4899,22 +4897,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5012,7 +5010,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -5048,7 +5046,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -5056,7 +5054,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -5064,7 +5062,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -5103,45 +5101,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -5155,7 +5153,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -5163,11 +5161,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5175,23 +5173,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -5203,7 +5201,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -5211,19 +5209,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -5231,7 +5229,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5239,11 +5237,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5264,23 +5262,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5302,7 +5300,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5329,7 +5327,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5348,7 +5346,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5361,7 +5359,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5370,7 +5368,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5390,7 +5388,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5420,20 +5418,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5441,11 +5439,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5458,23 +5456,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5487,7 +5485,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5534,11 +5532,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5547,11 +5545,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5560,11 +5558,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5573,11 +5571,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5599,11 +5597,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5612,15 +5610,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5629,11 +5627,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5681,7 +5679,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5709,19 +5707,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5729,23 +5727,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5781,7 +5779,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5789,7 +5787,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5850,23 +5848,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5874,23 +5872,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5924,7 +5922,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5952,7 +5950,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5964,7 +5962,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -6004,7 +6002,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -6012,7 +6010,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6021,7 +6019,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -6113,7 +6111,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6136,11 +6134,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6162,14 +6160,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -6185,7 +6183,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6223,7 +6221,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6237,11 +6235,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -6260,7 +6258,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6275,22 +6273,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6300,22 +6298,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6341,7 +6339,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6358,12 +6356,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6379,11 +6377,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6411,11 +6409,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6430,7 +6428,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6479,24 +6477,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6515,7 +6513,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6526,7 +6524,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6534,21 +6532,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6562,7 +6560,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6576,8 +6574,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6592,7 +6590,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6606,7 +6604,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6626,27 +6624,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6658,19 +6656,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6686,19 +6684,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6706,23 +6704,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6751,21 +6749,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6774,7 +6772,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6807,7 +6805,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6821,15 +6819,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6865,7 +6863,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6889,9 +6887,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6911,7 +6909,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6927,11 +6925,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6939,11 +6937,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6963,48 +6961,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -7039,8 +7037,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -7050,7 +7048,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -7136,11 +7134,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7207,24 +7205,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7232,70 +7230,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7321,19 +7319,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7446,8 +7444,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7463,11 +7461,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7475,28 +7473,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7504,31 +7502,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7552,19 +7550,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7632,13 +7630,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7647,7 +7645,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7831,7 +7829,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7839,7 +7837,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7848,7 +7846,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7856,7 +7854,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7865,7 +7863,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7873,7 +7871,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7887,7 +7885,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7899,7 +7897,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7918,13 +7916,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7932,13 +7930,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -8048,7 +8046,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -8060,7 +8058,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8097,11 +8095,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -103,7 +103,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -223,7 +223,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,7 +316,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -330,7 +330,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -406,7 +406,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -437,7 +437,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -468,7 +468,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -509,15 +509,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -546,11 +546,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -575,25 +575,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -605,23 +605,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -629,7 +629,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -637,11 +637,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -678,15 +678,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -745,7 +745,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -772,27 +772,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -830,7 +830,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,11 +849,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -884,14 +884,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1037,7 +1037,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1074,17 +1074,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1102,63 +1102,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1177,20 +1177,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1226,13 +1226,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1301,7 +1301,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1345,21 +1345,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1374,27 +1374,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1474,15 +1474,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,23 +1490,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1542,16 +1542,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1569,7 +1569,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1581,11 +1581,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1625,15 +1625,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1641,23 +1641,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1687,15 +1687,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1719,51 +1719,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1784,8 +1784,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1798,11 +1798,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1839,12 +1839,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1860,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1913,19 +1907,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1933,7 +1927,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1941,7 +1935,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1950,7 +1944,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1958,7 +1952,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1972,7 +1966,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1980,7 +1974,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2016,19 +2010,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2036,19 +2030,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2072,17 +2066,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2098,7 +2092,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2125,11 +2119,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2140,10 +2134,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2155,11 +2149,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2169,7 +2163,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2248,7 +2242,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2261,7 +2255,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2355,11 +2349,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2369,7 +2363,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2379,7 +2373,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2389,7 +2383,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2414,7 +2408,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2423,7 +2417,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2433,13 +2427,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2450,7 +2444,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2458,11 +2452,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2478,7 +2472,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2503,16 +2497,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2524,7 +2518,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2548,7 +2542,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2568,7 +2562,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2576,7 +2570,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2584,23 +2578,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2608,23 +2602,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2644,7 +2638,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2656,19 +2650,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2676,19 +2670,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2732,7 +2726,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2764,7 +2758,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2782,11 +2776,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2794,15 +2788,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2944,7 +2938,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2969,7 +2963,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2987,7 +2981,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2996,7 +2990,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3030,7 +3024,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3087,7 +3081,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3122,7 +3116,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3130,17 +3124,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3152,8 +3146,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3171,12 +3165,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3190,7 +3184,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3202,35 +3196,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3238,19 +3232,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3429,11 +3423,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3449,7 +3443,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3485,7 +3479,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3493,11 +3487,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3529,7 +3523,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3537,15 +3531,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3553,7 +3547,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3563,11 +3557,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3580,15 +3574,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3596,7 +3590,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3615,15 +3609,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3702,31 +3696,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3734,15 +3728,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3750,11 +3744,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3790,7 +3784,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3802,7 +3796,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3825,17 +3819,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3884,13 +3878,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3916,8 +3910,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3926,14 +3920,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3943,41 +3937,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4003,18 +3997,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4034,7 +4028,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4059,7 +4053,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4114,11 +4108,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4130,12 +4124,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4148,11 +4142,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4164,9 +4158,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4193,11 +4187,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4207,67 +4201,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4297,20 +4291,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4332,12 +4326,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4345,19 +4339,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4383,7 +4377,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4400,7 +4394,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4412,7 +4406,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4423,6 +4417,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4455,7 +4453,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4463,29 +4461,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4506,7 +4504,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4514,11 +4512,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4535,14 +4533,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4556,7 +4554,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4579,32 +4577,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4621,7 +4619,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4634,22 +4632,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4747,7 +4745,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4783,7 +4781,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4791,7 +4789,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4799,7 +4797,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4838,45 +4836,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4890,7 +4888,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4898,11 +4896,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4910,23 +4908,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4938,7 +4936,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4946,19 +4944,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4966,7 +4964,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4974,11 +4972,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4999,23 +4997,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5037,7 +5035,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5064,7 +5062,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5083,7 +5081,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5096,7 +5094,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5105,7 +5103,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5125,7 +5123,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5155,20 +5153,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5176,11 +5174,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5193,23 +5191,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5222,7 +5220,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5269,11 +5267,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5282,11 +5280,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5295,11 +5293,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5308,11 +5306,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5334,11 +5332,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5347,15 +5345,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5364,11 +5362,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5416,7 +5414,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5444,19 +5442,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5464,23 +5462,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5516,7 +5514,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5524,7 +5522,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5585,23 +5583,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5609,23 +5607,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5659,7 +5657,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5687,7 +5685,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5699,7 +5697,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5739,7 +5737,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5747,7 +5745,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5756,7 +5754,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5848,7 +5846,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5871,11 +5869,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5897,14 +5895,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5920,7 +5918,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5958,7 +5956,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5972,11 +5970,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5995,7 +5993,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6010,22 +6008,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6035,22 +6033,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6076,7 +6074,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6093,12 +6091,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6114,11 +6112,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6146,11 +6144,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6165,7 +6163,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6214,24 +6212,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6250,7 +6248,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6261,7 +6259,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6269,21 +6267,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6297,7 +6295,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6311,8 +6309,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6327,7 +6325,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6341,7 +6339,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6361,27 +6359,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6393,19 +6391,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6421,19 +6419,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6441,23 +6439,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6486,21 +6484,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6509,7 +6507,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6542,7 +6540,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6556,15 +6554,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6600,7 +6598,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6624,9 +6622,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6646,7 +6644,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6662,11 +6660,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6674,11 +6672,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6698,48 +6696,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6774,8 +6772,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6785,7 +6783,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6871,11 +6869,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6942,24 +6940,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6967,70 +6965,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7056,19 +7054,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7181,8 +7179,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7198,11 +7196,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7210,28 +7208,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7239,31 +7237,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7287,19 +7285,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7367,13 +7365,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7382,7 +7380,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7566,7 +7564,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7574,7 +7572,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7583,7 +7581,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7591,7 +7589,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7600,7 +7598,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7608,7 +7606,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7622,7 +7620,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7634,7 +7632,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7653,13 +7651,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7667,13 +7665,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7783,7 +7781,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7795,7 +7793,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7832,11 +7830,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -152,7 +152,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -332,7 +332,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -377,7 +377,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -418,7 +418,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -491,7 +491,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -517,7 +517,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -543,7 +543,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -580,7 +580,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -619,7 +619,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado"
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -655,7 +655,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -688,7 +688,7 @@ msgstr "%s não é um diretório"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr "(nenhum)"
 
@@ -722,7 +722,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
@@ -742,7 +742,7 @@ msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 #, fuzzy
 msgid "--project cannot be used with the query command"
 msgstr "--refresh só pode ser usado com containers"
@@ -770,15 +770,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -808,11 +808,11 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
@@ -820,7 +820,7 @@ msgstr "TIPO DE AUTENTICAÇÃO"
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
@@ -838,25 +838,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
@@ -869,24 +869,24 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -903,11 +903,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -945,15 +945,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Adicionar perfis aos containers"
@@ -963,7 +963,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Add roles to a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Adicionar perfis aos containers"
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -1016,7 +1016,7 @@ msgstr "Aliases:"
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr "Arquitetura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1044,30 +1044,30 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Anexar interfaces de rede aos containers"
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 #, fuzzy
 msgid "Attach new network interfaces to instances"
 msgstr "Anexar uma nova interface de rede aos containers"
@@ -1108,7 +1108,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1127,11 +1127,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 #, fuzzy
 msgid "Available projects:"
 msgstr "Criar projetos"
@@ -1163,14 +1163,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1185,7 +1185,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -1198,15 +1198,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Marca: %v"
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1222,7 +1222,7 @@ msgstr "NOME COMUM"
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1288,7 +1288,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1305,7 +1305,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -1318,7 +1318,7 @@ msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1355,18 +1355,18 @@ msgstr "Em cache: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1385,63 +1385,63 @@ msgstr "Certificado do cliente armazenado no servidor: "
 msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1460,20 +1460,20 @@ msgstr "Dispositivo %s removido de %s"
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1509,7 +1509,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1518,13 +1518,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
@@ -1611,7 +1611,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1640,21 +1640,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1669,27 +1669,27 @@ msgstr "Erro de análise de configuração: %s"
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1698,7 +1698,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1782,17 +1782,17 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 #, fuzzy
 msgid "Create new network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Criar novas redes"
@@ -1802,25 +1802,25 @@ msgstr "Criar novas redes"
 msgid "Create new network peering"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr "Criar perfis"
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr "Criar projetos"
 
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
@@ -1847,7 +1847,7 @@ msgstr "Criando %s"
 msgid "Creating %s: %%s"
 msgstr "Criando %s"
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Criando %s"
@@ -1857,16 +1857,16 @@ msgstr "Criando %s"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1884,7 +1884,7 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1897,11 +1897,11 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 #, fuzzy
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
@@ -1947,17 +1947,17 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 #, fuzzy
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Criar novas redes"
@@ -1967,25 +1967,25 @@ msgstr "Criar novas redes"
 msgid "Delete network peerings"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
@@ -2002,7 +2002,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -2016,15 +2016,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -2048,51 +2048,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2113,8 +2113,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr "Descrição"
 
@@ -2128,12 +2128,12 @@ msgstr "Descrição"
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Desconectar interfaces de rede dos containers"
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
@@ -2172,12 +2172,6 @@ msgstr "O dispositivo já existe: %s"
 msgid "Device doesn't exist"
 msgstr "Alias %s não existe"
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -2193,7 +2187,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2250,22 +2244,22 @@ msgstr "Criar projetos"
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "Criar projetos"
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Criar projetos"
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Criar projetos"
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Criar projetos"
@@ -2275,7 +2269,7 @@ msgstr "Criar projetos"
 msgid "Display storage pool buckets from all projects"
 msgstr "Criar projetos"
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2283,7 +2277,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -2292,7 +2286,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -2300,7 +2294,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DE VALIDADE"
@@ -2315,7 +2309,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2324,7 +2318,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -2368,21 +2362,21 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2392,21 +2386,21 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network peer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
@@ -2433,17 +2427,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2459,7 +2453,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2486,11 +2480,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2501,10 +2495,10 @@ msgstr "Editar propriedades da imagem"
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2516,12 +2510,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2531,7 +2525,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -2610,7 +2604,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2623,7 +2617,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2717,11 +2711,11 @@ msgstr "Aceitar certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2731,7 +2725,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2741,7 +2735,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Nome de membro do cluster"
@@ -2751,7 +2745,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to find image %q on remote %q"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2776,7 +2770,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2785,7 +2779,7 @@ msgstr "Aceitar certificado"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2795,13 +2789,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2812,7 +2806,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2820,11 +2814,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2841,7 +2835,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2866,16 +2860,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2887,7 +2881,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2911,7 +2905,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2931,7 +2925,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2940,7 +2934,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2949,24 +2943,24 @@ msgstr ""
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -2976,25 +2970,25 @@ msgstr "Criar novas redes"
 msgid "Get the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3016,7 +3010,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3031,21 +3025,21 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for instance or server configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3055,21 +3049,21 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3115,7 +3109,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -3147,7 +3141,7 @@ msgstr "Dispositivo %s adicionado a %s"
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr "ID"
 
@@ -3165,11 +3159,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3177,15 +3171,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -3329,7 +3323,7 @@ msgstr "Editar arquivos no container"
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -3354,7 +3348,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3372,7 +3366,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3381,7 +3375,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3415,7 +3409,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid export version %q: %w"
 msgstr "Versão do cliente: %s\n"
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Editar arquivos no container"
@@ -3473,7 +3467,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3509,7 +3503,7 @@ msgstr "Em cache: %s"
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3517,17 +3511,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3539,8 +3533,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3558,12 +3552,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Criando %s"
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Criando %s"
@@ -3578,7 +3572,7 @@ msgstr "Arquitetura: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3591,37 +3585,37 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Criar novas redes"
@@ -3630,20 +3624,20 @@ msgstr "Criar novas redes"
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3825,11 +3819,11 @@ msgstr "Criar projetos"
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3845,7 +3839,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3881,7 +3875,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3889,11 +3883,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3925,7 +3919,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3933,17 +3927,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 #, fuzzy
 msgid "Lower device"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 #, fuzzy
 msgid "Lower devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3951,7 +3945,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3961,11 +3955,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3978,15 +3972,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3994,7 +3988,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4013,15 +4007,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -4109,36 +4103,36 @@ msgstr "Editar templates de arquivo do container"
 msgid "Manage instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 #, fuzzy
 msgid "Manage network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Criar novas redes"
@@ -4148,17 +4142,17 @@ msgstr "Criar novas redes"
 msgid "Manage network peerings"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Criar novas redes"
@@ -4168,11 +4162,11 @@ msgstr "Criar novas redes"
 msgid "Manage permissions"
 msgstr "Editar arquivos no container"
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4211,7 +4205,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4224,7 +4218,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr "Nome de membro do cluster"
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Editar arquivos no container"
@@ -4249,17 +4243,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4310,14 +4304,14 @@ msgstr "Nome de membro do cluster"
 msgid "Missing certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4348,8 +4342,8 @@ msgstr "Nome de membro do cluster"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -4359,14 +4353,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
@@ -4377,43 +4371,43 @@ msgstr "Nome de membro do cluster"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nome de membro do cluster"
@@ -4441,18 +4435,18 @@ msgstr "Nome de membro do cluster"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4474,7 +4468,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4499,7 +4493,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4555,11 +4549,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4571,12 +4565,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4589,11 +4583,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4605,9 +4599,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4634,11 +4628,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4648,67 +4642,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4738,20 +4732,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4773,12 +4767,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4786,19 +4780,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4824,7 +4818,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4841,7 +4835,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4853,7 +4847,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4864,6 +4858,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4896,7 +4894,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4904,29 +4902,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4947,7 +4945,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4955,12 +4953,12 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4977,14 +4975,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4998,7 +4996,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -5021,32 +5019,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -5066,7 +5064,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5081,22 +5079,22 @@ msgstr "Copiar perfis"
 msgid "Profiles: "
 msgstr "Copiar perfis"
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5194,7 +5192,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -5231,7 +5229,7 @@ msgstr "Editar arquivos no container"
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -5239,7 +5237,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -5247,7 +5245,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -5288,46 +5286,46 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Adicionar novos clientes confiáveis"
@@ -5342,7 +5340,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
@@ -5352,11 +5350,11 @@ msgstr "Nome de membro do cluster"
 msgid "Remove a group from an identity"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
@@ -5365,25 +5363,25 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
@@ -5397,7 +5395,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -5406,22 +5404,22 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -5430,7 +5428,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Adicionar perfis aos containers"
@@ -5440,11 +5438,11 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5465,24 +5463,24 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 #, fuzzy
 msgid "Rename network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5504,7 +5502,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5532,7 +5530,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
@@ -5557,7 +5555,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -5570,7 +5568,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5580,7 +5578,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
@@ -5602,7 +5600,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "Criar projetos"
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5632,20 +5630,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5653,11 +5651,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5670,23 +5668,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "Criado: %s"
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5700,7 +5698,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5751,12 +5749,12 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5765,11 +5763,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5778,12 +5776,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5792,12 +5790,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5820,12 +5818,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5834,16 +5832,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5852,12 +5850,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5906,7 +5904,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5934,20 +5932,20 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -5957,25 +5955,25 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6013,7 +6011,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6023,7 +6021,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show content of instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -6090,26 +6088,26 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6119,26 +6117,26 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network peer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -6175,7 +6173,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -6205,7 +6203,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Nome de membro do cluster"
@@ -6218,7 +6216,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -6258,7 +6256,7 @@ msgstr "Dispositivo %s adicionado a %s"
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -6266,7 +6264,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6275,7 +6273,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -6368,7 +6366,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6391,11 +6389,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6417,14 +6415,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -6441,7 +6439,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6482,7 +6480,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6496,11 +6494,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nome de membro do cluster"
@@ -6519,7 +6517,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6534,22 +6532,22 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6559,22 +6557,22 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6600,7 +6598,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6617,12 +6615,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6639,11 +6637,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
@@ -6672,11 +6670,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6691,7 +6689,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6740,25 +6738,25 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6778,7 +6776,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6789,7 +6787,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6797,21 +6795,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6825,7 +6823,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
@@ -6840,8 +6838,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6856,7 +6854,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6871,7 +6869,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6896,31 +6894,31 @@ msgstr "Editar propriedades da imagem"
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Criar novas redes"
@@ -6935,21 +6933,21 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network peer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -6967,20 +6965,20 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -6990,26 +6988,26 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7039,22 +7037,22 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7063,7 +7061,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 #, fuzzy
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
@@ -7097,7 +7095,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -7111,15 +7109,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -7155,7 +7153,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -7179,9 +7177,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -7201,7 +7199,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -7219,11 +7217,11 @@ msgid ""
 msgstr "Criar perfis"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -7232,12 +7230,12 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -7258,57 +7256,57 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Criar perfis"
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Criar perfis"
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Criar perfis"
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -7345,8 +7343,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Criar perfis"
@@ -7358,7 +7356,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr "Criar perfis"
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
@@ -7454,11 +7452,11 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7529,27 +7527,27 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7558,76 +7556,76 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7658,20 +7656,20 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "Criar perfis"
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7799,8 +7797,8 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
@@ -7817,11 +7815,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
@@ -7830,29 +7828,29 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Criar projetos"
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7861,37 +7859,37 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Criar perfis"
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Criar perfis"
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Criar perfis"
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -7917,22 +7915,22 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 #, fuzzy
 msgid "[<remote>:][<warning-uuid>]"
 msgstr "Criar perfis"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -8000,13 +7998,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -8015,7 +8013,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8199,7 +8197,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -8207,7 +8205,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8216,7 +8214,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8224,7 +8222,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8233,7 +8231,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -8241,7 +8239,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -8255,7 +8253,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8267,7 +8265,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8286,13 +8284,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8300,13 +8298,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -8416,7 +8414,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -8428,7 +8426,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8465,11 +8463,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "sim"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -156,7 +156,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -333,7 +333,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -378,7 +378,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -419,7 +419,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -495,7 +495,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -523,7 +523,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -551,7 +551,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -588,7 +588,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -627,7 +627,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -666,7 +666,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -697,7 +697,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr "(пусто)"
 
@@ -728,7 +728,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -770,15 +770,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -812,11 +812,11 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -824,7 +824,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
@@ -841,25 +841,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
@@ -872,24 +872,24 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Копирование образа: %s"
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -948,15 +948,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -965,7 +965,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -1017,7 +1017,7 @@ msgstr "Псевдонимы:"
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1036,7 +1036,7 @@ msgstr "Архитектура: %s"
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1045,28 +1045,28 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1124,11 +1124,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 #, fuzzy
 msgid "Available projects:"
 msgstr "Доступные команды:"
@@ -1160,14 +1160,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1182,7 +1182,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -1195,15 +1195,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1219,7 +1219,7 @@ msgstr "ОБЩЕЕ ИМЯ"
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1302,7 +1302,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1328,7 +1328,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr ""
@@ -1360,13 +1360,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1385,63 +1385,63 @@ msgstr "Сертификат клиента хранится на сервере
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr " Использование сети:"
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1460,20 +1460,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1509,13 +1509,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1602,7 +1602,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1631,21 +1631,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
@@ -1660,27 +1660,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1772,16 +1772,16 @@ msgstr "Копирование образа: %s"
 msgid "Create new instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Копирование образа: %s"
@@ -1791,25 +1791,25 @@ msgstr "Копирование образа: %s"
 msgid "Create new network peering"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1828,7 +1828,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1838,7 +1838,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1848,16 +1848,16 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1875,7 +1875,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1936,15 +1936,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete key from a storage bucket"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Копирование образа: %s"
@@ -1953,25 +1953,25 @@ msgstr "Копирование образа: %s"
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1989,7 +1989,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -2003,15 +2003,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -2035,51 +2035,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2100,8 +2100,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -2115,11 +2115,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2157,12 +2157,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -2178,7 +2172,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2237,22 +2231,22 @@ msgstr "Копирование образа: %s"
 msgid "Display instances from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 #, fuzzy
 msgid "Display network ACLs from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 #, fuzzy
 msgid "Display networks from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Копирование образа: %s"
@@ -2262,7 +2256,7 @@ msgstr "Копирование образа: %s"
 msgid "Display storage pool buckets from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2270,7 +2264,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -2279,7 +2273,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -2287,7 +2281,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2301,7 +2295,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2309,7 +2303,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2349,19 +2343,19 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Копирование образа: %s"
@@ -2371,21 +2365,21 @@ msgstr "Копирование образа: %s"
 msgid "Edit network peer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2410,17 +2404,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2436,7 +2430,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2463,11 +2457,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2478,10 +2472,10 @@ msgstr "Копирование образа: %s"
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2493,7 +2487,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2501,7 +2495,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2511,7 +2505,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -2595,7 +2589,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2608,7 +2602,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2702,11 +2696,11 @@ msgstr "Принять сертификат"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2716,7 +2710,7 @@ msgstr "Принять сертификат"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2726,7 +2720,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Копирование образа: %s"
@@ -2736,7 +2730,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to find image %q on remote %q"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2761,7 +2755,7 @@ msgstr "Принять сертификат"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2770,7 +2764,7 @@ msgstr "Принять сертификат"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2780,13 +2774,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2797,7 +2791,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2805,11 +2799,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2826,7 +2820,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2851,16 +2845,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2872,7 +2866,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2896,7 +2890,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2916,7 +2910,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2925,7 +2919,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2933,24 +2927,24 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -2960,25 +2954,25 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3001,7 +2995,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Копирование образа: %s"
@@ -3014,20 +3008,20 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Копирование образа: %s"
@@ -3037,21 +3031,21 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network peer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3096,7 +3090,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3129,7 +3123,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3147,11 +3141,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3159,15 +3153,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -3313,7 +3307,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -3340,7 +3334,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -3359,7 +3353,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Имя контейнера: %s"
@@ -3368,7 +3362,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3402,7 +3396,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Имя контейнера: %s"
@@ -3460,7 +3454,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3496,7 +3490,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3504,17 +3498,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3526,8 +3520,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3545,12 +3539,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3565,7 +3559,7 @@ msgstr "Архитектура: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3579,38 +3573,38 @@ msgstr "Псевдонимы:"
 msgid "List all active certificate add tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 #, fuzzy
 msgid "List all warnings"
 msgstr "Псевдонимы:"
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Копирование образа: %s"
@@ -3619,20 +3613,20 @@ msgstr "Копирование образа: %s"
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3817,11 +3811,11 @@ msgstr "Копирование образа: %s"
 msgid "List permissions"
 msgstr "Псевдонимы:"
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3837,7 +3831,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3876,7 +3870,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3884,12 +3878,12 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 #, fuzzy
 msgid "List warnings"
 msgstr "Псевдонимы:"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3921,7 +3915,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3929,17 +3923,17 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 #, fuzzy
 msgid "Lower device"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 #, fuzzy
 msgid "Lower devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3947,7 +3941,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3957,11 +3951,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3974,15 +3968,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3990,7 +3984,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4009,16 +4003,16 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -4104,36 +4098,36 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Manage instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Копирование образа: %s"
@@ -4143,17 +4137,17 @@ msgstr "Копирование образа: %s"
 msgid "Manage network peerings"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Копирование образа: %s"
@@ -4163,11 +4157,11 @@ msgstr "Копирование образа: %s"
 msgid "Manage permissions"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4209,7 +4203,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4222,7 +4216,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr "Копирование образа: %s"
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Копирование образа: %s"
@@ -4246,17 +4240,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4308,14 +4302,14 @@ msgstr "Имя контейнера: %s"
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4346,8 +4340,8 @@ msgstr "Копирование образа: %s"
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
@@ -4358,14 +4352,14 @@ msgstr "Имя контейнера: %s"
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
@@ -4376,43 +4370,43 @@ msgstr "Имя контейнера: %s"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Имя контейнера: %s"
@@ -4440,19 +4434,19 @@ msgstr "Имя контейнера: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4475,7 +4469,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4500,7 +4494,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4557,11 +4551,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4573,12 +4567,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4591,11 +4585,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4607,9 +4601,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4636,11 +4630,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4650,67 +4644,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr " Использование сети:"
@@ -4740,22 +4734,22 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 #, fuzzy
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr " Использование сети:"
@@ -4777,12 +4771,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4791,19 +4785,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4830,7 +4824,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4847,7 +4841,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4859,7 +4853,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4870,6 +4864,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4902,7 +4900,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4910,29 +4908,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4953,7 +4951,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4961,12 +4959,12 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4983,14 +4981,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -5004,7 +5002,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -5027,32 +5025,32 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -5069,7 +5067,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -5082,22 +5080,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5195,7 +5193,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -5231,7 +5229,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -5239,7 +5237,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -5247,7 +5245,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -5290,46 +5288,46 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -5343,7 +5341,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
@@ -5352,11 +5350,11 @@ msgstr "Копирование образа: %s"
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Копирование образа: %s"
@@ -5365,25 +5363,25 @@ msgstr "Копирование образа: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -5396,7 +5394,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -5404,20 +5402,20 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -5426,7 +5424,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5434,11 +5432,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5462,23 +5460,23 @@ msgstr "Копирование образа: %s"
 msgid "Rename instances and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5502,7 +5500,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5530,7 +5528,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
@@ -5552,7 +5550,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -5565,7 +5563,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5575,7 +5573,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
@@ -5597,7 +5595,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "Доступные команды:"
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5627,20 +5625,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5648,11 +5646,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5665,23 +5663,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5695,7 +5693,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
@@ -5743,11 +5741,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5756,11 +5754,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5769,12 +5767,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5783,12 +5781,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5811,12 +5809,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5825,16 +5823,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5843,11 +5841,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5896,7 +5894,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5924,20 +5922,20 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -5947,25 +5945,25 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6004,7 +6002,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Копирование образа: %s"
@@ -6014,7 +6012,7 @@ msgstr "Копирование образа: %s"
 msgid "Show content of instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -6078,25 +6076,25 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Копирование образа: %s"
@@ -6106,26 +6104,26 @@ msgstr "Копирование образа: %s"
 msgid "Show network peer configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -6162,7 +6160,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -6192,7 +6190,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
@@ -6205,7 +6203,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -6246,7 +6244,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -6254,7 +6252,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "State"
 msgstr "Авто-обновление: %s"
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
@@ -6359,7 +6357,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6382,11 +6380,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6408,14 +6406,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -6431,7 +6429,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6469,7 +6467,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6483,11 +6481,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Копирование образа: %s"
@@ -6506,7 +6504,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Копирование образа: %s"
@@ -6521,22 +6519,22 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Копирование образа: %s"
@@ -6546,22 +6544,22 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Копирование образа: %s"
@@ -6587,7 +6585,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6604,12 +6602,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6626,11 +6624,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6658,11 +6656,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6677,7 +6675,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6726,24 +6724,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6763,7 +6761,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6774,7 +6772,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6782,21 +6780,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6810,7 +6808,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6824,8 +6822,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6840,7 +6838,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6855,7 +6853,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
@@ -6876,30 +6874,30 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Копирование образа: %s"
@@ -6914,21 +6912,21 @@ msgstr "Копирование образа: %s"
 msgid "Unset network peer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6945,20 +6943,20 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -6968,26 +6966,26 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7019,22 +7017,22 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Принять сертификат"
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -7043,7 +7041,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 #, fuzzy
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
@@ -7077,7 +7075,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -7091,15 +7089,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -7135,7 +7133,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -7159,9 +7157,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -7181,7 +7179,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -7205,11 +7203,11 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -7225,7 +7223,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -7233,7 +7231,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -7269,8 +7267,8 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -7278,7 +7276,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -7286,7 +7284,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -7294,7 +7292,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -7302,7 +7300,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -7310,7 +7308,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -7318,7 +7316,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 #, fuzzy
 msgid "[<remote>:]<API path>"
 msgstr ""
@@ -7326,7 +7324,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -7334,7 +7332,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -7342,7 +7340,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -7350,7 +7348,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -7405,8 +7403,8 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -7424,7 +7422,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -7594,7 +7592,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -7602,7 +7600,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -7733,8 +7731,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -7742,7 +7740,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -7750,7 +7748,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -7758,7 +7756,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -7766,7 +7764,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -7782,9 +7780,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7792,7 +7790,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -7800,7 +7798,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -7808,7 +7806,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -7816,7 +7814,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -7824,9 +7822,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7834,7 +7832,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -7842,7 +7840,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -7852,8 +7850,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -7861,7 +7859,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -7869,7 +7867,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -7879,13 +7877,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -7893,7 +7891,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -7943,7 +7941,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -7951,7 +7949,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -7959,7 +7957,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -7967,7 +7965,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -8184,8 +8182,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -8217,7 +8215,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -8225,7 +8223,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 #, fuzzy
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
@@ -8241,7 +8239,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -8249,7 +8247,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -8257,8 +8255,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8266,7 +8264,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8274,7 +8272,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8282,7 +8280,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8298,7 +8296,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -8306,7 +8304,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -8314,7 +8312,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -8322,7 +8320,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -8330,7 +8328,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -8338,7 +8336,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -8346,7 +8344,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -8394,7 +8392,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 #, fuzzy
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
@@ -8402,7 +8400,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8410,7 +8408,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -8418,7 +8416,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -8486,13 +8484,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -8501,7 +8499,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -8685,7 +8683,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -8693,7 +8691,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -8702,7 +8700,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -8710,7 +8708,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -8719,7 +8717,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -8727,7 +8725,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -8741,7 +8739,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8753,7 +8751,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -8772,13 +8770,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8786,13 +8784,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -8902,7 +8900,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -8914,7 +8912,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8951,11 +8949,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "да"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -107,7 +107,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -227,7 +227,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -320,7 +320,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -334,7 +334,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -410,7 +410,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -441,7 +441,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -513,15 +513,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -550,11 +550,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -562,7 +562,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -579,25 +579,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -609,23 +609,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -641,11 +641,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -682,15 +682,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -712,7 +712,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -749,7 +749,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -776,27 +776,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -834,7 +834,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -853,11 +853,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -888,14 +888,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -947,7 +947,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1078,17 +1078,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1106,63 +1106,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1181,20 +1181,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1222,7 +1222,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1230,13 +1230,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1349,21 +1349,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1378,27 +1378,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1478,15 +1478,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1494,23 +1494,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1546,16 +1546,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1585,11 +1585,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1629,15 +1629,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1645,23 +1645,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1677,7 +1677,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1691,15 +1691,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1723,51 +1723,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1788,8 +1788,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1802,11 +1802,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1843,12 +1843,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1864,7 +1858,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1917,19 +1911,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1937,7 +1931,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1945,7 +1939,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1954,7 +1948,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1962,7 +1956,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1976,7 +1970,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1984,7 +1978,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2020,19 +2014,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2040,19 +2034,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2076,17 +2070,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2102,7 +2096,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2129,11 +2123,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2144,10 +2138,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2159,11 +2153,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2173,7 +2167,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2252,7 +2246,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2265,7 +2259,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2359,11 +2353,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2373,7 +2367,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2383,7 +2377,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2393,7 +2387,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2418,7 +2412,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2427,7 +2421,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2437,13 +2431,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2454,7 +2448,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2462,11 +2456,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2482,7 +2476,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2507,16 +2501,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2528,7 +2522,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2552,7 +2546,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2572,7 +2566,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2580,7 +2574,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2588,23 +2582,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2612,23 +2606,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2648,7 +2642,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2660,19 +2654,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2680,19 +2674,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2736,7 +2730,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2768,7 +2762,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2786,11 +2780,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2798,15 +2792,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2948,7 +2942,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2973,7 +2967,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2991,7 +2985,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3000,7 +2994,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3034,7 +3028,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3091,7 +3085,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3126,7 +3120,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3134,17 +3128,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3156,8 +3150,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3175,12 +3169,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3194,7 +3188,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3206,35 +3200,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3242,19 +3236,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3433,11 +3427,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3453,7 +3447,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3489,7 +3483,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3497,11 +3491,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3533,7 +3527,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3541,15 +3535,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3557,7 +3551,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3567,11 +3561,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3584,15 +3578,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3600,7 +3594,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3619,15 +3613,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3706,31 +3700,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3738,15 +3732,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3754,11 +3748,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3794,7 +3788,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3806,7 +3800,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3829,17 +3823,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3888,13 +3882,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3920,8 +3914,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3930,14 +3924,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3947,41 +3941,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4007,18 +4001,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4038,7 +4032,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4063,7 +4057,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4118,11 +4112,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4134,12 +4128,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4152,11 +4146,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4168,9 +4162,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4197,11 +4191,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4211,67 +4205,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4301,20 +4295,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4336,12 +4330,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4349,19 +4343,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4387,7 +4381,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4404,7 +4398,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4416,7 +4410,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4427,6 +4421,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4459,7 +4457,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4467,29 +4465,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4510,7 +4508,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4518,11 +4516,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4539,14 +4537,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4560,7 +4558,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4583,32 +4581,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4625,7 +4623,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4638,22 +4636,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4751,7 +4749,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4787,7 +4785,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4795,7 +4793,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4803,7 +4801,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4842,45 +4840,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4894,7 +4892,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4902,11 +4900,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4914,23 +4912,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4942,7 +4940,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4950,19 +4948,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4970,7 +4968,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4978,11 +4976,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5003,23 +5001,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5041,7 +5039,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5068,7 +5066,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5087,7 +5085,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5100,7 +5098,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5109,7 +5107,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5129,7 +5127,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5159,20 +5157,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5180,11 +5178,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5197,23 +5195,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5226,7 +5224,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5273,11 +5271,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5286,11 +5284,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5299,11 +5297,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5312,11 +5310,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5338,11 +5336,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5351,15 +5349,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5368,11 +5366,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5420,7 +5418,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5448,19 +5446,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5468,23 +5466,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5520,7 +5518,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5528,7 +5526,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5589,23 +5587,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5613,23 +5611,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5663,7 +5661,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5691,7 +5689,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5703,7 +5701,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5743,7 +5741,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5751,7 +5749,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5760,7 +5758,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5852,7 +5850,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5875,11 +5873,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5901,14 +5899,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5924,7 +5922,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5962,7 +5960,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5976,11 +5974,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5999,7 +5997,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6014,22 +6012,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6039,22 +6037,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6080,7 +6078,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6097,12 +6095,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6118,11 +6116,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6150,11 +6148,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6169,7 +6167,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6218,24 +6216,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6254,7 +6252,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6265,7 +6263,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6273,21 +6271,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6301,7 +6299,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6315,8 +6313,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6331,7 +6329,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6345,7 +6343,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6365,27 +6363,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6397,19 +6395,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6425,19 +6423,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6445,23 +6443,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6490,21 +6488,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6513,7 +6511,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6546,7 +6544,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6560,15 +6558,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6604,7 +6602,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6628,9 +6626,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6650,7 +6648,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6666,11 +6664,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6678,11 +6676,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6702,48 +6700,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6778,8 +6776,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6789,7 +6787,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6875,11 +6873,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6946,24 +6944,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6971,70 +6969,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7060,19 +7058,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7185,8 +7183,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7202,11 +7200,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7214,28 +7212,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7243,31 +7241,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7291,19 +7289,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7371,13 +7369,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7386,7 +7384,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7570,7 +7568,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7578,7 +7576,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7587,7 +7585,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7595,7 +7593,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7604,7 +7602,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7612,7 +7610,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7626,7 +7624,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7638,7 +7636,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7657,13 +7655,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7671,13 +7669,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7787,7 +7785,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7799,7 +7797,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7836,11 +7834,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -107,7 +107,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -227,7 +227,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -320,7 +320,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -334,7 +334,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -410,7 +410,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -441,7 +441,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -513,15 +513,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -550,11 +550,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -562,7 +562,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -579,25 +579,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -609,23 +609,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -641,11 +641,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -682,15 +682,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -712,7 +712,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -749,7 +749,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -776,27 +776,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -834,7 +834,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -853,11 +853,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -888,14 +888,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -947,7 +947,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1078,17 +1078,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1106,63 +1106,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1181,20 +1181,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1222,7 +1222,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1230,13 +1230,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1349,21 +1349,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1378,27 +1378,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1478,15 +1478,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1494,23 +1494,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1546,16 +1546,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1585,11 +1585,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1629,15 +1629,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1645,23 +1645,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1677,7 +1677,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1691,15 +1691,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1723,51 +1723,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1788,8 +1788,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1802,11 +1802,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1843,12 +1843,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1864,7 +1858,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1917,19 +1911,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1937,7 +1931,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1945,7 +1939,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1954,7 +1948,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1962,7 +1956,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1976,7 +1970,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1984,7 +1978,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2020,19 +2014,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2040,19 +2034,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2076,17 +2070,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2102,7 +2096,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2129,11 +2123,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2144,10 +2138,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2159,11 +2153,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2173,7 +2167,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2252,7 +2246,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2265,7 +2259,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2359,11 +2353,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2373,7 +2367,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2383,7 +2377,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2393,7 +2387,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2418,7 +2412,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2427,7 +2421,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2437,13 +2431,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2454,7 +2448,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2462,11 +2456,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2482,7 +2476,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2507,16 +2501,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2528,7 +2522,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2552,7 +2546,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2572,7 +2566,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2580,7 +2574,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2588,23 +2582,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2612,23 +2606,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2648,7 +2642,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2660,19 +2654,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2680,19 +2674,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2736,7 +2730,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2768,7 +2762,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2786,11 +2780,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2798,15 +2792,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2948,7 +2942,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2973,7 +2967,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2991,7 +2985,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3000,7 +2994,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3034,7 +3028,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3091,7 +3085,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3126,7 +3120,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3134,17 +3128,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3156,8 +3150,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3175,12 +3169,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3194,7 +3188,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3206,35 +3200,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3242,19 +3236,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3433,11 +3427,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3453,7 +3447,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3489,7 +3483,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3497,11 +3491,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3533,7 +3527,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3541,15 +3535,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3557,7 +3551,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3567,11 +3561,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3584,15 +3578,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3600,7 +3594,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3619,15 +3613,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3706,31 +3700,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3738,15 +3732,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3754,11 +3748,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3794,7 +3788,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3806,7 +3800,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3829,17 +3823,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3888,13 +3882,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3920,8 +3914,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3930,14 +3924,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3947,41 +3941,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4007,18 +4001,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4038,7 +4032,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4063,7 +4057,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4118,11 +4112,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4134,12 +4128,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4152,11 +4146,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4168,9 +4162,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4197,11 +4191,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4211,67 +4205,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4301,20 +4295,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4336,12 +4330,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4349,19 +4343,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4387,7 +4381,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4404,7 +4398,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4416,7 +4410,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4427,6 +4421,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4459,7 +4457,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4467,29 +4465,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4510,7 +4508,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4518,11 +4516,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4539,14 +4537,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4560,7 +4558,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4583,32 +4581,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4625,7 +4623,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4638,22 +4636,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4751,7 +4749,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4787,7 +4785,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4795,7 +4793,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4803,7 +4801,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4842,45 +4840,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4894,7 +4892,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4902,11 +4900,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4914,23 +4912,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4942,7 +4940,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4950,19 +4948,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4970,7 +4968,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4978,11 +4976,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5003,23 +5001,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5041,7 +5039,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5068,7 +5066,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5087,7 +5085,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5100,7 +5098,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5109,7 +5107,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5129,7 +5127,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5159,20 +5157,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5180,11 +5178,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5197,23 +5195,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5226,7 +5224,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5273,11 +5271,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5286,11 +5284,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5299,11 +5297,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5312,11 +5310,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5338,11 +5336,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5351,15 +5349,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5368,11 +5366,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5420,7 +5418,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5448,19 +5446,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5468,23 +5466,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5520,7 +5518,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5528,7 +5526,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5589,23 +5587,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5613,23 +5611,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5663,7 +5661,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5691,7 +5689,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5703,7 +5701,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5743,7 +5741,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5751,7 +5749,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5760,7 +5758,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5852,7 +5850,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5875,11 +5873,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5901,14 +5899,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5924,7 +5922,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5962,7 +5960,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5976,11 +5974,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5999,7 +5997,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6014,22 +6012,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6039,22 +6037,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6080,7 +6078,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6097,12 +6095,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6118,11 +6116,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6150,11 +6148,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6169,7 +6167,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6218,24 +6216,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6254,7 +6252,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6265,7 +6263,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6273,21 +6271,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6301,7 +6299,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6315,8 +6313,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6331,7 +6329,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6345,7 +6343,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6365,27 +6363,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6397,19 +6395,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6425,19 +6423,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6445,23 +6443,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6490,21 +6488,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6513,7 +6511,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6546,7 +6544,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6560,15 +6558,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6604,7 +6602,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6628,9 +6626,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6650,7 +6648,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6666,11 +6664,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6678,11 +6676,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6702,48 +6700,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6778,8 +6776,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6789,7 +6787,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6875,11 +6873,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6946,24 +6944,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6971,70 +6969,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7060,19 +7058,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7185,8 +7183,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7202,11 +7200,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7214,28 +7212,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7243,31 +7241,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7291,19 +7289,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7371,13 +7369,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7386,7 +7384,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7570,7 +7568,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7578,7 +7576,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7587,7 +7585,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7595,7 +7593,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7604,7 +7602,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7612,7 +7610,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7626,7 +7624,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7638,7 +7636,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7657,13 +7655,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7671,13 +7669,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7787,7 +7785,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7799,7 +7797,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7836,11 +7834,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -103,7 +103,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -223,7 +223,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -275,7 +275,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,7 +316,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -330,7 +330,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -344,7 +344,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -406,7 +406,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -437,7 +437,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -468,7 +468,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -509,15 +509,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -546,11 +546,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -575,25 +575,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -605,23 +605,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -629,7 +629,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -637,11 +637,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -678,15 +678,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -745,7 +745,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -772,27 +772,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -830,7 +830,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,11 +849,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -884,14 +884,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -919,15 +919,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1037,7 +1037,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1074,17 +1074,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1102,63 +1102,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1177,20 +1177,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1226,13 +1226,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1301,7 +1301,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1345,21 +1345,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1374,27 +1374,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1474,15 +1474,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,23 +1490,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1542,16 +1542,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1569,7 +1569,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1581,11 +1581,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1625,15 +1625,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1641,23 +1641,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1687,15 +1687,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1719,51 +1719,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1784,8 +1784,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1798,11 +1798,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1839,12 +1839,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1860,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1913,19 +1907,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1933,7 +1927,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1941,7 +1935,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1950,7 +1944,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1958,7 +1952,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1972,7 +1966,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1980,7 +1974,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2016,19 +2010,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2036,19 +2030,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2072,17 +2066,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2098,7 +2092,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2125,11 +2119,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2140,10 +2134,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2155,11 +2149,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2169,7 +2163,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2248,7 +2242,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2261,7 +2255,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2355,11 +2349,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2369,7 +2363,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2379,7 +2373,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2389,7 +2383,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2414,7 +2408,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2423,7 +2417,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2433,13 +2427,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2450,7 +2444,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2458,11 +2452,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2478,7 +2472,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2503,16 +2497,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2524,7 +2518,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2548,7 +2542,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2568,7 +2562,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2576,7 +2570,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2584,23 +2578,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2608,23 +2602,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2644,7 +2638,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2656,19 +2650,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2676,19 +2670,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2732,7 +2726,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2764,7 +2758,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2782,11 +2776,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2794,15 +2788,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2944,7 +2938,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2969,7 +2963,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2987,7 +2981,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2996,7 +2990,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3030,7 +3024,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3087,7 +3081,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3122,7 +3116,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3130,17 +3124,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3152,8 +3146,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3171,12 +3165,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3190,7 +3184,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3202,35 +3196,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3238,19 +3232,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3429,11 +3423,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3449,7 +3443,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3485,7 +3479,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3493,11 +3487,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3529,7 +3523,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3537,15 +3531,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3553,7 +3547,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3563,11 +3557,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3580,15 +3574,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3596,7 +3590,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3615,15 +3609,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3702,31 +3696,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3734,15 +3728,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3750,11 +3744,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3790,7 +3784,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3802,7 +3796,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3825,17 +3819,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3884,13 +3878,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3916,8 +3910,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3926,14 +3920,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3943,41 +3937,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4003,18 +3997,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4034,7 +4028,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4059,7 +4053,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4114,11 +4108,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4130,12 +4124,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4148,11 +4142,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4164,9 +4158,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4193,11 +4187,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4207,67 +4201,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4297,20 +4291,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4332,12 +4326,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4345,19 +4339,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4383,7 +4377,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4400,7 +4394,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4412,7 +4406,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4423,6 +4417,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4455,7 +4453,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4463,29 +4461,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4506,7 +4504,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4514,11 +4512,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4535,14 +4533,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4556,7 +4554,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4579,32 +4577,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4621,7 +4619,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4634,22 +4632,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4747,7 +4745,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4783,7 +4781,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4791,7 +4789,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4799,7 +4797,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4838,45 +4836,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4890,7 +4888,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4898,11 +4896,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4910,23 +4908,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4938,7 +4936,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4946,19 +4944,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4966,7 +4964,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4974,11 +4972,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4999,23 +4997,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5037,7 +5035,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5064,7 +5062,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5083,7 +5081,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5096,7 +5094,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5105,7 +5103,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5125,7 +5123,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5155,20 +5153,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5176,11 +5174,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5193,23 +5191,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5222,7 +5220,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5269,11 +5267,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5282,11 +5280,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5295,11 +5293,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5308,11 +5306,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5334,11 +5332,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5347,15 +5345,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5364,11 +5362,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5416,7 +5414,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5444,19 +5442,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5464,23 +5462,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5516,7 +5514,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5524,7 +5522,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5585,23 +5583,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5609,23 +5607,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5659,7 +5657,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5687,7 +5685,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5699,7 +5697,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5739,7 +5737,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5747,7 +5745,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5756,7 +5754,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5848,7 +5846,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5871,11 +5869,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5897,14 +5895,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5920,7 +5918,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5958,7 +5956,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5972,11 +5970,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5995,7 +5993,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6010,22 +6008,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6035,22 +6033,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6076,7 +6074,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6093,12 +6091,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6114,11 +6112,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6146,11 +6144,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6165,7 +6163,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6214,24 +6212,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6250,7 +6248,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6261,7 +6259,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6269,21 +6267,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6297,7 +6295,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6311,8 +6309,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6327,7 +6325,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6341,7 +6339,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6361,27 +6359,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6393,19 +6391,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6421,19 +6419,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6441,23 +6439,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6486,21 +6484,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6509,7 +6507,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6542,7 +6540,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6556,15 +6554,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6600,7 +6598,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6624,9 +6622,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6646,7 +6644,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6662,11 +6660,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6674,11 +6672,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6698,48 +6696,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6774,8 +6772,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6785,7 +6783,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6871,11 +6869,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6942,24 +6940,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6967,70 +6965,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7056,19 +7054,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7181,8 +7179,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7198,11 +7196,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7210,28 +7208,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7239,31 +7237,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7287,19 +7285,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7367,13 +7365,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7382,7 +7380,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7566,7 +7564,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7574,7 +7572,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7583,7 +7581,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7591,7 +7589,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7600,7 +7598,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7608,7 +7606,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7622,7 +7620,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7634,7 +7632,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7653,13 +7651,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7667,13 +7665,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7783,7 +7781,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7795,7 +7793,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7832,11 +7830,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -107,7 +107,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -227,7 +227,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -320,7 +320,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -334,7 +334,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -410,7 +410,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -441,7 +441,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -513,15 +513,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -550,11 +550,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -562,7 +562,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -579,25 +579,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -609,23 +609,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -641,11 +641,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -682,15 +682,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -712,7 +712,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -749,7 +749,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -776,27 +776,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -834,7 +834,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -853,11 +853,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -888,14 +888,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -910,7 +910,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -923,15 +923,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -947,7 +947,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1078,17 +1078,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1106,63 +1106,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1181,20 +1181,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1222,7 +1222,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1230,13 +1230,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1349,21 +1349,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1378,27 +1378,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1478,15 +1478,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1494,23 +1494,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1546,16 +1546,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1585,11 +1585,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1629,15 +1629,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1645,23 +1645,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1677,7 +1677,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1691,15 +1691,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1723,51 +1723,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1788,8 +1788,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1802,11 +1802,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1843,12 +1843,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1864,7 +1858,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1917,19 +1911,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1937,7 +1931,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1945,7 +1939,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1954,7 +1948,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1962,7 +1956,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1976,7 +1970,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1984,7 +1978,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2020,19 +2014,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2040,19 +2034,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2076,17 +2070,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2102,7 +2096,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2129,11 +2123,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2144,10 +2138,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2159,11 +2153,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2173,7 +2167,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2252,7 +2246,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2265,7 +2259,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2359,11 +2353,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2373,7 +2367,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2383,7 +2377,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2393,7 +2387,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2418,7 +2412,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2427,7 +2421,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2437,13 +2431,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2454,7 +2448,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2462,11 +2456,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2482,7 +2476,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2507,16 +2501,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2528,7 +2522,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2552,7 +2546,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2572,7 +2566,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2580,7 +2574,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2588,23 +2582,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2612,23 +2606,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2648,7 +2642,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2660,19 +2654,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2680,19 +2674,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2736,7 +2730,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2768,7 +2762,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2786,11 +2780,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2798,15 +2792,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2948,7 +2942,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2973,7 +2967,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2991,7 +2985,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3000,7 +2994,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3034,7 +3028,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3091,7 +3085,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3126,7 +3120,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3134,17 +3128,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3156,8 +3150,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3175,12 +3169,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3194,7 +3188,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3206,35 +3200,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3242,19 +3236,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3433,11 +3427,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3453,7 +3447,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3489,7 +3483,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3497,11 +3491,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3533,7 +3527,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3541,15 +3535,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3557,7 +3551,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3567,11 +3561,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3584,15 +3578,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3600,7 +3594,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3619,15 +3613,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3706,31 +3700,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3738,15 +3732,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3754,11 +3748,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3794,7 +3788,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3806,7 +3800,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3829,17 +3823,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3888,13 +3882,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3920,8 +3914,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3930,14 +3924,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3947,41 +3941,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4007,18 +4001,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4038,7 +4032,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4063,7 +4057,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4118,11 +4112,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4134,12 +4128,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4152,11 +4146,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4168,9 +4162,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4197,11 +4191,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4211,67 +4205,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4301,20 +4295,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4336,12 +4330,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4349,19 +4343,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4387,7 +4381,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4404,7 +4398,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4416,7 +4410,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4427,6 +4421,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4459,7 +4457,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4467,29 +4465,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4510,7 +4508,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4518,11 +4516,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4539,14 +4537,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4560,7 +4558,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4583,32 +4581,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4625,7 +4623,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4638,22 +4636,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4751,7 +4749,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4787,7 +4785,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4795,7 +4793,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4803,7 +4801,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4842,45 +4840,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4894,7 +4892,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4902,11 +4900,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4914,23 +4912,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4942,7 +4940,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4950,19 +4948,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4970,7 +4968,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4978,11 +4976,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5003,23 +5001,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5041,7 +5039,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5068,7 +5066,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5087,7 +5085,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5100,7 +5098,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5109,7 +5107,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5129,7 +5127,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5159,20 +5157,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5180,11 +5178,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5197,23 +5195,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5226,7 +5224,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5273,11 +5271,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5286,11 +5284,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5299,11 +5297,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5312,11 +5310,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5338,11 +5336,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5351,15 +5349,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5368,11 +5366,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5420,7 +5418,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5448,19 +5446,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5468,23 +5466,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5520,7 +5518,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5528,7 +5526,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5589,23 +5587,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5613,23 +5611,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5663,7 +5661,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5691,7 +5689,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5703,7 +5701,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5743,7 +5741,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5751,7 +5749,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5760,7 +5758,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5852,7 +5850,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5875,11 +5873,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5901,14 +5899,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5924,7 +5922,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5962,7 +5960,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5976,11 +5974,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5999,7 +5997,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6014,22 +6012,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6039,22 +6037,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6080,7 +6078,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6097,12 +6095,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6118,11 +6116,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6150,11 +6148,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6169,7 +6167,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6218,24 +6216,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6254,7 +6252,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6265,7 +6263,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6273,21 +6271,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6301,7 +6299,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6315,8 +6313,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6331,7 +6329,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6345,7 +6343,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6365,27 +6363,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6397,19 +6395,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6425,19 +6423,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6445,23 +6443,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6490,21 +6488,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6513,7 +6511,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6546,7 +6544,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6560,15 +6558,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6604,7 +6602,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6628,9 +6626,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6650,7 +6648,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6666,11 +6664,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6678,11 +6676,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6702,48 +6700,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6778,8 +6776,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6789,7 +6787,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6875,11 +6873,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6946,24 +6944,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6971,70 +6969,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7060,19 +7058,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7185,8 +7183,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7202,11 +7200,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7214,28 +7212,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7243,31 +7241,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7291,19 +7289,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7371,13 +7369,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7386,7 +7384,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7570,7 +7568,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7578,7 +7576,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7587,7 +7585,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7595,7 +7593,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7604,7 +7602,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7612,7 +7610,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7626,7 +7624,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7638,7 +7636,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7657,13 +7655,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7671,13 +7669,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7787,7 +7785,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7799,7 +7797,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7836,11 +7834,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -151,7 +151,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -311,7 +311,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -339,7 +339,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -363,7 +363,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -440,7 +440,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -465,7 +465,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -490,7 +490,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -510,7 +510,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -531,7 +531,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -570,7 +570,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -601,7 +601,7 @@ msgstr "%s 不是一个目录"
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -648,7 +648,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -673,15 +673,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -710,11 +710,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -739,25 +739,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -769,23 +769,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -793,7 +793,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -842,15 +842,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -872,7 +872,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -936,27 +936,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1013,11 +1013,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -1048,14 +1048,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -1083,15 +1083,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -1107,7 +1107,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1188,7 +1188,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1238,17 +1238,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1257,7 +1257,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1266,63 +1266,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1341,20 +1341,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1390,13 +1390,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1465,7 +1465,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1481,7 +1481,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1509,21 +1509,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1538,27 +1538,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1638,15 +1638,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1654,23 +1654,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1687,7 +1687,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1697,7 +1697,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1706,16 +1706,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1733,7 +1733,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1745,11 +1745,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1789,15 +1789,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1805,23 +1805,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1851,15 +1851,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1883,51 +1883,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1948,8 +1948,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1962,11 +1962,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2003,12 +2003,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -2024,7 +2018,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2077,19 +2071,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2097,7 +2091,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2105,7 +2099,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -2114,7 +2108,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -2122,7 +2116,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2136,7 +2130,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2144,7 +2138,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2180,19 +2174,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2200,19 +2194,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2236,17 +2230,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2262,7 +2256,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2289,11 +2283,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2304,10 +2298,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2319,11 +2313,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2333,7 +2327,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2412,7 +2406,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2425,7 +2419,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2519,11 +2513,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2533,7 +2527,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2543,7 +2537,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2553,7 +2547,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2578,7 +2572,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2587,7 +2581,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2597,13 +2591,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2614,7 +2608,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2622,11 +2616,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2642,7 +2636,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2667,16 +2661,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2688,7 +2682,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2712,7 +2706,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2732,7 +2726,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2740,7 +2734,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2748,23 +2742,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2772,23 +2766,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2808,7 +2802,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2820,19 +2814,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2840,19 +2834,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2896,7 +2890,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2928,7 +2922,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2946,11 +2940,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2958,15 +2952,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -3108,7 +3102,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -3133,7 +3127,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3151,7 +3145,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3160,7 +3154,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3194,7 +3188,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3251,7 +3245,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3286,7 +3280,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3294,17 +3288,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3316,8 +3310,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3335,12 +3329,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3354,7 +3348,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3366,35 +3360,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3402,19 +3396,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3593,11 +3587,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3613,7 +3607,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3649,7 +3643,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3657,11 +3651,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3693,7 +3687,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3701,15 +3695,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3717,7 +3711,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3727,11 +3721,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3744,15 +3738,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3760,7 +3754,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3779,15 +3773,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3866,31 +3860,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3898,15 +3892,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3914,11 +3908,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3954,7 +3948,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3966,7 +3960,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3989,17 +3983,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4048,13 +4042,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -4080,8 +4074,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -4090,14 +4084,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -4107,41 +4101,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4167,18 +4161,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4198,7 +4192,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4223,7 +4217,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4278,11 +4272,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4294,12 +4288,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4312,11 +4306,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4328,9 +4322,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4357,11 +4351,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4371,67 +4365,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4461,20 +4455,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4496,12 +4490,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4509,19 +4503,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4547,7 +4541,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4564,7 +4558,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4576,7 +4570,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4587,6 +4581,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4619,7 +4617,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4627,29 +4625,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4670,7 +4668,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4678,11 +4676,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4699,14 +4697,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4720,7 +4718,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4743,32 +4741,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4785,7 +4783,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4798,22 +4796,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4911,7 +4909,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4947,7 +4945,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4955,7 +4953,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4963,7 +4961,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -5002,45 +5000,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -5054,7 +5052,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -5062,11 +5060,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5074,23 +5072,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -5102,7 +5100,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -5110,19 +5108,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -5130,7 +5128,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5138,11 +5136,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5163,23 +5161,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5201,7 +5199,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5228,7 +5226,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5247,7 +5245,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5260,7 +5258,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5269,7 +5267,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5289,7 +5287,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5319,20 +5317,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5340,11 +5338,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5357,23 +5355,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5386,7 +5384,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5433,11 +5431,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5446,11 +5444,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5459,11 +5457,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5472,11 +5470,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5498,11 +5496,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5511,15 +5509,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5528,11 +5526,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5580,7 +5578,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5608,19 +5606,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5628,23 +5626,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5680,7 +5678,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5688,7 +5686,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5749,23 +5747,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5773,23 +5771,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5823,7 +5821,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5863,7 +5861,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5903,7 +5901,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5911,7 +5909,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5920,7 +5918,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -6012,7 +6010,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6035,11 +6033,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6061,14 +6059,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -6084,7 +6082,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6122,7 +6120,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6136,11 +6134,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -6159,7 +6157,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6174,22 +6172,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6199,22 +6197,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6240,7 +6238,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6257,12 +6255,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6278,11 +6276,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6310,11 +6308,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6329,7 +6327,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6378,24 +6376,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6414,7 +6412,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6425,7 +6423,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6433,21 +6431,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6461,7 +6459,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6475,8 +6473,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6491,7 +6489,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6505,7 +6503,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6525,27 +6523,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6557,19 +6555,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6585,19 +6583,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6605,23 +6603,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6650,21 +6648,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6673,7 +6671,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6706,7 +6704,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6720,15 +6718,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6764,7 +6762,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6788,9 +6786,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6810,7 +6808,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6826,11 +6824,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6838,11 +6836,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6862,48 +6860,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6938,8 +6936,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6949,7 +6947,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -7035,11 +7033,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -7106,24 +7104,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7131,70 +7129,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7220,19 +7218,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7345,8 +7343,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7362,11 +7360,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7374,28 +7372,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7403,31 +7401,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7451,19 +7449,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7531,13 +7529,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7546,7 +7544,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7730,7 +7728,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7738,7 +7736,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7747,7 +7745,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7755,7 +7753,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7764,7 +7762,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7772,7 +7770,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7786,7 +7784,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7798,7 +7796,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7817,13 +7815,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7831,13 +7829,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7947,7 +7945,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7959,7 +7957,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7996,11 +7994,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-29 07:41-0600\n"
+"POT-Creation-Date: 2025-05-08 12:32-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -106,7 +106,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:426
+#: lxc/cluster_group.go:427
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -226,7 +226,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:626
+#: lxc/network_acl.go:627
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:676
+#: lxc/network_forward.go:677
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:638
+#: lxc/network_load_balancer.go:639
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -319,7 +319,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:1257
+#: lxc/network_zone.go:1258
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,7 +333,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:561
+#: lxc/network_zone.go:562
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:684
+#: lxc/network.go:685
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -367,7 +367,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:528
+#: lxc/profile.go:529
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:288
+#: lxc/project.go:289
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:795
+#: lxc/cluster.go:796
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -440,7 +440,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:154 lxc/profile.go:262
+#: lxc/cluster_group.go:155 lxc/profile.go:263
 msgid "(none)"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:146 lxc/rebuild.go:65
+#: lxc/init.go:150 lxc/rebuild.go:77
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr ""
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: lxc/query.go:72
+#: lxc/query.go:73
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:951 lxc/remote.go:1016
+#: lxc/remote.go:952 lxc/remote.go:1017
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1065
+#: lxc/remote.go:1066
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:870
+#: lxc/remote.go:871
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -549,11 +549,11 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
+#: lxc/cluster.go:196 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:852
+#: lxc/remote.go:853
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Accept certificate"
 msgstr ""
 
@@ -578,25 +578,25 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:263 lxc/warning.go:264
 msgid "Acknowledge warning"
 msgstr ""
 
-#: lxc/query.go:43
+#: lxc/query.go:44
 msgid "Action"
 msgstr ""
 
-#: lxc/query.go:76
+#: lxc/query.go:77
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: lxc/project.go:106
+#: lxc/project.go:107
 msgid ""
 "Add a NIC device to the default profile connected to the specified network"
 msgstr ""
 
-#: lxc/cluster_group.go:735
+#: lxc/cluster_group.go:736
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add a group to an identity provider group"
 msgstr ""
 
-#: lxc/network_zone.go:1442
+#: lxc/network_zone.go:1443
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/project.go:105
+#: lxc/project.go:106
 msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
-#: lxc/network_load_balancer.go:860
+#: lxc/network_load_balancer.go:861
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:860
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1443
+#: lxc/network_zone.go:1444
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:734
+#: lxc/cluster_group.go:735
 msgid "Add member to group"
 msgstr ""
 
@@ -640,11 +640,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:92
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -681,15 +681,15 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:897 lxc/network_forward.go:898
+#: lxc/network_forward.go:898 lxc/network_forward.go:899
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1049
+#: lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1050
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:109 lxc/profile.go:110
+#: lxc/profile.go:110 lxc/profile.go:111
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:877 lxc/network_acl.go:878
+#: lxc/network_acl.go:878 lxc/network_acl.go:879
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:680
+#: lxc/remote.go:681
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:194
+#: lxc/remote.go:195
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1384
+#: lxc/cluster.go:1385
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -775,27 +775,27 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:348 lxc/rebuild.go:131
+#: lxc/init.go:352 lxc/rebuild.go:143
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:85
+#: lxc/cluster_group.go:85 lxc/cluster_group.go:86
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:189 lxc/profile.go:190
+#: lxc/profile.go:190 lxc/profile.go:191
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:135
+#: lxc/network.go:136
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:237 lxc/network.go:238
+#: lxc/network.go:238 lxc/network.go:239
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:136
+#: lxc/network.go:137
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:635
+#: lxc/remote.go:636
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,11 +852,11 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:266 lxc/network_load_balancer.go:268
+#: lxc/network_forward.go:267 lxc/network_load_balancer.go:269
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:138
 msgid "Available projects:"
 msgstr ""
 
@@ -887,14 +887,14 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:376 lxc/network_acl.go:449 lxc/network_forward.go:327
-#: lxc/network_load_balancer.go:322 lxc/network_peer.go:309
-#: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:377 lxc/network_acl.go:450 lxc/network_forward.go:328
+#: lxc/network_load_balancer.go:323 lxc/network_peer.go:309
+#: lxc/network_zone.go:385 lxc/network_zone.go:1072 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:245 lxc/move.go:400 lxc/project.go:168
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:963
 msgid "Bond:"
 msgstr ""
 
@@ -922,15 +922,15 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:975
+#: lxc/network.go:976
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:589 lxc/network.go:954
+#: lxc/info.go:589 lxc/network.go:955
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:590 lxc/network.go:955
+#: lxc/info.go:590 lxc/network.go:956
 msgid "Bytes sent"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "COUNT"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:995
+#: lxc/remote.go:996
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:173
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:947
+#: lxc/network_acl.go:948
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1077,17 +1077,17 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:523
+#: lxc/remote.go:524
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/network.go:996
+#: lxc/network.go:997
 msgid "Chassis"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:721
+#: lxc/remote.go:722
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1105,63 +1105,63 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:243
+#: lxc/cluster_group.go:244
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:304
+#: lxc/cluster_group.go:305
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:579
+#: lxc/cluster_group.go:580
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:656
+#: lxc/cluster_group.go:657
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1160
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:158
+#: lxc/cluster_group.go:159
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:797
+#: lxc/cluster_group.go:798
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:786
+#: lxc/cluster_group.go:787
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: lxc/cluster_group.go:599
+#: lxc/cluster_group.go:600
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:67 lxc/network.go:335 lxc/network.go:806 lxc/network.go:887
-#: lxc/network.go:1022 lxc/network.go:1288 lxc/network.go:1381
-#: lxc/network.go:1453 lxc/network_forward.go:183 lxc/network_forward.go:265
-#: lxc/network_forward.go:506 lxc/network_forward.go:658
-#: lxc/network_forward.go:812 lxc/network_forward.go:901
-#: lxc/network_forward.go:987 lxc/network_load_balancer.go:185
-#: lxc/network_load_balancer.go:267 lxc/network_load_balancer.go:485
-#: lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775
-#: lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939
-#: lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126
+#: lxc/move.go:67 lxc/network.go:336 lxc/network.go:807 lxc/network.go:888
+#: lxc/network.go:1023 lxc/network.go:1289 lxc/network.go:1382
+#: lxc/network.go:1454 lxc/network_forward.go:184 lxc/network_forward.go:266
+#: lxc/network_forward.go:507 lxc/network_forward.go:659
+#: lxc/network_forward.go:813 lxc/network_forward.go:902
+#: lxc/network_forward.go:988 lxc/network_load_balancer.go:186
+#: lxc/network_load_balancer.go:268 lxc/network_load_balancer.go:486
+#: lxc/network_load_balancer.go:621 lxc/network_load_balancer.go:776
+#: lxc/network_load_balancer.go:864 lxc/network_load_balancer.go:940
+#: lxc/network_load_balancer.go:1053 lxc/network_load_balancer.go:1127
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
 #: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
 #: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
@@ -1180,20 +1180,20 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:899
+#: lxc/cluster.go:900
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:761
+#: lxc/cluster.go:762
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:734
-#: lxc/storage_volume.go:1621 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:735
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:104
+#: lxc/project.go:105
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1229,13 +1229,13 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:402 lxc/config.go:322
+#: lxc/cluster.go:865 lxc/cluster_group.go:403 lxc/config.go:322
 #: lxc/config.go:397 lxc/config.go:1380 lxc/config_metadata.go:156
-#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:769
-#: lxc/network_acl.go:716 lxc/network_forward.go:776
-#: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
-#: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:610
-#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/config_trust.go:312 lxc/image.go:492 lxc/network.go:770
+#: lxc/network_acl.go:717 lxc/network_forward.go:777
+#: lxc/network_load_balancer.go:740 lxc/network_peer.go:699
+#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
+#: lxc/project.go:371 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1145 lxc/storage_volume.go:1179
 #: lxc/storage_volume.go:1211
 #, c-format
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:285 lxc/profile.go:286
+#: lxc/profile.go:286 lxc/profile.go:287
 msgid "Copy profiles"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:288
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:289
 #: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1348,21 +1348,21 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:573
+#: lxc/remote.go:574
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:557
+#: lxc/remote.go:238 lxc/remote.go:558
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1241
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1377,27 +1377,27 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1254
+#: lxc/cluster.go:1255
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:568
+#: lxc/remote.go:569
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1554
+#: lxc/network_zone.go:1555
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Create a TLS identity"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:175
+#: lxc/cluster_group.go:175 lxc/cluster_group.go:176
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1477,15 +1477,15 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:381 lxc/network_acl.go:382
+#: lxc/network_acl.go:382 lxc/network_acl.go:383
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:256 lxc/network_forward.go:257
+#: lxc/network_forward.go:257 lxc/network_forward.go:258
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:259
+#: lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:260
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1493,23 +1493,23 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:1002 lxc/network_zone.go:1003
+#: lxc/network_zone.go:1003 lxc/network_zone.go:1004
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:318 lxc/network_zone.go:319
+#: lxc/network_zone.go:319 lxc/network_zone.go:320
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:327 lxc/network.go:328
+#: lxc/network.go:328 lxc/network.go:329
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:367 lxc/profile.go:368
+#: lxc/profile.go:368 lxc/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:96 lxc/project.go:97
+#: lxc/project.go:97 lxc/project.go:98
 msgid "Create projects"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:190
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:188
 msgid "Creating the instance"
 msgstr ""
 
@@ -1545,16 +1545,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:159
+#: lxc/network_forward.go:160
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:509
-#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1119
-#: lxc/network_acl.go:171 lxc/network_forward.go:158
-#: lxc/network_load_balancer.go:161 lxc/network_peer.go:149
-#: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:760 lxc/project.go:580 lxc/storage.go:723
+#: lxc/auth.go:380 lxc/cluster.go:198 lxc/cluster_group.go:510
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1120
+#: lxc/network_acl.go:172 lxc/network_forward.go:159
+#: lxc/network_load_balancer.go:162 lxc/network_peer.go:149
+#: lxc/network_zone.go:163 lxc/network_zone.go:847 lxc/operation.go:173
+#: lxc/profile.go:761 lxc/project.go:581 lxc/storage.go:723
 #: lxc/storage_bucket.go:528 lxc/storage_bucket.go:852
 #: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:979
+#: lxc/network.go:980
 msgid "Default VLAN ID"
 msgstr ""
 
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:260 lxc/cluster_group.go:261
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:362
 msgid "Delete all warnings"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:805 lxc/network_acl.go:806
+#: lxc/network_acl.go:806 lxc/network_acl.go:807
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:808 lxc/network_forward.go:809
+#: lxc/network_forward.go:809 lxc/network_forward.go:810
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:773
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1366 lxc/network_zone.go:1367
+#: lxc/network_zone.go:1367 lxc/network_zone.go:1368
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:671 lxc/network_zone.go:672
+#: lxc/network_zone.go:672 lxc/network_zone.go:673
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:414 lxc/network.go:415
+#: lxc/network.go:415 lxc/network.go:416
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:449 lxc/profile.go:450
+#: lxc/profile.go:450 lxc/profile.go:451
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:196 lxc/project.go:197
+#: lxc/project.go:197 lxc/project.go:198
 msgid "Delete projects"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:358 lxc/warning.go:359
 msgid "Delete warning"
 msgstr ""
 
@@ -1690,15 +1690,15 @@ msgstr ""
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
 #: lxc/auth.go:1644 lxc/auth.go:1682 lxc/auth.go:1734 lxc/auth.go:1783
 #: lxc/auth.go:1902 lxc/auth.go:1962 lxc/auth.go:2011 lxc/auth.go:2062
-#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:30 lxc/cluster.go:123
-#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
-#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
-#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1341
-#: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:175
-#: lxc/cluster_group.go:261 lxc/cluster_group.go:321 lxc/cluster_group.go:445
-#: lxc/cluster_group.go:527 lxc/cluster_group.go:617 lxc/cluster_group.go:673
-#: lxc/cluster_group.go:735 lxc/cluster_role.go:24 lxc/cluster_role.go:51
+#: lxc/auth.go:2085 lxc/auth.go:2138 lxc/cluster.go:31 lxc/cluster.go:124
+#: lxc/cluster.go:216 lxc/cluster.go:273 lxc/cluster.go:332 lxc/cluster.go:405
+#: lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682
+#: lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093
+#: lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342
+#: lxc/cluster_group.go:32 lxc/cluster_group.go:86 lxc/cluster_group.go:176
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:322 lxc/cluster_group.go:446
+#: lxc/cluster_group.go:528 lxc/cluster_group.go:618 lxc/cluster_group.go:674
+#: lxc/cluster_group.go:736 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434
 #: lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996
 #: lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213
@@ -1722,51 +1722,51 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:84 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
-#: lxc/network.go:238 lxc/network.go:328 lxc/network.go:415 lxc/network.go:473
-#: lxc/network.go:570 lxc/network.go:667 lxc/network.go:803 lxc/network.go:884
-#: lxc/network.go:1017 lxc/network.go:1143 lxc/network.go:1222
-#: lxc/network.go:1282 lxc/network.go:1378 lxc/network.go:1450
-#: lxc/network_acl.go:30 lxc/network_acl.go:96 lxc/network_acl.go:192
-#: lxc/network_acl.go:253 lxc/network_acl.go:309 lxc/network_acl.go:382
-#: lxc/network_acl.go:479 lxc/network_acl.go:567 lxc/network_acl.go:610
-#: lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863
-#: lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:53
-#: lxc/network_forward.go:34 lxc/network_forward.go:91
-#: lxc/network_forward.go:180 lxc/network_forward.go:257
-#: lxc/network_forward.go:413 lxc/network_forward.go:498
-#: lxc/network_forward.go:608 lxc/network_forward.go:655
-#: lxc/network_forward.go:809 lxc/network_forward.go:883
-#: lxc/network_forward.go:898 lxc/network_forward.go:983
-#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:95
-#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:477
-#: lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617
-#: lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845
-#: lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936
-#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049
-#: lxc/network_load_balancer.go:1122 lxc/network_peer.go:29
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:34 lxc/network.go:137
+#: lxc/network.go:239 lxc/network.go:329 lxc/network.go:416 lxc/network.go:474
+#: lxc/network.go:571 lxc/network.go:668 lxc/network.go:804 lxc/network.go:885
+#: lxc/network.go:1018 lxc/network.go:1144 lxc/network.go:1223
+#: lxc/network.go:1283 lxc/network.go:1379 lxc/network.go:1451
+#: lxc/network_acl.go:31 lxc/network_acl.go:97 lxc/network_acl.go:193
+#: lxc/network_acl.go:254 lxc/network_acl.go:310 lxc/network_acl.go:383
+#: lxc/network_acl.go:480 lxc/network_acl.go:568 lxc/network_acl.go:611
+#: lxc/network_acl.go:750 lxc/network_acl.go:807 lxc/network_acl.go:864
+#: lxc/network_acl.go:879 lxc/network_acl.go:1017 lxc/network_allocations.go:53
+#: lxc/network_forward.go:35 lxc/network_forward.go:92
+#: lxc/network_forward.go:181 lxc/network_forward.go:258
+#: lxc/network_forward.go:414 lxc/network_forward.go:499
+#: lxc/network_forward.go:609 lxc/network_forward.go:656
+#: lxc/network_forward.go:810 lxc/network_forward.go:884
+#: lxc/network_forward.go:899 lxc/network_forward.go:984
+#: lxc/network_load_balancer.go:35 lxc/network_load_balancer.go:96
+#: lxc/network_load_balancer.go:183 lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:410 lxc/network_load_balancer.go:478
+#: lxc/network_load_balancer.go:588 lxc/network_load_balancer.go:618
+#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861 lxc/network_load_balancer.go:937
+#: lxc/network_load_balancer.go:1035 lxc/network_load_balancer.go:1050
+#: lxc/network_load_balancer.go:1123 lxc/network_peer.go:29
 #: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
 #: lxc/network_peer.go:361 lxc/network_peer.go:446 lxc/network_peer.go:548
-#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:29
-#: lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246
-#: lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502
-#: lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728
-#: lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927
-#: lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190
-#: lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428
-#: lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25
+#: lxc/network_peer.go:595 lxc/network_peer.go:732 lxc/network_zone.go:30
+#: lxc/network_zone.go:88 lxc/network_zone.go:184 lxc/network_zone.go:247
+#: lxc/network_zone.go:320 lxc/network_zone.go:415 lxc/network_zone.go:503
+#: lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729
+#: lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928
+#: lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1191
+#: lxc/network_zone.go:1238 lxc/network_zone.go:1368 lxc/network_zone.go:1429
+#: lxc/network_zone.go:1444 lxc/network_zone.go:1502 lxc/operation.go:25
 #: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
-#: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:190 lxc/profile.go:286
-#: lxc/profile.go:368 lxc/profile.go:450 lxc/profile.go:508 lxc/profile.go:644
-#: lxc/profile.go:720 lxc/profile.go:877 lxc/profile.go:970 lxc/profile.go:1030
-#: lxc/profile.go:1119 lxc/profile.go:1183 lxc/project.go:31 lxc/project.go:97
-#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
-#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
-#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
-#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
-#: lxc/remote.go:1067 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
+#: lxc/profile.go:36 lxc/profile.go:111 lxc/profile.go:191 lxc/profile.go:287
+#: lxc/profile.go:369 lxc/profile.go:451 lxc/profile.go:509 lxc/profile.go:645
+#: lxc/profile.go:721 lxc/profile.go:878 lxc/profile.go:971 lxc/profile.go:1031
+#: lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:32 lxc/project.go:98
+#: lxc/project.go:198 lxc/project.go:269 lxc/project.go:405 lxc/project.go:479
+#: lxc/project.go:599 lxc/project.go:664 lxc/project.go:752 lxc/project.go:796
+#: lxc/project.go:857 lxc/project.go:924 lxc/publish.go:34 lxc/query.go:35
+#: lxc/rebuild.go:28 lxc/remote.go:36 lxc/remote.go:92 lxc/remote.go:750
+#: lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019
+#: lxc/remote.go:1068 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:2106 lxc/storage_volume.go:2264
 #: lxc/storage_volume.go:2385 lxc/storage_volume.go:2447
 #: lxc/storage_volume.go:2583 lxc/storage_volume.go:2667
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:473
+#: lxc/network.go:473 lxc/network.go:474
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:569 lxc/network.go:570
+#: lxc/network.go:570 lxc/network.go:571
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1842,12 +1842,6 @@ msgstr ""
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:795
-msgid ""
-"Device from profile(s) cannot be modified for individual instance. Override "
-"device or modify profile instead"
-msgstr ""
-
 #: lxc/config_device.go:658
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
@@ -1863,7 +1857,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:408
+#: lxc/init.go:412
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1916,19 +1910,19 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/network_acl.go:100
+#: lxc/network_acl.go:101
 msgid "Display network ACLs from all projects"
 msgstr ""
 
-#: lxc/network_zone.go:91
+#: lxc/network_zone.go:92
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1024
 msgid "Display networks from all projects"
 msgstr ""
 
-#: lxc/profile.go:738
+#: lxc/profile.go:739
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -1936,7 +1930,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: lxc/cluster.go:595
+#: lxc/cluster.go:596
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1944,7 +1938,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:967
 msgid "Down delay"
 msgstr ""
 
@@ -1953,7 +1947,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:847
+#: lxc/network_zone.go:848
 msgid "ENTRIES"
 msgstr ""
 
@@ -1961,7 +1955,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1076 lxc/config_trust.go:514
+#: lxc/cluster.go:1077 lxc/config_trust.go:514
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1975,7 +1969,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:320 lxc/cluster_group.go:321
+#: lxc/cluster_group.go:321 lxc/cluster_group.go:322
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1983,7 +1977,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:774 lxc/cluster.go:775
+#: lxc/cluster.go:775 lxc/cluster.go:776
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2019,19 +2013,19 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:609 lxc/network_acl.go:610
+#: lxc/network_acl.go:610 lxc/network_acl.go:611
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:666 lxc/network.go:667
+#: lxc/network.go:667 lxc/network.go:668
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:654 lxc/network_forward.go:655
+#: lxc/network_forward.go:655 lxc/network_forward.go:656
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:617
+#: lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:618
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2039,19 +2033,19 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:544 lxc/network_zone.go:545
+#: lxc/network_zone.go:545 lxc/network_zone.go:546
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:1236 lxc/network_zone.go:1237
+#: lxc/network_zone.go:1237 lxc/network_zone.go:1238
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:507 lxc/profile.go:508
+#: lxc/profile.go:508 lxc/profile.go:509
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:267 lxc/project.go:268
+#: lxc/project.go:268 lxc/project.go:269
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2075,17 +2069,17 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:776
-#: lxc/storage_volume.go:1798 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:777
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:680
+#: lxc/cluster.go:681
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:681
+#: lxc/cluster.go:682
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,7 +2095,7 @@ msgid ""
 "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
-#: lxc/network_zone.go:1445
+#: lxc/network_zone.go:1446
 msgid "Entry TTL"
 msgstr ""
 
@@ -2128,11 +2122,11 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1356
-#: lxc/network_acl.go:542 lxc/network_forward.go:581
-#: lxc/network_load_balancer.go:560 lxc/network_peer.go:523
-#: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1097
-#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:622
+#: lxc/cluster.go:464 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1357
+#: lxc/network_acl.go:543 lxc/network_forward.go:582
+#: lxc/network_load_balancer.go:561 lxc/network_peer.go:523
+#: lxc/network_zone.go:478 lxc/network_zone.go:1166 lxc/profile.go:1098
+#: lxc/project.go:727 lxc/storage.go:812 lxc/storage_bucket.go:622
 #: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
@@ -2143,10 +2137,10 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:457 lxc/network.go:1350 lxc/network_acl.go:536
-#: lxc/network_forward.go:575 lxc/network_load_balancer.go:554
-#: lxc/network_peer.go:517 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1091 lxc/project.go:720 lxc/storage.go:806
+#: lxc/cluster.go:458 lxc/network.go:1351 lxc/network_acl.go:537
+#: lxc/network_forward.go:576 lxc/network_load_balancer.go:555
+#: lxc/network_peer.go:517 lxc/network_zone.go:472 lxc/network_zone.go:1160
+#: lxc/profile.go:1092 lxc/project.go:721 lxc/storage.go:806
 #: lxc/storage_bucket.go:616 lxc/storage_volume.go:2191
 #: lxc/storage_volume.go:2229
 #, c-format
@@ -2158,11 +2152,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1304
+#: lxc/cluster.go:1305
 msgid ""
 "Evacuate cluster member\n"
 "\n"
@@ -2172,7 +2166,7 @@ msgid ""
 " - live-migrate: live migrate all instances on the member to other members\n"
 msgstr ""
 
-#: lxc/cluster.go:1409
+#: lxc/cluster.go:1416
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2251,7 +2245,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:196
+#: lxc/cluster.go:197
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2264,7 +2258,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "FIRST SEEN"
 msgstr ""
 
@@ -2358,11 +2352,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:203
+#: lxc/remote.go:204
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:255
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2372,7 +2366,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:244
+#: lxc/remote.go:245
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2382,7 +2376,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:500
+#: lxc/remote.go:501
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
@@ -2392,7 +2386,7 @@ msgstr ""
 msgid "Failed to find image %q on remote %q"
 msgstr ""
 
-#: lxc/remote.go:306
+#: lxc/remote.go:307
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:249
+#: lxc/remote.go:250
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2426,7 +2420,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/network_acl.go:135 lxc/network_zone.go:126
+#: lxc/network.go:1059 lxc/network_acl.go:136 lxc/network_zone.go:127
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2436,13 +2430,13 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1314
+#: lxc/cluster.go:1315
 msgid ""
 "Force a particular instance evacuation action. One of stop, migrate or live-"
 "migrate"
 msgstr ""
 
-#: lxc/cluster.go:1344
+#: lxc/cluster.go:1345
 msgid ""
 "Force a particular instance restore action. Use \"skip\" to restore only the "
 "cluster member status without starting local instances or migrating back "
@@ -2453,7 +2447,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1313
+#: lxc/cluster.go:1314
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2461,11 +2455,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:594
+#: lxc/cluster.go:595
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1343
+#: lxc/cluster.go:1344
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2481,7 +2475,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:611
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2506,16 +2500,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1906
-#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:447
+#: lxc/cluster.go:126 lxc/cluster.go:984 lxc/cluster_group.go:448
 #: lxc/config_template.go:275 lxc/config_trust.go:350 lxc/config_trust.go:432
-#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1021
-#: lxc/network.go:1145 lxc/network_acl.go:99 lxc/network_allocations.go:59
-#: lxc/network_forward.go:94 lxc/network_load_balancer.go:98
-#: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:737 lxc/project.go:480
-#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1022
+#: lxc/network.go:1146 lxc/network_acl.go:100 lxc/network_allocations.go:59
+#: lxc/network_forward.go:95 lxc/network_load_balancer.go:99
+#: lxc/network_peer.go:85 lxc/network_zone.go:91 lxc/network_zone.go:789
+#: lxc/operation.go:109 lxc/profile.go:738 lxc/project.go:481
+#: lxc/project.go:926 lxc/remote.go:792 lxc/storage.go:657
 #: lxc/storage_bucket.go:462 lxc/storage_bucket.go:794
-#: lxc/storage_volume.go:1640 lxc/warning.go:94
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2527,7 +2521,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:978
+#: lxc/network.go:979
 msgid "Forward delay"
 msgstr ""
 
@@ -2551,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:856
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:457
+#: lxc/remote.go:166 lxc/remote.go:458
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2579,7 +2573,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:922 lxc/project.go:923
+#: lxc/project.go:923 lxc/project.go:924
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2587,23 +2581,23 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:883 lxc/network.go:884
+#: lxc/network.go:884 lxc/network.go:885
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:333
+#: lxc/cluster.go:334
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:311
+#: lxc/network_acl.go:312
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:415
+#: lxc/network_forward.go:416
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:413
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2611,23 +2605,23 @@ msgstr ""
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:807
+#: lxc/network.go:808
 msgid "Get the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:249
+#: lxc/network_zone.go:250
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:930
+#: lxc/network_zone.go:931
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:649
+#: lxc/profile.go:650
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:408
+#: lxc/project.go:409
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2647,7 +2641,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2659,19 +2653,19 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:308 lxc/network_acl.go:309
+#: lxc/network_acl.go:309 lxc/network_acl.go:310
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:802 lxc/network.go:803
+#: lxc/network.go:803 lxc/network.go:804
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:412 lxc/network_forward.go:413
+#: lxc/network_forward.go:413 lxc/network_forward.go:414
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:409 lxc/network_load_balancer.go:410
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2679,19 +2673,19 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:245 lxc/network_zone.go:246
+#: lxc/network_zone.go:246 lxc/network_zone.go:247
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:926 lxc/network_zone.go:927
+#: lxc/network_zone.go:927 lxc/network_zone.go:928
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:643 lxc/profile.go:644
+#: lxc/profile.go:644 lxc/profile.go:645
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:403 lxc/project.go:404
+#: lxc/project.go:404 lxc/project.go:405
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2735,7 +2729,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1198
+#: lxc/network.go:1199
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2767,7 +2761,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:976 lxc/operation.go:171
+#: lxc/network.go:977 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2785,11 +2779,11 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:574
+#: lxc/project.go:575
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1200
+#: lxc/network.go:1201
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2797,15 +2791,15 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:945
+#: lxc/network.go:946
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1117
+#: lxc/list.go:560 lxc/network.go:1118
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1118
+#: lxc/list.go:561 lxc/network.go:1119
 msgid "IPV6"
 msgstr ""
 
@@ -2947,7 +2941,7 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:44
+#: lxc/query.go:45
 msgid "Input data"
 msgstr ""
 
@@ -2972,7 +2966,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:419
+#: lxc/init.go:423
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2990,7 +2984,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:87
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2999,7 +2993,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:409
+#: lxc/remote.go:410
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3033,7 +3027,7 @@ msgstr ""
 msgid "Invalid export version %q: %w"
 msgstr ""
 
-#: lxc/monitor.go:71
+#: lxc/monitor.go:79
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3090,7 +3084,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3125,7 +3119,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3133,17 +3127,17 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:1000
+#: lxc/project.go:1001
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:157 lxc/network_load_balancer.go:160
+#: lxc/network_forward.go:158 lxc/network_load_balancer.go:161
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1205 lxc/network_forward.go:164
-#: lxc/network_load_balancer.go:166 lxc/operation.go:178
-#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1206 lxc/network_forward.go:165
+#: lxc/network_load_balancer.go:167 lxc/operation.go:178
+#: lxc/storage_bucket.go:532 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3155,8 +3149,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
-#: lxc/cluster.go:1236 lxc/cluster_group.go:490
+#: lxc/cluster.go:168 lxc/cluster.go:1026 lxc/cluster.go:1129
+#: lxc/cluster.go:1237 lxc/cluster_group.go:491
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3174,12 +3168,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:182
 msgid "Launching the instance"
 msgstr ""
 
@@ -3193,7 +3187,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1142 lxc/network.go:1143
+#: lxc/network.go:1143 lxc/network.go:1144
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3205,35 +3199,35 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:981 lxc/cluster.go:982
+#: lxc/cluster.go:982 lxc/cluster.go:983
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:444 lxc/cluster_group.go:445
+#: lxc/cluster_group.go:445 lxc/cluster_group.go:446
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:123 lxc/cluster.go:124
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:96
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:96
+#: lxc/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:90 lxc/network_forward.go:91
+#: lxc/network_forward.go:91 lxc/network_forward.go:92
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:95
+#: lxc/network_load_balancer.go:95 lxc/network_load_balancer.go:96
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3241,19 +3235,19 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:87
+#: lxc/network_zone.go:88
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:784 lxc/network_zone.go:785
+#: lxc/network_zone.go:785 lxc/network_zone.go:786
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:87
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1016 lxc/network.go:1017
+#: lxc/network.go:1017 lxc/network.go:1018
 msgid "List available networks"
 msgstr ""
 
@@ -3432,11 +3426,11 @@ msgstr ""
 msgid "List permissions"
 msgstr ""
 
-#: lxc/profile.go:719
+#: lxc/profile.go:720
 msgid "List profiles"
 msgstr ""
 
-#: lxc/profile.go:720
+#: lxc/profile.go:721
 msgid ""
 "List profiles\n"
 "\n"
@@ -3452,7 +3446,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:477 lxc/project.go:478
+#: lxc/project.go:478 lxc/project.go:479
 msgid "List projects"
 msgstr ""
 
@@ -3488,7 +3482,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:786 lxc/remote.go:787
+#: lxc/remote.go:787 lxc/remote.go:788
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,11 +3490,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:73
 msgid ""
 "List warnings\n"
 "\n"
@@ -3532,7 +3526,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:80
+#: lxc/monitor.go:88
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3540,15 +3534,15 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:988
+#: lxc/network.go:989
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:969
+#: lxc/network.go:970
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1199
+#: lxc/network.go:1200
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3556,7 +3550,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -3566,11 +3560,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1116
+#: lxc/network.go:1117
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:510
+#: lxc/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -3583,15 +3577,15 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:199
+#: lxc/cluster.go:200
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:967
+#: lxc/network.go:968
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:968
+#: lxc/network.go:969
 msgid "MII state"
 msgstr ""
 
@@ -3599,7 +3593,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -3618,15 +3612,15 @@ msgid ""
 "got "
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:33 lxc/network.go:34
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:30 lxc/cluster_group.go:31
+#: lxc/cluster_group.go:31 lxc/cluster_group.go:32
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:30 lxc/cluster.go:31
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3705,31 +3699,31 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:862 lxc/network_acl.go:863
+#: lxc/network_acl.go:863 lxc/network_acl.go:864
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:30 lxc/network_acl.go:31
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:882 lxc/network_forward.go:883
+#: lxc/network_forward.go:883 lxc/network_forward.go:884
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:33 lxc/network_forward.go:34
+#: lxc/network_forward.go:34 lxc/network_forward.go:35
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:846
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1034
+#: lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1035
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:34
+#: lxc/network_load_balancer.go:34 lxc/network_load_balancer.go:35
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3737,15 +3731,15 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1427 lxc/network_zone.go:1428
+#: lxc/network_zone.go:1428 lxc/network_zone.go:1429
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:727 lxc/network_zone.go:728
+#: lxc/network_zone.go:728 lxc/network_zone.go:729
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:29 lxc/network_zone.go:30
 msgid "Manage network zones"
 msgstr ""
 
@@ -3753,11 +3747,11 @@ msgstr ""
 msgid "Manage permissions"
 msgstr ""
 
-#: lxc/profile.go:34 lxc/profile.go:35
+#: lxc/profile.go:35 lxc/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3793,7 +3787,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:34 lxc/remote.go:35
+#: lxc/remote.go:35 lxc/remote.go:36
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3805,7 +3799,7 @@ msgstr ""
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:30 lxc/warning.go:31
 msgid "Manage warnings"
 msgstr ""
 
@@ -3828,17 +3822,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:963
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:665
+#: lxc/cluster.go:666
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:570
+#: lxc/cluster.go:571
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3887,13 +3881,13 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:228 lxc/cluster_group.go:294 lxc/cluster_group.go:354
-#: lxc/cluster_group.go:706
+#: lxc/cluster_group.go:229 lxc/cluster_group.go:295 lxc/cluster_group.go:355
+#: lxc/cluster_group.go:707
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:816 lxc/cluster.go:1380 lxc/cluster_group.go:134
-#: lxc/cluster_group.go:569 lxc/cluster_group.go:776 lxc/cluster_role.go:82
+#: lxc/cluster.go:817 lxc/cluster.go:1381 lxc/cluster_group.go:135
+#: lxc/cluster_group.go:570 lxc/cluster_group.go:777 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -3919,8 +3913,8 @@ msgstr ""
 #: lxc/config_metadata.go:112 lxc/config_metadata.go:221
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
-#: lxc/config_template.go:377 lxc/profile.go:151 lxc/profile.go:237
-#: lxc/profile.go:918 lxc/rebuild.go:61
+#: lxc/config_template.go:377 lxc/profile.go:152 lxc/profile.go:238
+#: lxc/profile.go:919 lxc/rebuild.go:73
 msgid "Missing instance name"
 msgstr ""
 
@@ -3929,14 +3923,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:220 lxc/network_forward.go:458
-#: lxc/network_forward.go:543 lxc/network_forward.go:718
-#: lxc/network_forward.go:849 lxc/network_forward.go:946
-#: lxc/network_forward.go:1032 lxc/network_load_balancer.go:222
-#: lxc/network_load_balancer.go:437 lxc/network_load_balancer.go:522
-#: lxc/network_load_balancer.go:680 lxc/network_load_balancer.go:812
-#: lxc/network_load_balancer.go:900 lxc/network_load_balancer.go:976
-#: lxc/network_load_balancer.go:1089 lxc/network_load_balancer.go:1163
+#: lxc/network_forward.go:221 lxc/network_forward.go:459
+#: lxc/network_forward.go:544 lxc/network_forward.go:719
+#: lxc/network_forward.go:850 lxc/network_forward.go:947
+#: lxc/network_forward.go:1033 lxc/network_load_balancer.go:223
+#: lxc/network_load_balancer.go:438 lxc/network_load_balancer.go:523
+#: lxc/network_load_balancer.go:681 lxc/network_load_balancer.go:813
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:977
+#: lxc/network_load_balancer.go:1090 lxc/network_load_balancer.go:1164
 msgid "Missing listen address"
 msgstr ""
 
@@ -3946,41 +3940,41 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:222 lxc/network_acl.go:282 lxc/network_acl.go:345
-#: lxc/network_acl.go:417 lxc/network_acl.go:515 lxc/network_acl.go:668
-#: lxc/network_acl.go:779 lxc/network_acl.go:836 lxc/network_acl.go:972
-#: lxc/network_acl.go:1056
+#: lxc/network_acl.go:223 lxc/network_acl.go:283 lxc/network_acl.go:346
+#: lxc/network_acl.go:418 lxc/network_acl.go:516 lxc/network_acl.go:669
+#: lxc/network_acl.go:780 lxc/network_acl.go:837 lxc/network_acl.go:973
+#: lxc/network_acl.go:1057
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:177 lxc/network.go:279 lxc/network.go:447 lxc/network.go:509
-#: lxc/network.go:606 lxc/network.go:719 lxc/network.go:842 lxc/network.go:918
-#: lxc/network.go:1176 lxc/network.go:1254 lxc/network.go:1320
-#: lxc/network.go:1412 lxc/network_forward.go:128 lxc/network_forward.go:216
-#: lxc/network_forward.go:293 lxc/network_forward.go:454
-#: lxc/network_forward.go:539 lxc/network_forward.go:714
-#: lxc/network_forward.go:845 lxc/network_forward.go:942
-#: lxc/network_forward.go:1028 lxc/network_load_balancer.go:132
-#: lxc/network_load_balancer.go:218 lxc/network_load_balancer.go:287
-#: lxc/network_load_balancer.go:433 lxc/network_load_balancer.go:518
-#: lxc/network_load_balancer.go:676 lxc/network_load_balancer.go:808
-#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:972
-#: lxc/network_load_balancer.go:1085 lxc/network_load_balancer.go:1159
+#: lxc/network.go:178 lxc/network.go:280 lxc/network.go:448 lxc/network.go:510
+#: lxc/network.go:607 lxc/network.go:720 lxc/network.go:843 lxc/network.go:919
+#: lxc/network.go:1177 lxc/network.go:1255 lxc/network.go:1321
+#: lxc/network.go:1413 lxc/network_forward.go:129 lxc/network_forward.go:217
+#: lxc/network_forward.go:294 lxc/network_forward.go:455
+#: lxc/network_forward.go:540 lxc/network_forward.go:715
+#: lxc/network_forward.go:846 lxc/network_forward.go:943
+#: lxc/network_forward.go:1029 lxc/network_load_balancer.go:133
+#: lxc/network_load_balancer.go:219 lxc/network_load_balancer.go:288
+#: lxc/network_load_balancer.go:434 lxc/network_load_balancer.go:519
+#: lxc/network_load_balancer.go:677 lxc/network_load_balancer.go:809
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:973
+#: lxc/network_load_balancer.go:1086 lxc/network_load_balancer.go:1160
 #: lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266
 #: lxc/network_peer.go:402 lxc/network_peer.go:486 lxc/network_peer.go:645
 #: lxc/network_peer.go:766
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:213 lxc/network_zone.go:282 lxc/network_zone.go:354
-#: lxc/network_zone.go:450 lxc/network_zone.go:591 lxc/network_zone.go:702
-#: lxc/network_zone.go:816 lxc/network_zone.go:896 lxc/network_zone.go:1041
-#: lxc/network_zone.go:1138 lxc/network_zone.go:1400 lxc/network_zone.go:1477
-#: lxc/network_zone.go:1534
+#: lxc/network_zone.go:214 lxc/network_zone.go:283 lxc/network_zone.go:355
+#: lxc/network_zone.go:451 lxc/network_zone.go:592 lxc/network_zone.go:703
+#: lxc/network_zone.go:817 lxc/network_zone.go:897 lxc/network_zone.go:1042
+#: lxc/network_zone.go:1139 lxc/network_zone.go:1401 lxc/network_zone.go:1478
+#: lxc/network_zone.go:1535
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:966 lxc/network_zone.go:1286
+#: lxc/network_zone.go:967 lxc/network_zone.go:1287
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4006,18 +4000,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:482 lxc/profile.go:564 lxc/profile.go:682 lxc/profile.go:1002
-#: lxc/profile.go:1070 lxc/profile.go:1151
+#: lxc/profile.go:483 lxc/profile.go:565 lxc/profile.go:683 lxc/profile.go:1003
+#: lxc/profile.go:1071 lxc/profile.go:1152
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:419 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
-#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
-#: lxc/project.go:956
+#: lxc/profile.go:420 lxc/project.go:153 lxc/project.go:235 lxc/project.go:325
+#: lxc/project.go:442 lxc/project.go:631 lxc/project.go:700 lxc/project.go:828
+#: lxc/project.go:957
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:325
+#: lxc/profile.go:326
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4037,7 +4031,7 @@ msgstr ""
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:964
 msgid "Mode"
 msgstr ""
 
@@ -4062,7 +4056,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:529 lxc/network.go:626 lxc/storage_volume.go:883
+#: lxc/network.go:530 lxc/network.go:627 lxc/storage_volume.go:883
 #: lxc/storage_volume.go:987
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -4117,11 +4111,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1076 lxc/network_load_balancer.go:1207
+#: lxc/network_forward.go:1077 lxc/network_load_balancer.go:1208
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:1111
+#: lxc/network_acl.go:1112
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4133,12 +4127,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:192
-#: lxc/cluster.go:1074 lxc/cluster_group.go:508 lxc/config_trust.go:407
-#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1114
-#: lxc/network_acl.go:170 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:758 lxc/project.go:573
-#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:527
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1945 lxc/cluster.go:193
+#: lxc/cluster.go:1075 lxc/cluster_group.go:509 lxc/config_trust.go:407
+#: lxc/config_trust.go:512 lxc/list.go:573 lxc/network.go:1115
+#: lxc/network_acl.go:171 lxc/network_peer.go:148 lxc/network_zone.go:162
+#: lxc/network_zone.go:846 lxc/profile.go:759 lxc/project.go:574
+#: lxc/remote.go:850 lxc/storage.go:715 lxc/storage_bucket.go:527
 #: lxc/storage_bucket.go:851 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
@@ -4151,11 +4145,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:579
+#: lxc/project.go:580
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:578
+#: lxc/project.go:579
 msgid "NETWORKS"
 msgstr ""
 
@@ -4167,9 +4161,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/operation.go:155 lxc/project.go:531
-#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
-#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1088 lxc/operation.go:155 lxc/project.go:532
+#: lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552
+#: lxc/project.go:557 lxc/remote.go:810 lxc/remote.go:815 lxc/remote.go:820
 msgid "NO"
 msgstr ""
 
@@ -4196,11 +4190,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:143
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:936 lxc/storage_volume.go:1475
+#: lxc/info.go:472 lxc/network.go:937 lxc/storage_volume.go:1475
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4210,67 +4204,67 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:397
+#: lxc/network.go:398
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:457
+#: lxc/network.go:458
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:395
+#: lxc/network.go:396
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1264
+#: lxc/network.go:1265
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:461
+#: lxc/network_acl.go:462
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:846
+#: lxc/network_acl.go:847
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:789
+#: lxc/network_acl.go:790
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:396
+#: lxc/network_zone.go:397
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:712
+#: lxc/network_zone.go:713
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:395
+#: lxc/network_forward.go:396
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:866
+#: lxc/network_forward.go:867
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:392
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:829
+#: lxc/network_load_balancer.go:830
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4300,20 +4294,20 @@ msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:336
+#: lxc/network.go:337
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:607 lxc/network.go:953
+#: lxc/info.go:607 lxc/network.go:954
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:1083
+#: lxc/network_zone.go:1084
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1410
+#: lxc/network_zone.go:1411
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4335,12 +4329,12 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1166
+#: lxc/cluster.go:1167
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:538 lxc/network.go:635
+#: lxc/network.go:539 lxc/network.go:636
 msgid "No device found for this network"
 msgstr ""
 
@@ -4348,19 +4342,19 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1007
+#: lxc/network_load_balancer.go:1008
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1087 lxc/network_load_balancer.go:1218
+#: lxc/network_forward.go:1088 lxc/network_load_balancer.go:1219
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:1122
+#: lxc/network_acl.go:1123
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/warning.go:393
+#: lxc/warning.go:394
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
@@ -4386,7 +4380,7 @@ msgstr ""
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:995
+#: lxc/network.go:996
 msgid "OVN:"
 msgstr ""
 
@@ -4403,7 +4397,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:392
+#: lxc/remote.go:393
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4415,7 +4409,7 @@ msgstr ""
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:745 lxc/network.go:1335
+#: lxc/network.go:746 lxc/network.go:1336
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4426,6 +4420,10 @@ msgstr ""
 
 #: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
+msgstr ""
+
+#: lxc/config_device.go:795
+msgid "Override device or modify profile instead"
 msgstr ""
 
 #: lxc/main.go:97
@@ -4458,7 +4456,7 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:160 lxc/network_load_balancer.go:162
+#: lxc/network_forward.go:161 lxc/network_load_balancer.go:163
 msgid "PORTS"
 msgstr ""
 
@@ -4466,29 +4464,29 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:575
+#: lxc/list.go:576 lxc/project.go:576
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1125 lxc/network_acl.go:176
-#: lxc/network_zone.go:167 lxc/profile.go:759 lxc/storage_bucket.go:536
-#: lxc/storage_volume.go:1788 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network.go:1126 lxc/network_acl.go:177
+#: lxc/network_zone.go:168 lxc/profile.go:760 lxc/storage_bucket.go:536
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:852
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1146 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:591 lxc/network.go:956
+#: lxc/info.go:591 lxc/network.go:957
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:592 lxc/network.go:957
+#: lxc/info.go:592 lxc/network.go:958
 msgid "Packets sent"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:195
+#: lxc/remote.go:196
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4517,11 +4515,11 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:936
+#: lxc/cluster.go:937
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:551
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4538,14 +4536,14 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:865
-#: lxc/cluster_group.go:403 lxc/config.go:323 lxc/config.go:398
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1871 lxc/cluster.go:866
+#: lxc/cluster_group.go:404 lxc/config.go:323 lxc/config.go:398
 #: lxc/config.go:1381 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:770
-#: lxc/network_acl.go:717 lxc/network_forward.go:777
-#: lxc/network_load_balancer.go:740 lxc/network_peer.go:700
-#: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:611
-#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/config_trust.go:313 lxc/image.go:493 lxc/network.go:771
+#: lxc/network_acl.go:718 lxc/network_forward.go:778
+#: lxc/network_load_balancer.go:741 lxc/network_peer.go:700
+#: lxc/network_zone.go:641 lxc/network_zone.go:1336 lxc/profile.go:612
+#: lxc/project.go:372 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1146 lxc/storage_volume.go:1180
 #: lxc/storage_volume.go:1212
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4559,7 +4557,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:42
+#: lxc/query.go:43
 msgid "Print the raw response"
 msgstr ""
 
@@ -4582,32 +4580,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:173
+#: lxc/profile.go:174
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:433
+#: lxc/profile.go:434
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:492
+#: lxc/profile.go:493
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:928
+#: lxc/profile.go:929
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:953
+#: lxc/profile.go:954
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:1012
+#: lxc/profile.go:1013
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4624,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:266
+#: lxc/profile.go:267
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4637,22 +4635,22 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:180
+#: lxc/project.go:181
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:244
+#: lxc/project.go:245
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:645
+#: lxc/project.go:646
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:108
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4748,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Public image server"
 msgstr ""
 
@@ -4786,7 +4784,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: lxc/query.go:87
+#: lxc/query.go:88
 msgid "Query path must start with /"
 msgstr ""
 
@@ -4794,7 +4792,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:999
+#: lxc/project.go:1000
 msgid "RESOURCE"
 msgstr ""
 
@@ -4802,7 +4800,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:195
 msgid "ROLES"
 msgstr ""
 
@@ -4841,45 +4839,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:911
+#: lxc/remote.go:912
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1048
-#: lxc/remote.go:1096
+#: lxc/project.go:891 lxc/remote.go:903 lxc/remote.go:984 lxc/remote.go:1049
+#: lxc/remote.go:1097
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:359
+#: lxc/remote.go:360
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:991
+#: lxc/remote.go:992
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1100
+#: lxc/remote.go:907 lxc/remote.go:988 lxc/remote.go:1101
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:333
+#: lxc/remote.go:334
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:354
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Remote trust token"
 msgstr ""
 
@@ -4893,7 +4891,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:527
+#: lxc/cluster_group.go:528
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4901,11 +4899,11 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:589 lxc/cluster.go:590
+#: lxc/cluster.go:590 lxc/cluster.go:591
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1500
+#: lxc/network_zone.go:1501
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -4913,23 +4911,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:984 lxc/network_load_balancer.go:1123
+#: lxc/network_forward.go:985 lxc/network_load_balancer.go:1124
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:1017
+#: lxc/network_acl.go:1018
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:936
+#: lxc/network_load_balancer.go:937
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:936
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1501
+#: lxc/network_zone.go:1502
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4941,7 +4939,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:526
+#: lxc/cluster_group.go:527
 msgid "Remove member from group"
 msgstr ""
 
@@ -4949,19 +4947,19 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:982 lxc/network_forward.go:983
+#: lxc/network_forward.go:983 lxc/network_forward.go:984
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1121 lxc/network_load_balancer.go:1122
+#: lxc/network_load_balancer.go:1122 lxc/network_load_balancer.go:1123
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:876 lxc/profile.go:877
+#: lxc/profile.go:877 lxc/profile.go:878
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:953 lxc/remote.go:954
+#: lxc/remote.go:954 lxc/remote.go:955
 msgid "Remove remotes"
 msgstr ""
 
@@ -4969,7 +4967,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:1015 lxc/network_acl.go:1016
+#: lxc/network_acl.go:1016 lxc/network_acl.go:1017
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -4977,11 +4975,11 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:616 lxc/cluster_group.go:617
+#: lxc/cluster_group.go:617 lxc/cluster_group.go:618
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:531 lxc/cluster.go:532
+#: lxc/cluster.go:532 lxc/cluster.go:533
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5002,23 +5000,23 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:748 lxc/network_acl.go:749
+#: lxc/network_acl.go:749 lxc/network_acl.go:750
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1221 lxc/network.go:1222
+#: lxc/network.go:1222 lxc/network.go:1223
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:969 lxc/profile.go:970
+#: lxc/profile.go:970 lxc/profile.go:971
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:597 lxc/project.go:598
+#: lxc/project.go:598 lxc/project.go:599
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:873
+#: lxc/remote.go:873 lxc/remote.go:874
 msgid "Rename remotes"
 msgstr ""
 
@@ -5040,7 +5038,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:897 lxc/cluster.go:898
+#: lxc/cluster.go:898 lxc/cluster.go:899
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5067,7 +5065,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1340 lxc/cluster.go:1341
+#: lxc/cluster.go:1341 lxc/cluster.go:1342
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5086,7 +5084,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1407
+#: lxc/cluster.go:1414
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5099,7 +5097,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:362
+#: lxc/init.go:366
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5108,7 +5106,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:1092
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5128,7 +5126,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:215
 msgid "SEVERITY"
 msgstr ""
 
@@ -5158,20 +5156,20 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1121
+#: lxc/cluster.go:199 lxc/list.go:578 lxc/network.go:1122
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:855
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:174 lxc/warning.go:215
+#: lxc/operation.go:174 lxc/warning.go:216
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:577
+#: lxc/project.go:578
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,11 +5177,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:576
+#: lxc/project.go:577
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:977
+#: lxc/network.go:978
 msgid "STP"
 msgstr ""
 
@@ -5196,23 +5194,23 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: lxc/query.go:33 lxc/query.go:34
+#: lxc/query.go:34 lxc/query.go:35
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:547
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:299 lxc/remote.go:717
+#: lxc/remote.go:300 lxc/remote.go:718
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5225,7 +5223,7 @@ msgstr ""
 msgid "Set UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:404
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -5272,11 +5270,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:478
+#: lxc/network_acl.go:479
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:479
+#: lxc/network_acl.go:480
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5285,11 +5283,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1281
+#: lxc/network.go:1282
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1282
+#: lxc/network.go:1283
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5298,11 +5296,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:498
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:498
+#: lxc/network_forward.go:499
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5311,11 +5309,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:477
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:477
+#: lxc/network_load_balancer.go:478
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5337,11 +5335,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:413
+#: lxc/network_zone.go:414
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:414
+#: lxc/network_zone.go:415
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5350,15 +5348,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1100 lxc/network_zone.go:1101
+#: lxc/network_zone.go:1101 lxc/network_zone.go:1102
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1029
+#: lxc/profile.go:1030
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1030
+#: lxc/profile.go:1031
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5367,11 +5365,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5419,7 +5417,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1066 lxc/remote.go:1067
+#: lxc/remote.go:1067 lxc/remote.go:1068
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5447,19 +5445,19 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/cluster.go:406
+#: lxc/cluster.go:407
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:485
+#: lxc/network_acl.go:486
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:505
+#: lxc/network_forward.go:506
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:485
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5467,23 +5465,23 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1289
+#: lxc/network.go:1290
 msgid "Set the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:421
+#: lxc/network_zone.go:422
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1106
+#: lxc/network_zone.go:1107
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1037
+#: lxc/profile.go:1038
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:670
+#: lxc/project.go:671
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5519,7 +5517,7 @@ msgstr ""
 msgid "Show an identity provider group"
 msgstr ""
 
-#: lxc/cluster_group.go:672 lxc/cluster_group.go:673
+#: lxc/cluster_group.go:673 lxc/cluster_group.go:674
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5527,7 +5525,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:214 lxc/cluster.go:215
+#: lxc/cluster.go:215 lxc/cluster.go:216
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5588,23 +5586,23 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:191 lxc/network_acl.go:192
+#: lxc/network_acl.go:192 lxc/network_acl.go:193
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:252 lxc/network_acl.go:253
+#: lxc/network_acl.go:253 lxc/network_acl.go:254
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1377 lxc/network.go:1378
+#: lxc/network.go:1378 lxc/network.go:1379
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:179 lxc/network_forward.go:180
+#: lxc/network_forward.go:180 lxc/network_forward.go:181
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:182
+#: lxc/network_load_balancer.go:182 lxc/network_load_balancer.go:183
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5612,23 +5610,23 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:182 lxc/network_zone.go:183
+#: lxc/network_zone.go:183 lxc/network_zone.go:184
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:862
+#: lxc/network_zone.go:863
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:863
+#: lxc/network_zone.go:864
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:1118 lxc/profile.go:1119
+#: lxc/profile.go:1119 lxc/profile.go:1120
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:794 lxc/project.go:795
+#: lxc/project.go:795 lxc/project.go:796
 msgid "Show project options"
 msgstr ""
 
@@ -5662,7 +5660,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:748 lxc/remote.go:749
+#: lxc/remote.go:749 lxc/remote.go:750
 msgid "Show the default remote"
 msgstr ""
 
@@ -5690,7 +5688,7 @@ msgstr ""
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:271 lxc/cluster.go:272
+#: lxc/cluster.go:272 lxc/cluster.go:273
 msgid "Show useful information about a cluster member"
 msgstr ""
 
@@ -5702,7 +5700,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:304 lxc/warning.go:305
 msgid "Show warning"
 msgstr ""
 
@@ -5742,7 +5740,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/warning.go:376
+#: lxc/warning.go:377
 msgid "Specify a warning UUID or use --all"
 msgstr ""
 
@@ -5750,7 +5748,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:92
+#: lxc/launch.go:96
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5759,7 +5757,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -5851,7 +5849,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1276
+#: lxc/cluster.go:1277
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5874,11 +5872,11 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:855 lxc/project.go:856
+#: lxc/project.go:856 lxc/project.go:857
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:1017 lxc/remote.go:1018
+#: lxc/remote.go:1018 lxc/remote.go:1019
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5900,14 +5898,14 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1075 lxc/config_trust.go:513
+#: lxc/cluster.go:1076 lxc/config_trust.go:513
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:406 lxc/image.go:1148
-#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1115
-#: lxc/network.go:1201 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1762 lxc/warning.go:216
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1116
+#: lxc/network.go:1202 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
@@ -5923,7 +5921,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:348
+#: lxc/remote.go:162 lxc/remote.go:349
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5961,7 +5959,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:1006 lxc/network_acl.go:1145
+#: lxc/network_acl.go:1007 lxc/network_acl.go:1146
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5975,11 +5973,11 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:444
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:385
+#: lxc/cluster.go:386
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5998,7 +5996,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/cluster.go:376
+#: lxc/cluster.go:377
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
@@ -6013,22 +6011,22 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:450
+#: lxc/network_load_balancer.go:451
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:860
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: lxc/network_acl.go:357
+#: lxc/network_acl.go:358
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:471
+#: lxc/network_forward.go:472
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6038,22 +6036,22 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:294
+#: lxc/network_zone.go:295
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: lxc/network_zone.go:978
+#: lxc/network_zone.go:979
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: lxc/profile.go:695
+#: lxc/profile.go:696
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:454
+#: lxc/project.go:455
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6079,7 +6077,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:541
+#: lxc/remote.go:542
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6096,12 +6094,12 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:543 lxc/network.go:640 lxc/storage_volume.go:897
+#: lxc/network.go:544 lxc/network.go:641 lxc/storage_volume.go:897
 #: lxc/storage_volume.go:1001
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:547 lxc/network.go:644
+#: lxc/network.go:548 lxc/network.go:645
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -6117,11 +6115,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:744
+#: lxc/cluster.go:745
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:734
+#: lxc/cluster.go:735
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6149,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:442
+#: lxc/init.go:446
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:441
+#: lxc/init.go:445
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6168,7 +6166,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:347 lxc/config.go:538 lxc/config.go:744 lxc/config.go:844
-#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:924 lxc/storage.go:515
+#: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:925 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6217,24 +6215,24 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:965
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:344
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:339
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:653
+#: lxc/remote.go:654
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:302 lxc/launch.go:124
+#: lxc/action.go:302 lxc/launch.go:128
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6253,7 +6251,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:940
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:941
 #: lxc/storage_volume.go:1484
 #, c-format
 msgid "Type: %s"
@@ -6264,7 +6262,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:971
+#: lxc/project.go:972
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6272,21 +6270,21 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:850
+#: lxc/cluster.go:194 lxc/remote.go:851
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1767
+#: lxc/project.go:1002 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1120 lxc/network_acl.go:172 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:761 lxc/project.go:581
+#: lxc/network.go:1121 lxc/network_acl.go:173 lxc/network_allocations.go:24
+#: lxc/network_zone.go:164 lxc/profile.go:762 lxc/project.go:582
 #: lxc/storage.go:724 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:218
 msgid "UUID"
 msgstr ""
 
@@ -6300,7 +6298,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:226 lxc/remote.go:260
+#: lxc/remote.go:227 lxc/remote.go:261
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6314,8 +6312,8 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:782
-#: lxc/storage_volume.go:1804 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:783
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:942 lxc/network_acl.go:1078
+#: lxc/network_acl.go:943 lxc/network_acl.go:1079
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6344,7 +6342,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:488
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6364,27 +6362,27 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:566 lxc/network_acl.go:567
+#: lxc/network_acl.go:567 lxc/network_acl.go:568
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1449 lxc/network.go:1450
+#: lxc/network.go:1450 lxc/network.go:1451
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:607
+#: lxc/network_forward.go:608
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:608
+#: lxc/network_forward.go:609
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:586
+#: lxc/network_load_balancer.go:587
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:587
+#: lxc/network_load_balancer.go:588
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6396,19 +6394,19 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:501 lxc/network_zone.go:502
+#: lxc/network_zone.go:502 lxc/network_zone.go:503
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:1189 lxc/network_zone.go:1190
+#: lxc/network_zone.go:1190 lxc/network_zone.go:1191
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:1182 lxc/profile.go:1183
+#: lxc/profile.go:1183 lxc/profile.go:1184
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:750 lxc/project.go:751
+#: lxc/project.go:751 lxc/project.go:752
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6424,19 +6422,19 @@ msgstr ""
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:490
+#: lxc/cluster.go:491
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: lxc/network_acl.go:570
+#: lxc/network_acl.go:571
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:611
+#: lxc/network_forward.go:612
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:590
+#: lxc/network_load_balancer.go:591
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6444,23 +6442,23 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1454
+#: lxc/network.go:1455
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: lxc/network_zone.go:505
+#: lxc/network_zone.go:506
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: lxc/network_zone.go:1193
+#: lxc/network_zone.go:1194
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: lxc/profile.go:1187
+#: lxc/profile.go:1188
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:755
+#: lxc/project.go:756
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6489,21 +6487,21 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:965
+#: lxc/network.go:966
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1179
+#: lxc/cluster.go:1180
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1181
+#: lxc/cluster.go:1182
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/profile.go:289
+#: lxc/profile.go:290
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -6512,7 +6510,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:982
 msgid "Upper devices"
 msgstr ""
 
@@ -6545,7 +6543,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:629 lxc/delete.go:53
+#: lxc/cluster.go:630 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6559,15 +6557,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:989
+#: lxc/network.go:990
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:980
+#: lxc/network.go:981
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:987
+#: lxc/network.go:988
 msgid "VLAN:"
 msgstr ""
 
@@ -6603,7 +6601,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -6627,9 +6625,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1089 lxc/operation.go:157 lxc/project.go:533
-#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
-#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1090 lxc/operation.go:157 lxc/project.go:534
+#: lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/project.go:554
+#: lxc/project.go:559 lxc/remote.go:812 lxc/remote.go:817 lxc/remote.go:822
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6647,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:132
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6665,11 +6663,11 @@ msgid ""
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1899
-#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:442
+#: lxc/cluster.go:121 lxc/cluster.go:981 lxc/cluster_group.go:443
 #: lxc/config_trust.go:345 lxc/config_trust.go:428 lxc/monitor.go:32
-#: lxc/network.go:1014 lxc/network_acl.go:93 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:717 lxc/project.go:475
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/network.go:1015 lxc/network_acl.go:94 lxc/network_zone.go:85
+#: lxc/operation.go:104 lxc/profile.go:718 lxc/project.go:476
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:70
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6677,11 +6675,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1178
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/config_trust.go:576
+#: lxc/cluster.go:680 lxc/config_trust.go:576
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6701,48 +6699,48 @@ msgstr ""
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
-#: lxc/network_acl.go:190 lxc/network_acl.go:251 lxc/network_acl.go:608
-#: lxc/network_acl.go:803
+#: lxc/network_acl.go:191 lxc/network_acl.go:252 lxc/network_acl.go:609
+#: lxc/network_acl.go:804
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:876 lxc/network_acl.go:1014
+#: lxc/network_acl.go:877 lxc/network_acl.go:1015
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:307 lxc/network_acl.go:565
+#: lxc/network_acl.go:308 lxc/network_acl.go:566
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:477
+#: lxc/network_acl.go:478
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:746
+#: lxc/network_acl.go:747
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:380
+#: lxc/network_acl.go:381
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:181 lxc/network_zone.go:543 lxc/network_zone.go:669
+#: lxc/network_zone.go:182 lxc/network_zone.go:544 lxc/network_zone.go:670
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:244 lxc/network_zone.go:500
+#: lxc/network_zone.go:245 lxc/network_zone.go:501
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:412
+#: lxc/network_zone.go:413
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:317
+#: lxc/network_zone.go:318
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -6777,8 +6775,8 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:173
-#: lxc/cluster_group.go:258 lxc/cluster_group.go:319 lxc/cluster_group.go:671
+#: lxc/auth.go:1105 lxc/auth.go:1680 lxc/cluster_group.go:174
+#: lxc/cluster_group.go:259 lxc/cluster_group.go:320 lxc/cluster_group.go:672
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -6788,7 +6786,7 @@ msgid ""
 "[<key>=<value>...]"
 msgstr ""
 
-#: lxc/cluster_group.go:614
+#: lxc/cluster_group.go:615
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6874,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:108 lxc/profile.go:875
+#: lxc/profile.go:109 lxc/profile.go:876
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:187
+#: lxc/profile.go:188
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6945,24 +6943,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
-#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1339
+#: lxc/cluster.go:214 lxc/cluster.go:271 lxc/cluster.go:588 lxc/cluster.go:774
+#: lxc/cluster.go:1091 lxc/cluster.go:1303 lxc/cluster.go:1340
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:82 lxc/cluster_group.go:525 lxc/cluster_group.go:733
+#: lxc/cluster_group.go:83 lxc/cluster_group.go:526 lxc/cluster_group.go:734
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:486
+#: lxc/cluster.go:330 lxc/cluster.go:487
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:402
+#: lxc/cluster.go:403
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:529
+#: lxc/cluster.go:530
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6970,70 +6968,70 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:412 lxc/network.go:665 lxc/network.go:882 lxc/network.go:1141
-#: lxc/network.go:1376 lxc/network_forward.go:88
-#: lxc/network_load_balancer.go:92 lxc/network_peer.go:79
+#: lxc/network.go:413 lxc/network.go:666 lxc/network.go:883 lxc/network.go:1142
+#: lxc/network.go:1377 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:471
+#: lxc/network.go:472
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:134
+#: lxc/network.go:135
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:801 lxc/network.go:1448
+#: lxc/network.go:802 lxc/network.go:1449
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1280
+#: lxc/network.go:1281
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:178 lxc/network_forward.go:653
-#: lxc/network_forward.go:806 lxc/network_load_balancer.go:180
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:769
+#: lxc/network_forward.go:179 lxc/network_forward.go:654
+#: lxc/network_forward.go:807 lxc/network_load_balancer.go:181
+#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934
+#: lxc/network_load_balancer.go:935
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858
+#: lxc/network_load_balancer.go:859
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:411 lxc/network_forward.go:606
-#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:585
+#: lxc/network_forward.go:412 lxc/network_forward.go:607
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:586
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:496 lxc/network_load_balancer.go:475
+#: lxc/network_forward.go:497 lxc/network_load_balancer.go:476
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:1047
+#: lxc/network_load_balancer.go:1048
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:896
+#: lxc/network_forward.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:981 lxc/network_load_balancer.go:1120
+#: lxc/network_forward.go:982 lxc/network_load_balancer.go:1121
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1219
+#: lxc/network.go:1220
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7059,19 +7057,19 @@ msgstr ""
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:568
+#: lxc/network.go:569
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:236
+#: lxc/network.go:237
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:255 lxc/network_load_balancer.go:257
+#: lxc/network_forward.go:256 lxc/network_load_balancer.go:258
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
-#: lxc/network.go:326
+#: lxc/network.go:327
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -7184,8 +7182,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:366
-#: lxc/profile.go:447 lxc/profile.go:506 lxc/profile.go:1117
+#: lxc/config_device.go:405 lxc/config_device.go:831 lxc/profile.go:367
+#: lxc/profile.go:448 lxc/profile.go:507 lxc/profile.go:1118
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -7201,11 +7199,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:642 lxc/profile.go:1181
+#: lxc/profile.go:643 lxc/profile.go:1182
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:1028
+#: lxc/profile.go:1029
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
@@ -7213,28 +7211,28 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:967
+#: lxc/profile.go:968
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:283
+#: lxc/profile.go:284
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
-#: lxc/project.go:854 lxc/project.go:921
+#: lxc/project.go:96 lxc/project.go:195 lxc/project.go:267 lxc/project.go:794
+#: lxc/project.go:855 lxc/project.go:922
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:402 lxc/project.go:749
+#: lxc/project.go:403 lxc/project.go:750
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:661
+#: lxc/project.go:662
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:595
+#: lxc/project.go:596
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7242,31 +7240,31 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302
+#: lxc/warning.go:261 lxc/warning.go:303
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:782
+#: lxc/network_zone.go:783
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:861 lxc/network_zone.go:1235 lxc/network_zone.go:1364
+#: lxc/network_zone.go:862 lxc/network_zone.go:1236 lxc/network_zone.go:1365
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:925 lxc/network_zone.go:1188
+#: lxc/network_zone.go:926 lxc/network_zone.go:1189
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:1099
+#: lxc/network_zone.go:1100
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1441 lxc/network_zone.go:1499
+#: lxc/network_zone.go:1442 lxc/network_zone.go:1500
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:1001
+#: lxc/network_zone.go:1002
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -7290,19 +7288,19 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/warning.go:355
+#: lxc/warning.go:356
 msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:896
+#: lxc/cluster.go:897
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:563 lxc/remote.go:840
+#: lxc/project.go:564 lxc/remote.go:841
 msgid "current"
 msgstr ""
 
@@ -7370,13 +7368,13 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:777
+#: lxc/cluster.go:778
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:87
+#: lxc/cluster_group.go:88
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7385,7 +7383,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: lxc/cluster_group.go:178
+#: lxc/cluster_group.go:179
 msgid ""
 "lxc cluster group create g1\n"
 "\n"
@@ -7569,7 +7567,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network_acl.go:383
+#: lxc/network_acl.go:384
 msgid ""
 "lxc network acl create a1\n"
 "\n"
@@ -7577,7 +7575,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network.go:329
+#: lxc/network.go:330
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7586,7 +7584,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/network_forward.go:258
+#: lxc/network_forward.go:259
 msgid ""
 "lxc network forward create n1 127.0.0.1\n"
 "\n"
@@ -7594,7 +7592,7 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: lxc/network_load_balancer.go:260
+#: lxc/network_load_balancer.go:261
 msgid ""
 "lxc network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -7603,7 +7601,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:320
+#: lxc/network_zone.go:321
 msgid ""
 "lxc network zone create z1\n"
 "\n"
@@ -7611,7 +7609,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/network_zone.go:1004
+#: lxc/network_zone.go:1005
 msgid ""
 "lxc network zone record create z1 r1\n"
 "\n"
@@ -7625,7 +7623,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:192
+#: lxc/profile.go:193
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7637,7 +7635,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: lxc/profile.go:370
+#: lxc/profile.go:371
 msgid ""
 "lxc profile create p1\n"
 "\n"
@@ -7656,13 +7654,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:510
+#: lxc/profile.go:511
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:99
+#: lxc/project.go:100
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7670,13 +7668,13 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:270
+#: lxc/project.go:271
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:36
+#: lxc/query.go:37
 msgid ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -7786,7 +7784,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:545
+#: lxc/remote.go:546
 msgid "n"
 msgstr ""
 
@@ -7798,7 +7796,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:524
+#: lxc/remote.go:525
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7835,11 +7833,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:533
+#: lxc/remote.go:534
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/cluster.go:629 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""


### PR DESCRIPTION
Closes https://github.com/canonical/lxd/issues/12520.

This improves error messages for `lxc storage volume export` and `lxc config device` by adding relevant quoted details.