### PR TITLE
tests: Fix `command not found` error

### DIFF
--- a/test/suites/clustering_move.sh
+++ b/test/suites/clustering_move.sh
@@ -62,12 +62,12 @@ test_clustering_move() {
   lxc info cluster:c1 | grep -q "Location: node1"
 
   # c1 can be moved within the same cluster group if it has multiple members
-  current_location="$(query cluster:/1.0/instances/c1 | jq -r '.location')"
+  current_location="$(lxc query cluster:/1.0/instances/c1 | jq -r '.location')"
   lxc move cluster:c1 --target=@default
-  query cluster:/1.0/instances/c1 | jq -re ".location != \"$current_location\""
-  current_location="$(query cluster:/1.0/instances/c1 | jq -r '.location')"
+  lxc query cluster:/1.0/instances/c1 | jq -re ".location != \"$current_location\""
+  current_location="$(lxc query cluster:/1.0/instances/c1 | jq -r '.location')"
   lxc move cluster:c1 --target=@default
-  query cluster:/1.0/instances/c1 | jq -re ".location != \"$current_location\""
+  lxc query cluster:/1.0/instances/c1 | jq -re ".location != \"$current_location\""
 
   # c1 cannot be moved within the same cluster group if it has a single member
   lxc move cluster:c1 --target=@foobar3


### PR DESCRIPTION
This was missed with https://github.com/canonical/lxd/pull/15534/commits/f31af2ba509efe9a1bb8c4a55d76d06f845c4bea.

Excerpt from today's tests:

```
++ query cluster:/1.0/instances/c1
suites/clustering_move.sh: line 65: query: command not found
```