### PR TITLE
Storage: Add target request forwarding to `storagePoolVolumeTypeCustomBackupsGet` and consolidate functions into one database transaction in `storagePoolVolumeTypeCustomBackupsPost`

### DIFF
--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -181,8 +181,13 @@ func storagePoolVolumeTypeCustomBackupsGet(d *Daemon, r *http.Request) response.
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
 	}
 
+	resp := forwardedResponseIfTargetIsRemote(s, r)
+	if resp != nil {
+		return resp
+	}
+
 	// Handle requests targeted to a volume on a different node
-	resp := forwardedResponseIfVolumeIsRemote(s, r)
+	resp = forwardedResponseIfVolumeIsRemote(s, r)
 	if resp != nil {
 		return resp
 	}


### PR DESCRIPTION
Closes https://github.com/canonical/lxd/issues/13548.