### PR TITLE
github: only check lxc/lxd-agent bin sizes of not built for coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,7 @@ jobs:
           make
 
       - name: Check lxc/lxd-agent binary sizes
+        if: env.GOCOVERAGE != 'true'
         run: |
           set -eux
 


### PR DESCRIPTION
Binaries built with coverage information are inherently bigger than
regular/production builds.