### PR TITLE
doc: add info about snaps and user idmaps

### DIFF
--- a/doc/userns-idmap.md
+++ b/doc/userns-idmap.md
@@ -1,3 +1,4 @@
+(ref-idmap)=
 # Idmaps for user namespace
 
 LXD runs safe containers. This is achieved mostly through the use of
@@ -22,7 +23,17 @@ the POSIX range including root (0) and nobody (65534).
 User namespaces require a kernel >= 3.12, LXD will start even on older
 kernels but will refuse to start containers.
 
+(ref-idmap-allowed-ranges)=
 ## Allowed ranges
+
+```{admonition} If you installed LXD via snap
+:class: note
+
+If you {ref}`installed LXD via the Snap Store <installing-snap-package>` (the recommended method), this section does not apply.
+
+The `lxd` daemon runs as root inside the snap environment and does not use the `newuidmap` or `newgidmap` utilities. Thus, the allowed ID ranges in `/etc/subuid` and `/etc/subgid` are ignored, and you don't need to set them.
+
+```
 
 On most hosts, LXD will check `/etc/subuid` and `/etc/subgid` for
 allocations for the `root` user and on first start, set the default
@@ -91,6 +102,5 @@ be the same size.
 
 This property requires a container reboot to take effect.
 
-Remember that you may need to add an entry for the `root` user into
-`/etc/subid` and/or `/etc/subgid` so the container is allowed to make
-use of it.
+For non-snap installations of LXD, you might need to add an entry for the `root` user into
+`/etc/subid` and/or `/etc/subgid` so the container is allowed to make use of it. See: {ref}`ref-idmap-allowed-ranges`.


### PR DESCRIPTION
This PR notes that the Allowed ranges section is not needed for the LXD snap, due to the daemon running as root in the snap environment and disregarding the `/etc/sub{u,g}id` files.