### PR TITLE
storage: Ensure storage bucket config is applied during bucket activation

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1657,7 +1658,7 @@ func (d *zfs) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 		delete(commonRules, "zfs.block_mode")
 		delete(commonRules, "block.filesystem")
 		delete(commonRules, "block.mount_options")
-	} else if vol.volType == VolumeTypeCustom && !vol.IsBlockBacked() {
+	} else if !vol.IsBlockBacked() && slices.Contains([]VolumeType{VolumeTypeCustom, VolumeTypeBucket}, vol.volType) {
 		delete(commonRules, "block.filesystem")
 		delete(commonRules, "block.mount_options")
 	}


### PR DESCRIPTION
The bucket configuration is applied when configured through storage pool `volume.*` options. This is because when no configuration is provided, the default pool configuration applies. Therefore, if custom storage bucket configuration is provided, the volume is incorrectly mounted during bucket activation, as the configuration is not applied.

Fixes #15588