### PR TITLE
staticcheck.conf: add dedicated config to ignore ST1005

### DIFF
--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,2 @@
+# ST1005: error strings should not be capitalized (5585 occurences as of 2023-10-20)
+checks = ["-ST1005"]


### PR DESCRIPTION
Some linters like VSCode's Go extension and TIOBE scanner do not consult the `.golangci.yaml` so reporting many problems with error strings not starting with a capital letter.