### PR TITLE
Prevent server certificate deletion

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -1152,6 +1152,11 @@ func certificateDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// Disallow deletion of server certificates.
+	if certInfo.Type == certificate.TypeServer {
+		return response.BadRequest(errors.New("Cannot delete a server certificate. Remove the cluster member instead"))
+	}
+
 	var userCanEditCertificate bool
 	err = s.Authorizer.CheckPermission(r.Context(), entity.CertificateURL(certInfo.Fingerprint), auth.EntitlementCanDelete)
 	if err != nil && !auth.IsDeniedError(err) {

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -195,6 +195,12 @@ test_clustering_membership() {
   ns2="${prefix}2"
   spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}" "${LXD_ONE_DIR}"
 
+  # Neither server certificate can be deleted
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc config trust remove "$(cert_fingerprint "${LXD_ONE_DIR}/server.crt")" || false
+  ! LXD_DIR="${LXD_TWO_DIR}" lxc config trust remove "$(cert_fingerprint "${LXD_ONE_DIR}/server.crt")" || false
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc config trust remove "$(cert_fingerprint "${LXD_TWO_DIR}/server.crt")" || false
+  ! LXD_DIR="${LXD_TWO_DIR}" lxc config trust remove "$(cert_fingerprint "${LXD_TWO_DIR}/server.crt")" || false
+
   # Configuration keys can be changed on any node.
   LXD_DIR="${LXD_TWO_DIR}" lxc config set cluster.offline_threshold 11
   LXD_DIR="${LXD_ONE_DIR}" lxc info | grep -q 'cluster.offline_threshold: "11"'


### PR DESCRIPTION
In #15554 the server certificates were removed, this broke the cluster. This PR does not add a mechanism for re-adding server certificates as the author suggests, instead it prevents deletion of server certificates via `DELETE /1.0/certificates`. There is no reason that a server certificate should be deleted. Updating server certificates is still allowed as this could be used to rotate expiring certificates, but no process is documented for this yet.