### PR TITLE
lxd/db/cluster/images: Only populate update image source if found

### DIFF
--- a/lxd/db/cluster/images.go
+++ b/lxd/db/cluster/images.go
@@ -107,10 +107,11 @@ func (img *Image) ToAPI(ctx context.Context, tx *sql.Tx, profileProject string) 
 	_, source, err := GetImageSource(ctx, tx, img.ID)
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 		return nil, err
+	} else if err == nil {
+		// Only populate UpdateSource if image source found.
+		image.UpdateSource = &source
+		image.UpdateSource.ImageType = image.Type
 	}
-
-	image.UpdateSource = &source
-	image.UpdateSource.ImageType = image.Type
 
 	// Get effective project profiles.
 	if profileProject != "" {

--- a/lxd/db/cluster/images.go
+++ b/lxd/db/cluster/images.go
@@ -109,7 +109,7 @@ func (img *Image) ToAPI(ctx context.Context, tx *sql.Tx, profileProject string) 
 		return nil, err
 	} else if err == nil {
 		// Only populate UpdateSource if image source found.
-		image.UpdateSource = &source
+		image.UpdateSource = source
 		image.UpdateSource.ImageType = image.Type
 	}
 
@@ -169,7 +169,7 @@ var ImageSourceProtocol = map[int]string{
 }
 
 // GetImageSource returns the image source with the given ID.
-func GetImageSource(ctx context.Context, tx *sql.Tx, imageID int) (int, api.ImageSource, error) {
+func GetImageSource(ctx context.Context, tx *sql.Tx, imageID int) (int, *api.ImageSource, error) {
 	q := `SELECT id, server, protocol, certificate, alias FROM images_source WHERE image_id=?`
 	type imagesSource struct {
 		ID          int
@@ -193,21 +193,21 @@ func GetImageSource(ctx context.Context, tx *sql.Tx, imageID int) (int, api.Imag
 		return nil
 	}, imageID)
 	if err != nil {
-		return -1, api.ImageSource{}, err
+		return -1, nil, err
 	}
 
 	if len(sources) == 0 {
-		return -1, api.ImageSource{}, api.StatusErrorf(http.StatusNotFound, "Image source not found")
+		return -1, nil, api.StatusErrorf(http.StatusNotFound, "Image source not found")
 	}
 
 	source := sources[0]
 
 	protocol, found := ImageSourceProtocol[source.Protocol]
 	if !found {
-		return -1, api.ImageSource{}, fmt.Errorf("Invalid protocol: %d", source.Protocol)
+		return -1, nil, fmt.Errorf("Invalid protocol: %d", source.Protocol)
 	}
 
-	result := api.ImageSource{
+	result := &api.ImageSource{
 		Server:      source.Server,
 		Protocol:    protocol,
 		Certificate: source.Certificate,

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2279,7 +2279,7 @@ func distributeImage(ctx context.Context, s *state.State, nodes []string, oldFin
 // Returns whether the image has been updated.
 func autoUpdateImage(ctx context.Context, s *state.State, op *operations.Operation, id int, info *api.Image, projectName string, manual bool) (*api.Image, error) {
 	fingerprint := info.Fingerprint
-	var source api.ImageSource
+	var source *api.ImageSource
 
 	if !manual {
 		var interval int64


### PR DESCRIPTION
Otherwise leave UpdateSource as nil.

Fixes regression from https://github.com/canonical/lxd/pull/15548