### PR TITLE
Rework server-side migration (from Incus)

### DIFF
--- a/lxc/move.go
+++ b/lxc/move.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/canonical/lxd/lxc/config"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	cli "github.com/canonical/lxd/shared/cmd"
@@ -126,7 +125,7 @@ func (c *cmdMove) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// As an optimization, if the source an destination are the same, do
+	// As an optimization, if the source and destination are the same, do
 	// this via a simple rename. This only works for instances that aren't
 	// running, instances that are running should be live migrated (of
 	// course, this changing of hostname isn't supported right now, so this
@@ -179,77 +178,54 @@ func (c *cmdMove) run(cmd *cobra.Command, args []string) error {
 
 	stateful := !c.flagStateless
 
-	if c.flagTarget != "" {
-		// If the target option was specified, we're moving an instance from a
-		// cluster member to another, let's use the dedicated API.
-		if sourceRemote == destRemote {
-			if c.flagInstanceOnly {
-				return errors.New(i18n.G("The --instance-only flag can't be used with --target"))
-			}
-
-			if c.flagStorage != "" {
-				return errors.New(i18n.G("The --storage flag can't be used with --target"))
-			}
-
-			if c.flagTargetProject != "" {
-				return errors.New(i18n.G("The --target-project flag can't be used with --target"))
-			}
-
-			if c.flagMode != moveDefaultMode {
-				return errors.New(i18n.G("The --mode flag can't be used with --target"))
-			}
-
-			return moveClusterInstance(conf, sourceResource, destResource, c.flagTarget, c.global.flagQuiet, stateful)
+	isServerSide := func() bool {
+		// Check if same source and destination.
+		if sourceRemote != destRemote {
+			return false
 		}
 
-		dest, err := conf.GetInstanceServer(destRemote)
-		if err != nil {
-			return err
+		// Check if asked for specific client mode.
+		if c.flagMode != moveDefaultMode {
+			return false
 		}
 
-		if !dest.IsClustered() {
-			return errors.New(i18n.G("The destination LXD server is not clustered"))
-		}
-	}
-
-	// Support for server-side move. Currently, such migration can only move an instance to different project
-	// or storage pool. If specific profile, device or config is provided, the instance should be copied (move using copy).
-	if sourceRemote == destRemote && (c.flagStorage != "" || c.flagTargetProject != "") {
+		// Connect to the server.
 		source, err := conf.GetInstanceServer(sourceRemote)
 		if err != nil {
-			return err
+			return false
 		}
 
-		if source.HasExtension("instance_move_config") {
-			if c.flagMode != moveDefaultMode {
-				return errors.New(i18n.G("The --mode flag can't be used with --storage or --target-project"))
+		// Check if override is requested with a server lacking support.
+		if !source.HasExtension("instance_move_config") {
+			if len(c.flagConfig) > 0 {
+				return false
 			}
 
-			// Evaluate provided profiles. If no profiles were provided and flag noProfiles is false,
-			// existing instance profiles will be retained. Otherwise, flags are respected.
-			var profiles *[]string
+			if len(c.flagDevice) > 0 {
+				return false
+			}
+
 			if len(c.flagProfile) > 0 {
-				profiles = &c.flagProfile
-			} else if c.flagNoProfiles {
-				profiles = &[]string{}
+				return false
 			}
-
-			return c.moveInstance(conf, sourceResource, destResource, profiles, stateful)
 		}
 
-		if source.HasExtension("instance_pool_move") && source.HasExtension("instance_project_move") {
-			if len(c.flagConfig) != 0 || len(c.flagDevice) != 0 || len(c.flagProfile) != 0 || c.flagNoProfiles {
-				return errors.New("The move command does not support flags --config, --device, --profile, and --no-profiles. Please use copy instead")
-			}
-
-			if c.flagMode != moveDefaultMode {
-				return errors.New(i18n.G("The --mode flag can't be used with --storage or --target-project"))
-			}
-
-			c.flagConfig = []string{}
-			c.flagDevice = []string{}
-			return c.moveInstance(conf, sourceResource, destResource, nil, stateful)
+		// Check if server supports moving pools.
+		if c.flagStorage != "" && !source.HasExtension("instance_pool_move") {
+			return false
 		}
+
+		// Check if server supports moving projects.
+		if c.flagTargetProject != "" && !source.HasExtension("instance_project_move") {
+			return false
+		}
+
+		return true
+	}()
+
+	// Support for server-side move in clusters.
+	if isServerSide {
+		return c.moveInstance(sourceResource, destResource, stateful)
 	}
 
 	cpy := cmdCopy{}
@@ -282,84 +258,10 @@ func (c *cmdMove) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// Move an instance using special POST /instances/<name>?target=<member> API.
-func moveClusterInstance(conf *config.Config, sourceResource string, destResource string, target string, quiet bool, stateful bool) error {
-	// Parse the source.
-	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
-	if err != nil {
-		return err
-	}
-
-	// Parse the destination.
-	_, destName, err := conf.ParseRemote(destResource)
-	if err != nil {
-		return err
-	}
-
-	// Make sure we have an instance or snapshot name.
-	if sourceName == "" {
-		return errors.New(i18n.G("You must specify a source instance name"))
-	}
-
-	// The destination name is optional.
-	if destName == "" {
-		destName = sourceName
-	}
-
-	// Connect to the source host
-	source, err := conf.GetInstanceServer(sourceRemote)
-	if err != nil {
-		return fmt.Errorf(i18n.G("Failed to connect to cluster member: %w"), err)
-	}
-
-	// Check that it's a cluster
-	if !source.IsClustered() {
-		return errors.New(i18n.G("The source LXD server is not clustered"))
-	}
-
-	// The migrate API will do the right thing when passed a target.
-	source = source.UseTarget(target)
-	req := api.InstancePost{
-		Name:      destName,
-		Migration: true,
-		Live:      stateful,
-	}
-
-	op, err := source.MigrateInstance(sourceName, req)
-	if err != nil {
-		return fmt.Errorf(i18n.G("Migration API failure: %w"), err)
-	}
-
-	// Watch the background operation
-	progress := cli.ProgressRenderer{
-		Format: i18n.G("Transferring instance: %s"),
-		Quiet:  quiet,
-	}
-
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
-	}
-	// Wait for the move to complete
-	err = cli.CancelableWait(op, &progress)
-	if err != nil {
-		progress.Done("")
-		return err
-	}
-
-	progress.Done("")
-
-	err = op.Wait()
-	if err != nil {
-		return fmt.Errorf(i18n.G("Migration operation failure: %w"), err)
-	}
-
-	return nil
-}
-
 // Move an instance between pools and projects using special POST /instances/<name> API.
-func (c *cmdMove) moveInstance(conf *config.Config, sourceResource string, destResource string, profiles *[]string, stateful bool) error {
+func (c *cmdMove) moveInstance(sourceResource string, destResource string, stateful bool) error {
+	conf := c.global.conf
+
 	// Parse the source.
 	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
 	if err != nil {
@@ -388,35 +290,13 @@ func (c *cmdMove) moveInstance(conf *config.Config, sourceResource string, destR
 		return fmt.Errorf(i18n.G("Failed to connect to cluster member: %w"), err)
 	}
 
-	// Copy of an instance into a new instance.
-	inst, _, err := source.GetInstance(sourceName)
-	if err != nil {
-		return err
+	if !source.IsClustered() && c.flagTarget != "" {
+		return errors.New(i18n.G("--target can only be used with clusters"))
 	}
 
-	// Overwrite the config values.
-	for _, entry := range c.flagConfig {
-		key, value, found := strings.Cut(entry, "=")
-		if !found {
-			return fmt.Errorf(i18n.G("Bad key=value pair: %q"), entry)
-		}
-
-		inst.Config[key] = value
-	}
-
-	// Parse device map and overwrite device settings.
-	deviceMap, err := parseDeviceOverrides(c.flagDevice)
-	if err != nil {
-		return err
-	}
-
-	for k, m := range deviceMap {
-		if inst.Devices[k] == nil {
-			inst.Devices[k] = m
-			continue
-		}
-
-		maps.Copy(inst.Devices[k], m)
+	// Set the target if specified.
+	if c.flagTarget != "" {
+		source = source.UseTarget(c.flagTarget)
 	}
 
 	// Pass the new pool to the migration API.
@@ -427,11 +307,16 @@ func (c *cmdMove) moveInstance(conf *config.Config, sourceResource string, destR
 		Pool:         c.flagStorage,
 		Project:      c.flagTargetProject,
 		Live:         stateful,
-		Config:       inst.Config,
-		Devices:      inst.Devices,
 	}
 
-	// Overwrite profiles.
+	// Override profiles.
+	var profiles *[]string
+	if len(c.flagProfile) > 0 {
+		profiles = &c.flagProfile
+	} else if c.flagNoProfiles {
+		profiles = &[]string{}
+	}
+
 	if profiles != nil {
 		req.Profiles = *profiles
 	}
@@ -445,15 +330,70 @@ func (c *cmdMove) moveInstance(conf *config.Config, sourceResource string, destR
 		req.OverrideSnapshotProfiles = true
 	}
 
+	// Override config.
+	if len(c.flagConfig) > 0 {
+		req.Config = map[string]string{}
+
+		for _, entry := range c.flagConfig {
+			key, value, found := strings.Cut(entry, "=")
+			if !found {
+				return fmt.Errorf(i18n.G("Bad key=value pair: %q"), entry)
+			}
+
+			req.Config[key] = value
+		}
+	}
+
+	// Override devices.
+	if len(c.flagDevice) > 0 {
+		req.Devices = map[string]map[string]string{}
+
+		// Parse the overrides.
+		deviceMap, err := parseDeviceOverrides(c.flagDevice)
+		if err != nil {
+			return err
+		}
+
+		// Fetch the current isntance.
+		inst, _, err := source.GetInstance(sourceName)
+		if err != nil {
+			return err
+		}
+
+		for devName, dev := range deviceMap {
+			fullDev := inst.ExpandedDevices[devName]
+			maps.Copy(fullDev, dev)
+
+			req.Devices[devName] = fullDev
+		}
+	}
+
+	// Move the instance.
 	op, err := source.MigrateInstance(sourceName, req)
 	if err != nil {
 		return fmt.Errorf(i18n.G("Migration API failure: %w"), err)
 	}
 
-	err = op.Wait()
+	// Watch the background operation
+	progress := cli.ProgressRenderer{
+		Format: i18n.G("Transferring instance: %s"),
+		Quiet:  c.global.flagQuiet,
+	}
+
+	_, err = op.AddHandler(progress.UpdateOp)
 	if err != nil {
+		progress.Done("")
+		return err
+	}
+
+	// Wait for the move to complete
+	err = cli.CancelableWait(op, &progress)
+	if err != nil {
+		progress.Done("")
 		return fmt.Errorf(i18n.G("Migration operation failure: %w"), err)
 	}
+
+	progress.Done("")
 
 	return nil
 }

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -567,9 +567,10 @@ func migrateLocal(ctx context.Context, s *state.State, inst instance.Instance, r
 
 	targetProject := inst.Project().Name
 	if req.Project != "" {
-		target = target.UseProject(req.Project)
 		targetProject = req.Project
 	}
+
+	target = target.UseProject(targetProject)
 
 	// Check if we have a root disk in local config.
 	_, _, err = instancetype.GetRootDiskDevice(targetInstInfo.Devices)

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -492,6 +492,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -741,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -866,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -891,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -939,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +995,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1024,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1149,7 +1153,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1169,11 +1173,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1190,7 +1194,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1222,7 +1226,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1253,7 +1257,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1317,7 +1321,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1553,7 +1557,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1719,7 +1723,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1779,12 +1783,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1794,7 +1798,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2067,7 +2071,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2138,8 +2142,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2191,8 +2195,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2220,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2232,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2358,7 +2362,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2506,7 +2510,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2826,7 +2830,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2840,11 +2844,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2890,7 +2894,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2898,7 +2902,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2920,11 +2924,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3060,15 +3064,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3087,8 +3091,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3455,11 +3459,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3850,12 +3854,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3991,9 +3995,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4012,7 +4016,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4071,11 +4075,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4091,15 +4095,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4130,7 +4134,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4182,8 +4186,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4317,7 +4321,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4355,11 +4359,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4373,7 +4377,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4386,11 +4390,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4415,7 +4419,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4449,7 +4453,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4467,7 +4471,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4615,7 +4619,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4689,7 +4693,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4723,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4732,7 +4736,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5017,15 +5021,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5077,7 +5081,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5397,11 +5401,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5486,7 +5490,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5635,7 +5639,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5707,11 +5711,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5816,7 +5820,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5898,11 +5902,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5920,32 +5924,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6083,10 +6063,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6178,7 +6154,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6194,7 +6170,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6203,7 +6179,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6267,13 +6243,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6306,7 +6282,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6339,7 +6315,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6411,7 +6387,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6463,7 +6439,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6512,13 +6488,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6585,7 +6561,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6636,7 +6612,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6927,7 +6903,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7075,7 +7051,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7110,21 +7086,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7140,15 +7116,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7167,7 +7143,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7277,7 +7253,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7546,7 +7522,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7761,13 +7737,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -751,6 +751,11 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
+#: lxc/move.go:294
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--refresh kann nur mit Containern verwendet werden"
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 #, fuzzy
@@ -1019,7 +1024,7 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1153,17 +1158,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1179,7 +1184,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1227,7 +1232,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1290,7 +1295,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1323,7 +1328,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1454,7 +1459,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1474,11 +1479,11 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1495,7 +1500,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1529,7 +1534,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1561,7 +1566,7 @@ msgstr "Erstellt: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -1630,7 +1635,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1890,7 +1895,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -1910,7 +1915,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2067,7 +2072,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -2127,12 +2132,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -2142,7 +2147,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2453,7 +2458,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2511,7 +2516,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2525,8 +2530,8 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2587,8 +2592,8 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2612,7 +2617,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2627,12 +2632,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2758,7 +2763,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2910,7 +2915,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3254,7 +3259,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3268,11 +3273,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3320,7 +3325,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3328,7 +3333,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3352,11 +3357,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3494,16 +3499,16 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3523,8 +3528,8 @@ msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -3575,7 +3580,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3927,12 +3932,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4366,12 +4371,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4523,9 +4528,9 @@ msgstr "Fehlende Zusammenfassung."
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4546,7 +4551,7 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4610,12 +4615,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Mounted: %v"
 msgstr "Erstellt: %s"
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4631,17 +4636,17 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4673,7 +4678,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4725,8 +4730,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4862,7 +4867,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4904,11 +4909,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4922,7 +4927,7 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -4936,11 +4941,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4965,7 +4970,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4999,7 +5004,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -5017,7 +5022,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -5171,7 +5176,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5249,7 +5254,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5279,7 +5284,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5292,7 +5297,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5603,17 +5608,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5668,7 +5673,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -6008,12 +6013,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6108,7 +6113,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6276,7 +6281,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
@@ -6353,12 +6358,12 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -6467,7 +6472,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -6553,11 +6558,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -6576,35 +6581,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-#, fuzzy
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr "--refresh kann nur mit Containern verwendet werden"
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-#, fuzzy
-msgid "The --storage flag can't be used with --target"
-msgstr "--refresh kann nur mit Containern verwendet werden"
-
-#: lxc/move.go:195
-#, fuzzy
-msgid "The --target-project flag can't be used with --target"
-msgstr "--refresh kann nur mit Containern verwendet werden"
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6744,10 +6722,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 #, fuzzy
@@ -6844,7 +6818,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6860,7 +6834,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6869,7 +6843,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6935,13 +6909,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6975,7 +6949,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7010,7 +6984,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -7096,7 +7070,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7157,7 +7131,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7209,13 +7183,13 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7286,7 +7260,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7344,7 +7318,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7908,7 +7882,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8190,7 +8164,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8257,7 +8231,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8268,7 +8242,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8277,7 +8251,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8286,7 +8260,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8320,7 +8294,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8328,7 +8302,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8336,7 +8310,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8373,7 +8347,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8595,7 +8569,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8882,7 +8856,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
@@ -9101,13 +9075,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9174,6 +9148,18 @@ msgstr ""
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "The --mode flag can't be used with --storage or --target-project"
+#~ msgstr "--refresh kann nur mit Containern verwendet werden"
+
+#, fuzzy
+#~ msgid "The --storage flag can't be used with --target"
+#~ msgstr "--refresh kann nur mit Containern verwendet werden"
+
+#, fuzzy
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "Aktion (Standard: GET)"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -747,7 +751,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -872,16 +876,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -897,7 +901,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -945,7 +949,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -998,7 +1002,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1031,7 +1035,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1156,7 +1160,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1176,11 +1180,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1197,7 +1201,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1229,7 +1233,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1260,7 +1264,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1324,7 +1328,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1563,7 +1567,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1583,7 +1587,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1734,7 +1738,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1794,12 +1798,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1809,7 +1813,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
@@ -2093,7 +2097,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2150,7 +2154,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2164,8 +2168,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2217,8 +2221,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2242,7 +2246,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2254,11 +2258,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2532,7 +2536,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2865,7 +2869,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2879,11 +2883,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2929,7 +2933,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2937,7 +2941,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2959,11 +2963,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3099,15 +3103,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3126,8 +3130,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3173,7 +3177,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3497,11 +3501,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3908,12 +3912,12 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4057,9 +4061,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4078,7 +4082,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4138,11 +4142,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4158,15 +4162,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4197,7 +4201,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4249,8 +4253,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4386,7 +4390,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4424,11 +4428,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4442,7 +4446,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4455,11 +4459,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4484,7 +4488,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4518,7 +4522,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4536,7 +4540,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4685,7 +4689,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4759,7 +4763,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4789,7 +4793,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4802,7 +4806,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5092,15 +5096,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5152,7 +5156,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5480,11 +5484,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5575,7 +5579,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5734,7 +5738,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5807,11 +5811,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5916,7 +5920,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5998,11 +6002,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -6020,32 +6024,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6183,10 +6163,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6279,7 +6255,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6295,7 +6271,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6304,7 +6280,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6368,13 +6344,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6407,7 +6383,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6441,7 +6417,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6522,7 +6498,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6581,7 +6557,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6630,13 +6606,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6703,7 +6679,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6754,7 +6730,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7045,7 +7021,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7193,7 +7169,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7228,21 +7204,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7258,15 +7234,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7285,7 +7261,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7395,7 +7371,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7664,7 +7640,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7879,13 +7855,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -736,6 +736,11 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -991,7 +996,7 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -1118,16 +1123,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1143,7 +1148,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1192,7 +1197,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1245,7 +1250,7 @@ msgstr "Cacheado: %s"
 msgid "Caches:"
 msgstr "Cacheado: %s"
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 "No se puede anular la configuración o los perfiles en el cambio de nombre "
@@ -1281,7 +1286,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1408,7 +1413,7 @@ msgstr "Perfil %s eliminado de %s"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1428,11 +1433,11 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1449,7 +1454,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Columnas"
 
@@ -1482,7 +1487,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1514,7 +1519,7 @@ msgstr "Auto actualización: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1578,7 +1583,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1826,7 +1831,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1846,7 +1851,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1998,7 +2003,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -2058,12 +2063,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr "Descripción"
@@ -2073,7 +2078,7 @@ msgstr "Descripción"
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -2363,7 +2368,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2420,7 +2425,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2434,8 +2439,8 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2488,8 +2493,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2514,7 +2519,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2528,11 +2533,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2658,7 +2663,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2807,7 +2812,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3144,7 +3149,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3158,11 +3163,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3208,7 +3213,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3216,7 +3221,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3239,11 +3244,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3382,16 +3387,16 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3410,8 +3415,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3458,7 +3463,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3793,11 +3798,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4205,12 +4210,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4361,9 +4366,9 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4383,7 +4388,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4446,11 +4451,11 @@ msgstr "Aliases:"
 msgid "Mounted: %v"
 msgstr "Creado: %s"
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4466,15 +4471,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4505,7 +4510,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4557,8 +4562,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4692,7 +4697,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4730,11 +4735,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4748,7 +4753,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4761,11 +4766,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4790,7 +4795,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4824,7 +4829,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4842,7 +4847,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4993,7 +4998,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -5069,7 +5074,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5099,7 +5104,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5112,7 +5117,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5407,15 +5412,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5470,7 +5475,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5801,11 +5806,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5896,7 +5901,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6056,7 +6061,7 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -6129,11 +6134,11 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -6239,7 +6244,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -6321,11 +6326,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -6343,34 +6348,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-#, fuzzy
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-#, fuzzy
-msgid "The --target-project flag can't be used with --target"
-msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6508,10 +6487,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6605,7 +6580,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6621,7 +6596,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6630,7 +6605,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6696,13 +6671,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6735,7 +6710,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6770,7 +6745,7 @@ msgstr "Aliases:"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6851,7 +6826,7 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6910,7 +6885,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6960,13 +6935,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7033,7 +7008,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7084,7 +7059,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7436,7 +7411,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7616,7 +7591,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7659,24 +7634,24 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7696,17 +7671,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7729,7 +7704,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7866,7 +7841,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8139,7 +8114,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8354,13 +8329,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8427,6 +8402,16 @@ msgstr ""
 #: lxc/image.go:1207
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "The --mode flag can't be used with --storage or --target-project"
+#~ msgstr ""
+#~ "--container-only no se puede pasar cuando la fuente es una instantánea"
+
+#, fuzzy
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr ""
+#~ "--container-only no se puede pasar cuando la fuente es una instantánea"
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "Accion (predeterminados a GET)"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -742,6 +742,11 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
+#: lxc/move.go:294
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--target ne peut pas être utilisé avec des instances"
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -1023,7 +1028,7 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "All projects"
 msgstr "Rendre l'image publique"
@@ -1156,17 +1161,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1182,7 +1187,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1230,7 +1235,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1284,7 +1289,7 @@ msgstr "Créé : %s"
 msgid "Caches:"
 msgstr "Créé : %s"
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1319,7 +1324,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1448,7 +1453,7 @@ msgstr "Périphérique %s retiré de %s"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1468,11 +1473,11 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1489,7 +1494,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1531,7 +1536,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -1563,7 +1568,7 @@ msgstr "État : %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
@@ -1632,7 +1637,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1910,7 +1915,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1930,7 +1935,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -2093,7 +2098,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -2153,12 +2158,12 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -2168,7 +2173,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2475,7 +2480,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2533,7 +2538,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2547,8 +2552,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2617,8 +2622,8 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2644,7 +2649,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2659,12 +2664,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -2792,7 +2797,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2945,7 +2950,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3292,7 +3297,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3309,11 +3314,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3363,7 +3368,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3371,7 +3376,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -3396,11 +3401,11 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3540,16 +3545,16 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3569,8 +3574,8 @@ msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -3618,7 +3623,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -4016,12 +4021,12 @@ msgstr "Copie de l'image : %s"
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4452,12 +4457,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -4610,9 +4615,9 @@ msgstr "Résumé manquant."
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4633,7 +4638,7 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
@@ -4700,12 +4705,12 @@ msgstr "Création du conteneur"
 msgid "Mounted: %v"
 msgstr "Publié : %s"
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4721,17 +4726,17 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4763,7 +4768,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr "NOM"
 
@@ -4815,8 +4820,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -4954,7 +4959,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -4995,11 +5000,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5013,7 +5018,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -5029,13 +5034,13 @@ msgid ""
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -5066,7 +5071,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5101,7 +5106,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -5119,7 +5124,7 @@ msgstr "PROFILS"
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -5275,7 +5280,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -5352,7 +5357,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5382,7 +5387,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5395,7 +5400,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5710,17 +5715,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5792,7 +5797,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -6137,12 +6142,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6237,7 +6242,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -6410,7 +6415,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
@@ -6488,12 +6493,12 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -6604,7 +6609,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
@@ -6691,11 +6696,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -6714,32 +6719,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6886,10 +6867,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6987,7 +6964,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7003,7 +6980,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -7012,7 +6989,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -7079,13 +7056,13 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -7119,7 +7096,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7154,7 +7131,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -7243,7 +7220,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7304,7 +7281,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7356,13 +7333,13 @@ msgstr "Création du conteneur"
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7431,7 +7408,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7489,7 +7466,7 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -8113,7 +8090,7 @@ msgstr ""
 "lxc publish [<remote>:]<container>[/<snapshot>] [<remote>:] [--"
 "alias=ALIAS...] [prop-key=prop-value...]"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8413,7 +8390,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8480,7 +8457,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8494,7 +8471,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8506,7 +8483,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8518,7 +8495,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8558,7 +8535,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8566,7 +8543,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8574,7 +8551,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8617,7 +8594,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8851,7 +8828,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -9155,7 +9132,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
@@ -9382,13 +9359,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -496,6 +496,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -745,7 +749,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -870,16 +874,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -895,7 +899,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -943,7 +947,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -995,7 +999,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1028,7 +1032,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1153,7 +1157,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1173,11 +1177,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1194,7 +1198,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1226,7 +1230,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1257,7 +1261,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1321,7 +1325,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1557,7 +1561,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1577,7 +1581,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1723,7 +1727,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1783,12 +1787,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1798,7 +1802,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2071,7 +2075,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,7 +2132,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2142,8 +2146,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2195,8 +2199,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2220,7 +2224,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2232,11 +2236,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2362,7 +2366,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2510,7 +2514,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2830,7 +2834,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2844,11 +2848,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2894,7 +2898,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2902,7 +2906,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2924,11 +2928,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3064,15 +3068,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3091,8 +3095,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3138,7 +3142,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3459,11 +3463,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3854,12 +3858,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3995,9 +3999,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4016,7 +4020,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4075,11 +4079,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4095,15 +4099,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4134,7 +4138,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4186,8 +4190,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4321,7 +4325,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4359,11 +4363,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4377,7 +4381,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4390,11 +4394,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4419,7 +4423,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4453,7 +4457,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4471,7 +4475,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4619,7 +4623,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4693,7 +4697,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4723,7 +4727,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4736,7 +4740,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5021,15 +5025,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5081,7 +5085,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5401,11 +5405,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5490,7 +5494,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5639,7 +5643,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5711,11 +5715,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5820,7 +5824,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5902,11 +5906,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5924,32 +5928,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6087,10 +6067,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6182,7 +6158,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6198,7 +6174,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6207,7 +6183,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6271,13 +6247,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6310,7 +6286,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6343,7 +6319,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6415,7 +6391,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6467,7 +6443,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6516,13 +6492,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6589,7 +6565,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6640,7 +6616,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6931,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7079,7 +7055,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7114,21 +7090,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7144,15 +7120,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7171,7 +7147,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7281,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7550,7 +7526,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7765,13 +7741,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -738,6 +738,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -993,7 +997,7 @@ msgstr "il remote %s esiste già"
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -1120,16 +1124,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1145,7 +1149,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1193,7 +1197,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1246,7 +1250,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1279,7 +1283,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1406,7 +1410,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1426,11 +1430,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1447,7 +1451,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Colonne"
 
@@ -1479,7 +1483,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1510,7 +1514,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "Creazione del container in corso"
@@ -1575,7 +1579,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1823,7 +1827,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1843,7 +1847,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1994,7 +1998,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -2054,12 +2058,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -2069,7 +2073,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
@@ -2361,7 +2365,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2418,7 +2422,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2432,8 +2436,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2486,8 +2490,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2525,11 +2529,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2655,7 +2659,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
@@ -2805,7 +2809,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3151,11 +3155,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3202,7 +3206,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3233,11 +3237,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3375,16 +3379,16 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3404,8 +3408,8 @@ msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -3452,7 +3456,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3788,11 +3792,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4206,12 +4210,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4361,9 +4365,9 @@ msgstr "Il nome del container è: %s"
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4383,7 +4387,7 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4445,11 +4449,11 @@ msgstr "Creazione del container in corso"
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4465,15 +4469,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4504,7 +4508,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4556,8 +4560,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4691,7 +4695,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4730,11 +4734,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4748,7 +4752,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -4762,11 +4766,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4825,7 +4829,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4843,7 +4847,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4994,7 +4998,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -5069,7 +5073,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5099,7 +5103,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5112,7 +5116,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5409,15 +5413,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5472,7 +5476,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5801,11 +5805,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5894,7 +5898,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6054,7 +6058,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -6128,11 +6132,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -6239,7 +6243,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -6322,11 +6326,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -6345,32 +6349,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6509,10 +6489,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6606,7 +6582,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6622,7 +6598,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6631,7 +6607,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -6696,13 +6672,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6736,7 +6712,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6771,7 +6747,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -6850,7 +6826,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6906,7 +6882,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6957,13 +6933,13 @@ msgstr "Creazione del container in corso"
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7030,7 +7006,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7082,7 +7058,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -7436,7 +7412,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -7616,7 +7592,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -7659,24 +7635,24 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
@@ -7696,17 +7672,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
@@ -7729,7 +7705,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
@@ -7866,7 +7842,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -8139,7 +8115,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8354,13 +8330,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -729,6 +729,11 @@ msgstr "--project は query コマンドでは使えません"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
+#: lxc/move.go:294
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--target はインスタンスでは使えません"
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -1001,7 +1006,7 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1131,16 +1136,16 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1158,7 +1163,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1206,7 +1211,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1258,7 +1263,7 @@ msgstr "キャッシュ済: %s"
 msgid "Caches:"
 msgstr "キャッシュ:"
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
@@ -1292,7 +1297,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -1422,7 +1427,7 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1442,11 +1447,11 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
@@ -1463,7 +1468,7 @@ msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1499,7 +1504,7 @@ msgstr "新しいインスタンスに適用するキー/値の設定"
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
@@ -1530,7 +1535,7 @@ msgstr "コンテンツタイプ: %s"
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
@@ -1610,7 +1615,7 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
@@ -1855,7 +1860,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1875,7 +1880,7 @@ msgstr "DRM:"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -2024,7 +2029,7 @@ msgstr "警告を削除します"
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -2084,12 +2089,12 @@ msgstr "警告を削除します"
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr "説明"
@@ -2099,7 +2104,7 @@ msgstr "説明"
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
@@ -2389,7 +2394,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2458,7 +2463,7 @@ msgstr "イメージの取得中: %s"
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
@@ -2472,8 +2477,8 @@ msgstr "イメージのプロパティを削除します"
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2536,8 +2541,8 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2564,7 +2569,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2576,12 +2581,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2707,7 +2712,7 @@ msgstr "リモートの追加に失敗しました"
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
@@ -2872,7 +2877,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -3206,7 +3211,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -3222,11 +3227,11 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr "コピー中にファイルが更新された場合のエラーを無視します"
 
@@ -3272,7 +3277,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -3283,7 +3288,7 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -3310,11 +3315,11 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3455,17 +3460,17 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
@@ -3486,8 +3491,8 @@ msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -3533,7 +3538,7 @@ msgstr "LISTEN ADDRESS"
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3988,11 +3993,11 @@ msgstr "ストレージバケットの鍵を一覧表示します"
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 #, fuzzy
 msgid ""
 "List storage volumes\n"
@@ -4439,12 +4444,12 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -4584,9 +4589,9 @@ msgstr "ピア名を指定する必要があります"
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4605,7 +4610,7 @@ msgstr "プロジェクト名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
@@ -4669,11 +4674,11 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Mounted: %v"
 msgstr "モデル: %v"
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr "LXD サーバ内もしくはサーバ間でインスタンスを移動します"
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4700,15 +4705,15 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
@@ -4741,7 +4746,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr "NAME"
 
@@ -4794,8 +4799,8 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr "名前"
 
@@ -4931,7 +4936,7 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
@@ -4972,11 +4977,11 @@ msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -4990,7 +4995,7 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
@@ -5004,11 +5009,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -5033,7 +5038,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -5067,7 +5072,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -5085,7 +5090,7 @@ msgstr "PROFILES"
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -5236,7 +5241,7 @@ msgstr "新しいイメージに適用するプロファイル"
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
@@ -5310,7 +5315,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5343,7 +5348,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5356,7 +5361,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5652,16 +5657,16 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -5719,7 +5724,7 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -6095,11 +6100,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -6200,7 +6205,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -6353,7 +6358,7 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
@@ -6426,11 +6431,11 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
@@ -6535,7 +6540,7 @@ msgstr "ストレージプール %s を削除しました"
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
@@ -6617,11 +6622,11 @@ msgstr "TOKEN"
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -6639,34 +6644,9 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr "--instance-only と --target は同時に指定できません"
-
-#: lxc/move.go:225 lxc/move.go:246
-#, fuzzy
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr "--mode と --target-project は同時に指定できません"
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr "--mode と --target は同時に指定できません"
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr "--storage と --target は同時に指定できません"
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr "--target-project と --target は同時に指定できません"
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
-msgstr "移動先の LXD サーバはクラスタに属していません"
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
 msgid "The device already exists"
@@ -6810,10 +6790,6 @@ msgstr "サーバには新しい v2 resource API が実装されていません"
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr "移動元の LXD サーバはクラスタに属していません"
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6926,7 +6902,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6942,7 +6918,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull, push or relay"
 msgstr "転送モード。pull, push, relay のいずれか"
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
@@ -6951,7 +6927,7 @@ msgstr "転送モード。pull, push, relay のいずれか。"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -7018,13 +6994,13 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -7057,7 +7033,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -7091,7 +7067,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
@@ -7163,7 +7139,7 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -7223,7 +7199,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -7275,13 +7251,13 @@ msgstr "上位デバイス"
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7353,7 +7329,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -7407,7 +7383,7 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -7712,7 +7688,7 @@ msgstr "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
@@ -7871,7 +7847,7 @@ msgstr "[<remote>:]<operation>"
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -7906,7 +7882,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -7914,15 +7890,15 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
@@ -7939,17 +7915,17 @@ msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
@@ -7972,7 +7948,7 @@ msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
@@ -8084,7 +8060,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
@@ -8461,7 +8437,7 @@ msgstr ""
 "lxc monitor --type=lifecycle\n"
 "    lifecycle イベントのみを表示します。"
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8778,7 +8754,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8786,7 +8762,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 #, fuzzy
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
@@ -8860,6 +8836,28 @@ msgstr "y"
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "yes"
+
+#~ msgid "The --instance-only flag can't be used with --target"
+#~ msgstr "--instance-only と --target は同時に指定できません"
+
+#, fuzzy
+#~ msgid "The --mode flag can't be used with --storage or --target-project"
+#~ msgstr "--mode と --target-project は同時に指定できません"
+
+#~ msgid "The --mode flag can't be used with --target"
+#~ msgstr "--mode と --target は同時に指定できません"
+
+#~ msgid "The --storage flag can't be used with --target"
+#~ msgstr "--storage と --target は同時に指定できません"
+
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr "--target-project と --target は同時に指定できません"
+
+#~ msgid "The destination LXD server is not clustered"
+#~ msgstr "移動先の LXD サーバはクラスタに属していません"
+
+#~ msgid "The source LXD server is not clustered"
+#~ msgstr "移動元の LXD サーバはクラスタに属していません"
 
 #~ msgid "List available network zoneS"
 #~ msgstr "利用可能なネットワークゾーンを一覧表示します"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -492,6 +492,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -741,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -866,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -891,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -939,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +995,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1024,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1149,7 +1153,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1169,11 +1173,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1190,7 +1194,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1222,7 +1226,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1253,7 +1257,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1317,7 +1321,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1553,7 +1557,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1719,7 +1723,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1779,12 +1783,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1794,7 +1798,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2067,7 +2071,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2138,8 +2142,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2191,8 +2195,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2220,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2232,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2358,7 +2362,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2506,7 +2510,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2826,7 +2830,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2840,11 +2844,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2890,7 +2894,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2898,7 +2902,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2920,11 +2924,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3060,15 +3064,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3087,8 +3091,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3455,11 +3459,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3850,12 +3854,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3991,9 +3995,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4012,7 +4016,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4071,11 +4075,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4091,15 +4095,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4130,7 +4134,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4182,8 +4186,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4317,7 +4321,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4355,11 +4359,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4373,7 +4377,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4386,11 +4390,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4415,7 +4419,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4449,7 +4453,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4467,7 +4471,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4615,7 +4619,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4689,7 +4693,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4723,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4732,7 +4736,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5017,15 +5021,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5077,7 +5081,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5397,11 +5401,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5486,7 +5490,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5635,7 +5639,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5707,11 +5711,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5816,7 +5820,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5898,11 +5902,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5920,32 +5924,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6083,10 +6063,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6178,7 +6154,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6194,7 +6170,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6203,7 +6179,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6267,13 +6243,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6306,7 +6282,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6339,7 +6315,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6411,7 +6387,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6463,7 +6439,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6512,13 +6488,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6585,7 +6561,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6636,7 +6612,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6927,7 +6903,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7075,7 +7051,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7110,21 +7086,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7140,15 +7116,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7167,7 +7143,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7277,7 +7253,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7546,7 +7522,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7761,13 +7737,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-07-15 11:36+0100\n"
+        "POT-Creation-Date: 2025-07-30 16:03-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -463,6 +463,10 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
+#: lxc/move.go:294
+msgid   "--target can only be used with clusters"
+msgstr  ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864 lxc/info.go:461
 msgid   "--target cannot be used with instances"
 msgstr  ""
@@ -702,7 +706,7 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid   "All projects"
 msgstr  ""
 
@@ -824,16 +828,16 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid   "Backups:"
 msgstr  ""
 
@@ -847,7 +851,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -895,7 +899,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -947,7 +951,7 @@ msgstr  ""
 msgid   "Caches:"
 msgstr  ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
@@ -980,7 +984,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -1101,7 +1105,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797 lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65 lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890 lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382 lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267 lxc/network_forward.go:508 lxc/network_forward.go:658 lxc/network_forward.go:812 lxc/network_forward.go:901 lxc/network_forward.go:987 lxc/network_load_balancer.go:187 lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775 lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126 lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749 lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92 lxc/storage_bucket.go:192 lxc/storage_bucket.go:255 lxc/storage_bucket.go:386 lxc/storage_bucket.go:562 lxc/storage_bucket.go:653 lxc/storage_bucket.go:719 lxc/storage_bucket.go:794 lxc/storage_bucket.go:880 lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045 lxc/storage_bucket.go:1181 lxc/storage_volume.go:400 lxc/storage_volume.go:628 lxc/storage_volume.go:733 lxc/storage_volume.go:1035 lxc/storage_volume.go:1261 lxc/storage_volume.go:1390 lxc/storage_volume.go:1881 lxc/storage_volume.go:1983 lxc/storage_volume.go:2122 lxc/storage_volume.go:2280 lxc/storage_volume.go:2396 lxc/storage_volume.go:2457 lxc/storage_volume.go:2584 lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797 lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890 lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382 lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267 lxc/network_forward.go:508 lxc/network_forward.go:658 lxc/network_forward.go:812 lxc/network_forward.go:901 lxc/network_forward.go:987 lxc/network_load_balancer.go:187 lxc/network_load_balancer.go:269 lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:620 lxc/network_load_balancer.go:775 lxc/network_load_balancer.go:863 lxc/network_load_balancer.go:939 lxc/network_load_balancer.go:1052 lxc/network_load_balancer.go:1126 lxc/storage.go:106 lxc/storage.go:397 lxc/storage.go:480 lxc/storage.go:749 lxc/storage.go:849 lxc/storage.go:942 lxc/storage_bucket.go:92 lxc/storage_bucket.go:192 lxc/storage_bucket.go:255 lxc/storage_bucket.go:386 lxc/storage_bucket.go:562 lxc/storage_bucket.go:653 lxc/storage_bucket.go:719 lxc/storage_bucket.go:794 lxc/storage_bucket.go:880 lxc/storage_bucket.go:980 lxc/storage_bucket.go:1045 lxc/storage_bucket.go:1181 lxc/storage_volume.go:400 lxc/storage_volume.go:628 lxc/storage_volume.go:733 lxc/storage_volume.go:1035 lxc/storage_volume.go:1261 lxc/storage_volume.go:1390 lxc/storage_volume.go:1880 lxc/storage_volume.go:1982 lxc/storage_volume.go:2121 lxc/storage_volume.go:2279 lxc/storage_volume.go:2395 lxc/storage_volume.go:2456 lxc/storage_volume.go:2583 lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1117,7 +1121,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737 lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737 lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid   "Columns"
 msgstr  ""
 
@@ -1148,7 +1152,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
@@ -1171,7 +1175,7 @@ msgstr  ""
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid   "Copy a stateful instance as stateless"
 msgstr  ""
 
@@ -1229,7 +1233,7 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291 lxc/storage_volume.go:403
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291 lxc/storage_volume.go:403
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1456,7 +1460,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511 lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122 lxc/network_acl.go:173 lxc/network_forward.go:160 lxc/network_load_balancer.go:163 lxc/network_peer.go:150 lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173 lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724 lxc/storage_bucket.go:529 lxc/storage_bucket.go:851 lxc/storage_volume.go:1765
+#: lxc/auth.go:381 lxc/cluster.go:200 lxc/cluster_group.go:511 lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:563 lxc/network.go:1122 lxc/network_acl.go:173 lxc/network_forward.go:160 lxc/network_load_balancer.go:163 lxc/network_peer.go:150 lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173 lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724 lxc/storage_bucket.go:529 lxc/storage_bucket.go:851 lxc/storage_volume.go:1764
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1476,7 +1480,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1580,7 +1584,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105 lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397 lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580 lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984 lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291 lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463 lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784 lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063 lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126 lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407 lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682 lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093 lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342 lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177 lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447 lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675 lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52 lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173 lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484 lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703 lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349 lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579 lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136 lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690 lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52 lxc/network_forward.go:36 lxc/network_forward.go:93 lxc/network_forward.go:182 lxc/network_forward.go:259 lxc/network_forward.go:415 lxc/network_forward.go:500 lxc/network_forward.go:608 lxc/network_forward.go:655 lxc/network_forward.go:809 lxc/network_forward.go:883 lxc/network_forward.go:898 lxc/network_forward.go:983 lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251 lxc/storage_bucket.go:384 lxc/storage_bucket.go:462 lxc/storage_bucket.go:556 lxc/storage_bucket.go:648 lxc/storage_bucket.go:717 lxc/storage_bucket.go:751 lxc/storage_bucket.go:792 lxc/storage_bucket.go:871 lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176 lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315 lxc/storage_volume.go:396 lxc/storage_volume.go:621 lxc/storage_volume.go:730 lxc/storage_volume.go:817 lxc/storage_volume.go:922 lxc/storage_volume.go:1026 lxc/storage_volume.go:1247 lxc/storage_volume.go:1378 lxc/storage_volume.go:1540 lxc/storage_volume.go:1624 lxc/storage_volume.go:1877 lxc/storage_volume.go:1980 lxc/storage_volume.go:2107 lxc/storage_volume.go:2263 lxc/storage_volume.go:2384 lxc/storage_volume.go:2446 lxc/storage_volume.go:2582 lxc/storage_volume.go:2666 lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31 lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:37 lxc/auth.go:66 lxc/auth.go:105 lxc/auth.go:159 lxc/auth.go:208 lxc/auth.go:337 lxc/auth.go:397 lxc/auth.go:446 lxc/auth.go:498 lxc/auth.go:521 lxc/auth.go:580 lxc/auth.go:736 lxc/auth.go:775 lxc/auth.go:917 lxc/auth.go:984 lxc/auth.go:1047 lxc/auth.go:1108 lxc/auth.go:1237 lxc/auth.go:1291 lxc/auth.go:1314 lxc/auth.go:1372 lxc/auth.go:1441 lxc/auth.go:1463 lxc/auth.go:1645 lxc/auth.go:1683 lxc/auth.go:1735 lxc/auth.go:1784 lxc/auth.go:1903 lxc/auth.go:1963 lxc/auth.go:2012 lxc/auth.go:2063 lxc/auth.go:2086 lxc/auth.go:2139 lxc/cluster.go:33 lxc/cluster.go:126 lxc/cluster.go:218 lxc/cluster.go:275 lxc/cluster.go:334 lxc/cluster.go:407 lxc/cluster.go:489 lxc/cluster.go:533 lxc/cluster.go:591 lxc/cluster.go:682 lxc/cluster.go:776 lxc/cluster.go:899 lxc/cluster.go:983 lxc/cluster.go:1093 lxc/cluster.go:1181 lxc/cluster.go:1305 lxc/cluster.go:1342 lxc/cluster_group.go:33 lxc/cluster_group.go:87 lxc/cluster_group.go:177 lxc/cluster_group.go:263 lxc/cluster_group.go:323 lxc/cluster_group.go:447 lxc/cluster_group.go:529 lxc/cluster_group.go:619 lxc/cluster_group.go:675 lxc/cluster_group.go:737 lxc/cluster_role.go:25 lxc/cluster_role.go:52 lxc/cluster_role.go:116 lxc/config.go:33 lxc/config.go:141 lxc/config.go:434 lxc/config.go:578 lxc/config.go:793 lxc/config.go:925 lxc/config.go:996 lxc/config.go:1036 lxc/config.go:1091 lxc/config.go:1182 lxc/config.go:1213 lxc/config.go:1267 lxc/config_device.go:26 lxc/config_device.go:173 lxc/config_device.go:304 lxc/config_device.go:401 lxc/config_device.go:484 lxc/config_device.go:580 lxc/config_device.go:696 lxc/config_device.go:703 lxc/config_device.go:832 lxc/config_device.go:923 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:235 lxc/config_trust.go:349 lxc/config_trust.go:431 lxc/config_trust.go:533 lxc/config_trust.go:579 lxc/config_trust.go:650 lxc/console.go:41 lxc/copy.go:43 lxc/delete.go:33 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:89 lxc/file.go:136 lxc/file.go:318 lxc/file.go:371 lxc/file.go:457 lxc/file.go:690 lxc/file.go:1211 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1547 lxc/image.go:1613 lxc/image.go:1677 lxc/image.go:1740 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139 lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476 lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887 lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225 lxc/network.go:1285 lxc/network.go:1379 lxc/network.go:1451 lxc/network_acl.go:32 lxc/network_acl.go:98 lxc/network_acl.go:194 lxc/network_acl.go:255 lxc/network_acl.go:311 lxc/network_acl.go:384 lxc/network_acl.go:481 lxc/network_acl.go:567 lxc/network_acl.go:610 lxc/network_acl.go:749 lxc/network_acl.go:806 lxc/network_acl.go:863 lxc/network_acl.go:878 lxc/network_acl.go:1016 lxc/network_allocations.go:52 lxc/network_forward.go:36 lxc/network_forward.go:93 lxc/network_forward.go:182 lxc/network_forward.go:259 lxc/network_forward.go:415 lxc/network_forward.go:500 lxc/network_forward.go:608 lxc/network_forward.go:655 lxc/network_forward.go:809 lxc/network_forward.go:883 lxc/network_forward.go:898 lxc/network_forward.go:983 lxc/network_load_balancer.go:36 lxc/network_load_balancer.go:97 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:479 lxc/network_load_balancer.go:587 lxc/network_load_balancer.go:617 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:845 lxc/network_load_balancer.go:860 lxc/network_load_balancer.go:936 lxc/network_load_balancer.go:1034 lxc/network_load_balancer.go:1049 lxc/network_load_balancer.go:1122 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:168 lxc/network_peer.go:237 lxc/network_peer.go:362 lxc/network_peer.go:447 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:32 lxc/network_zone.go:90 lxc/network_zone.go:186 lxc/network_zone.go:249 lxc/network_zone.go:322 lxc/network_zone.go:417 lxc/network_zone.go:503 lxc/network_zone.go:546 lxc/network_zone.go:673 lxc/network_zone.go:729 lxc/network_zone.go:786 lxc/network_zone.go:864 lxc/network_zone.go:928 lxc/network_zone.go:1004 lxc/network_zone.go:1102 lxc/network_zone.go:1189 lxc/network_zone.go:1236 lxc/network_zone.go:1366 lxc/network_zone.go:1427 lxc/network_zone.go:1442 lxc/network_zone.go:1500 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:38 lxc/profile.go:113 lxc/profile.go:193 lxc/profile.go:289 lxc/profile.go:371 lxc/profile.go:453 lxc/profile.go:511 lxc/profile.go:647 lxc/profile.go:723 lxc/profile.go:880 lxc/profile.go:973 lxc/profile.go:1033 lxc/profile.go:1120 lxc/profile.go:1184 lxc/project.go:33 lxc/project.go:99 lxc/project.go:199 lxc/project.go:270 lxc/project.go:406 lxc/project.go:480 lxc/project.go:600 lxc/project.go:665 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:35 lxc/rebuild.go:28 lxc/remote.go:38 lxc/remote.go:94 lxc/remote.go:753 lxc/remote.go:791 lxc/remote.go:877 lxc/remote.go:958 lxc/remote.go:1022 lxc/remote.go:1071 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:35 lxc/storage.go:98 lxc/storage.go:204 lxc/storage.go:262 lxc/storage.go:394 lxc/storage.go:476 lxc/storage.go:656 lxc/storage.go:743 lxc/storage.go:845 lxc/storage.go:939 lxc/storage_bucket.go:31 lxc/storage_bucket.go:85 lxc/storage_bucket.go:190 lxc/storage_bucket.go:251 lxc/storage_bucket.go:384 lxc/storage_bucket.go:462 lxc/storage_bucket.go:556 lxc/storage_bucket.go:648 lxc/storage_bucket.go:717 lxc/storage_bucket.go:751 lxc/storage_bucket.go:792 lxc/storage_bucket.go:871 lxc/storage_bucket.go:977 lxc/storage_bucket.go:1041 lxc/storage_bucket.go:1176 lxc/storage_volume.go:67 lxc/storage_volume.go:240 lxc/storage_volume.go:315 lxc/storage_volume.go:396 lxc/storage_volume.go:621 lxc/storage_volume.go:730 lxc/storage_volume.go:817 lxc/storage_volume.go:922 lxc/storage_volume.go:1026 lxc/storage_volume.go:1247 lxc/storage_volume.go:1378 lxc/storage_volume.go:1539 lxc/storage_volume.go:1623 lxc/storage_volume.go:1876 lxc/storage_volume.go:1979 lxc/storage_volume.go:2106 lxc/storage_volume.go:2262 lxc/storage_volume.go:2383 lxc/storage_volume.go:2445 lxc/storage_volume.go:2581 lxc/storage_volume.go:2665 lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31 lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid   "Description"
 msgstr  ""
 
@@ -1589,7 +1593,7 @@ msgstr  ""
 msgid   "Description: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid   "Destination cluster member name"
 msgstr  ""
 
@@ -1856,7 +1860,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779 lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779 lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1904,7 +1908,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359 lxc/network_acl.go:544 lxc/network_forward.go:583 lxc/network_load_balancer.go:562 lxc/network_peer.go:524 lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100 lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623 lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/cluster.go:466 lxc/config.go:683 lxc/config.go:715 lxc/network.go:1359 lxc/network_acl.go:544 lxc/network_forward.go:583 lxc/network_load_balancer.go:562 lxc/network_peer.go:524 lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100 lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623 lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1914,7 +1918,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538 lxc/network_forward.go:577 lxc/network_load_balancer.go:556 lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160 lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807 lxc/storage_bucket.go:617 lxc/storage_volume.go:2192 lxc/storage_volume.go:2230
+#: lxc/cluster.go:460 lxc/network.go:1353 lxc/network_acl.go:538 lxc/network_forward.go:577 lxc/network_load_balancer.go:556 lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160 lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807 lxc/storage_bucket.go:617 lxc/storage_volume.go:2191 lxc/storage_volume.go:2229
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1963,7 +1967,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541 lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540 lxc/storage_volume.go:1590
 msgid   "Expires at"
 msgstr  ""
 
@@ -1986,7 +1990,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1998,11 +2002,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2127,7 +2131,7 @@ msgstr  ""
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
@@ -2254,7 +2258,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907 lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449 lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433 lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024 lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58 lxc/network_forward.go:96 lxc/network_load_balancer.go:100 lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789 lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482 lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658 lxc/storage_bucket.go:463 lxc/storage_bucket.go:793 lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/alias.go:112 lxc/auth.go:341 lxc/auth.go:921 lxc/auth.go:1907 lxc/cluster.go:128 lxc/cluster.go:984 lxc/cluster_group.go:449 lxc/config_template.go:275 lxc/config_trust.go:351 lxc/config_trust.go:433 lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:134 lxc/network.go:1024 lxc/network.go:1148 lxc/network_acl.go:101 lxc/network_allocations.go:58 lxc/network_forward.go:96 lxc/network_load_balancer.go:100 lxc/network_peer.go:86 lxc/network_zone.go:93 lxc/network_zone.go:789 lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482 lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658 lxc/storage_bucket.go:463 lxc/storage_bucket.go:793 lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2574,7 +2578,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2586,11 +2590,11 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid   "Ignore copy errors for volatile files"
 msgstr  ""
 
@@ -2636,7 +2640,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2644,7 +2648,7 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -2664,11 +2668,11 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -2803,15 +2807,15 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
@@ -2829,7 +2833,7 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311 lxc/storage_volume.go:1435 lxc/storage_volume.go:2028 lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311 lxc/storage_volume.go:1435 lxc/storage_volume.go:2027 lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -2873,7 +2877,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166 lxc/network_load_balancer.go:168 lxc/operation.go:178 lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166 lxc/network_load_balancer.go:168 lxc/operation.go:178 lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid   "LOCATION"
 msgstr  ""
 
@@ -3181,11 +3185,11 @@ msgstr  ""
 msgid   "List storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3569,12 +3573,12 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -3651,7 +3655,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510 lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114 lxc/storage_bucket.go:214 lxc/storage_bucket.go:290 lxc/storage_bucket.go:409 lxc/storage_bucket.go:487 lxc/storage_bucket.go:585 lxc/storage_bucket.go:675 lxc/storage_bucket.go:817 lxc/storage_bucket.go:904 lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080 lxc/storage_bucket.go:1203 lxc/storage_volume.go:287 lxc/storage_volume.go:362 lxc/storage_volume.go:659 lxc/storage_volume.go:766 lxc/storage_volume.go:857 lxc/storage_volume.go:962 lxc/storage_volume.go:1083 lxc/storage_volume.go:1300 lxc/storage_volume.go:2017 lxc/storage_volume.go:2158 lxc/storage_volume.go:2314 lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage.go:236 lxc/storage.go:314 lxc/storage.go:432 lxc/storage.go:510 lxc/storage.go:781 lxc/storage.go:885 lxc/storage_bucket.go:114 lxc/storage_bucket.go:214 lxc/storage_bucket.go:290 lxc/storage_bucket.go:409 lxc/storage_bucket.go:487 lxc/storage_bucket.go:585 lxc/storage_bucket.go:675 lxc/storage_bucket.go:817 lxc/storage_bucket.go:904 lxc/storage_bucket.go:1001 lxc/storage_bucket.go:1080 lxc/storage_bucket.go:1203 lxc/storage_volume.go:287 lxc/storage_volume.go:362 lxc/storage_volume.go:659 lxc/storage_volume.go:766 lxc/storage_volume.go:857 lxc/storage_volume.go:962 lxc/storage_volume.go:1083 lxc/storage_volume.go:1300 lxc/storage_volume.go:2016 lxc/storage_volume.go:2157 lxc/storage_volume.go:2313 lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -3667,7 +3671,7 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid   "Missing source volume name"
 msgstr  ""
 
@@ -3724,11 +3728,11 @@ msgstr  ""
 msgid   "Mounted: %v"
 msgstr  ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid   "Move instances within or in between LXD servers"
 msgstr  ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid   "Move instances within or in between LXD servers\n"
         "\n"
         "Transfer modes (--mode):\n"
@@ -3739,15 +3743,15 @@ msgid   "Move instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid   "Move to a project different from the source"
 msgstr  ""
 
@@ -3772,7 +3776,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195 lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408 lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117 lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164 lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575 lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528 lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/auth.go:380 lxc/auth.go:967 lxc/auth.go:1946 lxc/cluster.go:195 lxc/cluster.go:1075 lxc/cluster_group.go:510 lxc/config_trust.go:408 lxc/config_trust.go:513 lxc/list.go:571 lxc/network.go:1117 lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164 lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575 lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528 lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid   "NAME"
 msgstr  ""
 
@@ -3822,7 +3826,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539 lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538 lxc/storage_volume.go:1588
 msgid   "Name"
 msgstr  ""
 
@@ -3955,7 +3959,7 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
@@ -3993,11 +3997,11 @@ msgstr  ""
 msgid   "No need to specify a warning UUID when using --all"
 msgstr  ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -4011,7 +4015,7 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid   "Not a snapshot name"
 msgstr  ""
 
@@ -4023,11 +4027,11 @@ msgstr  ""
 msgid   "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -4052,7 +4056,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4086,7 +4090,7 @@ msgstr  ""
 msgid   "PID: %d"
 msgstr  ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid   "POOL"
 msgstr  ""
 
@@ -4102,7 +4106,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178 lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537 lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178 lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537 lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4241,7 +4245,7 @@ msgstr  ""
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
@@ -4309,7 +4313,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4333,7 +4337,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4344,7 +4348,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
 msgstr  ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4625,15 +4629,15 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -4683,7 +4687,7 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -4976,11 +4980,11 @@ msgid   "Set storage pool configuration keys\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5063,7 +5067,7 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -5208,7 +5212,7 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid   "Show storage volume configurations"
 msgstr  ""
 
@@ -5278,11 +5282,11 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
@@ -5387,7 +5391,7 @@ msgstr  ""
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -5466,11 +5470,11 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148 lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118 lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172 lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148 lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118 lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172 lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid   "Taken at"
 msgstr  ""
 
@@ -5486,32 +5490,8 @@ msgstr  ""
 msgid   "The --accept-certificate flag is not supported when adding a remote using a trust token"
 msgstr  ""
 
-#: lxc/move.go:187
-msgid   "The --instance-only flag can't be used with --target"
-msgstr  ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid   "The --mode flag can't be used with --storage or --target-project"
-msgstr  ""
-
-#: lxc/move.go:199
-msgid   "The --mode flag can't be used with --target"
-msgstr  ""
-
 #: lxc/console.go:134
 msgid   "The --show-log flag is only supported for by 'console' output type"
-msgstr  ""
-
-#: lxc/move.go:191
-msgid   "The --storage flag can't be used with --target"
-msgstr  ""
-
-#: lxc/move.go:195
-msgid   "The --target-project flag can't be used with --target"
-msgstr  ""
-
-#: lxc/move.go:211
-msgid   "The destination LXD server is not clustered"
 msgstr  ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -5645,10 +5625,6 @@ msgstr  ""
 msgid   "The server doesn't support setting the metadata format version"
 msgstr  ""
 
-#: lxc/move.go:317
-msgid   "The source LXD server is not clustered"
-msgstr  ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid   "The specified device doesn't exist"
 msgstr  ""
@@ -5733,7 +5709,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -5749,7 +5725,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull, push or relay"
 msgstr  ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
@@ -5758,7 +5734,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -5819,11 +5795,11 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23 lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583 lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23 lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583 lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid   "USED BY"
 msgstr  ""
 
@@ -5855,7 +5831,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785 lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785 lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5888,7 +5864,7 @@ msgstr  ""
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid   "Unset all profiles on the target instance"
 msgstr  ""
 
@@ -5960,7 +5936,7 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
@@ -6012,7 +5988,7 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -6059,11 +6035,11 @@ msgstr  ""
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid   "Use a different metadata format version than the latest one supported by the server (to support imports on older LXD versions)"
 msgstr  ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -6128,7 +6104,7 @@ msgstr  ""
 msgid   "View the current identity"
 msgstr  ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid   "Volume Only"
 msgstr  ""
 
@@ -6173,7 +6149,7 @@ msgstr  ""
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid   "You must specify a source instance name"
 msgstr  ""
 
@@ -6445,7 +6421,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr  ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -6577,7 +6553,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -6609,19 +6585,19 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
@@ -6637,15 +6613,15 @@ msgstr  ""
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr  ""
 
@@ -6661,7 +6637,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
@@ -6769,7 +6745,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
@@ -6995,7 +6971,7 @@ msgid   "lxc monitor --type=logging\n"
         "    Only show lifecycle events."
 msgstr  ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid   "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--instance-only]\n"
         "    Move an instance between two hosts, renaming it if destination name differs.\n"
         "\n"
@@ -7174,12 +7150,12 @@ msgid   "lxc storage volume create p1 v1\n"
         "	Create storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid   "lxc storage volume snapshot default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
         "\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -719,6 +719,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -968,7 +972,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -1093,16 +1097,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1118,7 +1122,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1166,7 +1170,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1218,7 +1222,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1251,7 +1255,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1376,7 +1380,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1396,11 +1400,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1417,7 +1421,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1449,7 +1453,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1480,7 +1484,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1544,7 +1548,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1780,7 +1784,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1800,7 +1804,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1946,7 +1950,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -2006,12 +2010,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -2021,7 +2025,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2294,7 +2298,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2351,7 +2355,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2365,8 +2369,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2418,8 +2422,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2443,7 +2447,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2455,11 +2459,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2585,7 +2589,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2733,7 +2737,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3053,7 +3057,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3067,11 +3071,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3117,7 +3121,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3125,7 +3129,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3147,11 +3151,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3287,15 +3291,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3314,8 +3318,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3361,7 +3365,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3682,11 +3686,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4077,12 +4081,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4218,9 +4222,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4239,7 +4243,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4298,11 +4302,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4318,15 +4322,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4357,7 +4361,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4409,8 +4413,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4544,7 +4548,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4582,11 +4586,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4600,7 +4604,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4613,11 +4617,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4642,7 +4646,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4676,7 +4680,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4694,7 +4698,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4842,7 +4846,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4916,7 +4920,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4946,7 +4950,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4959,7 +4963,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5244,15 +5248,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5304,7 +5308,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5624,11 +5628,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5713,7 +5717,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5862,7 +5866,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5934,11 +5938,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -6043,7 +6047,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -6125,11 +6129,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -6147,32 +6151,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6310,10 +6290,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6405,7 +6381,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6421,7 +6397,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6430,7 +6406,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6494,13 +6470,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6533,7 +6509,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6566,7 +6542,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6638,7 +6614,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6690,7 +6666,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6739,13 +6715,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6812,7 +6788,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6863,7 +6839,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7154,7 +7130,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7302,7 +7278,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7337,21 +7313,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7367,15 +7343,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7394,7 +7370,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7504,7 +7480,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7773,7 +7749,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7988,13 +7964,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,6 +757,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -1006,7 +1010,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -1131,16 +1135,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1156,7 +1160,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1204,7 +1208,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1289,7 +1293,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1434,11 +1438,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1455,7 +1459,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1487,7 +1491,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1582,7 +1586,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1818,7 +1822,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1838,7 +1842,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1984,7 +1988,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -2044,12 +2048,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -2059,7 +2063,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2332,7 +2336,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2389,7 +2393,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2403,8 +2407,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2456,8 +2460,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2481,7 +2485,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2493,11 +2497,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2623,7 +2627,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2771,7 +2775,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3091,7 +3095,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3105,11 +3109,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3155,7 +3159,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3163,7 +3167,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3185,11 +3189,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3325,15 +3329,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3352,8 +3356,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3399,7 +3403,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3720,11 +3724,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4115,12 +4119,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4256,9 +4260,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4277,7 +4281,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4336,11 +4340,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4356,15 +4360,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4395,7 +4399,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4447,8 +4451,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4582,7 +4586,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4620,11 +4624,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4638,7 +4642,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4651,11 +4655,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4680,7 +4684,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4714,7 +4718,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4732,7 +4736,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4880,7 +4884,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4954,7 +4958,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4984,7 +4988,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4997,7 +5001,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5282,15 +5286,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5342,7 +5346,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5662,11 +5666,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5751,7 +5755,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5900,7 +5904,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5972,11 +5976,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -6081,7 +6085,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -6163,11 +6167,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -6185,32 +6189,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6348,10 +6328,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6443,7 +6419,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6459,7 +6435,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6468,7 +6444,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6532,13 +6508,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6571,7 +6547,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6604,7 +6580,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6676,7 +6652,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6728,7 +6704,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6777,13 +6753,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6850,7 +6826,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6901,7 +6877,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7192,7 +7168,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7340,7 +7316,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7375,21 +7351,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7405,15 +7381,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7432,7 +7408,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7542,7 +7518,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7811,7 +7787,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8026,13 +8002,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -492,6 +492,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -741,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -866,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -891,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -939,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +995,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1024,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1149,7 +1153,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1169,11 +1173,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1190,7 +1194,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1222,7 +1226,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1253,7 +1257,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1317,7 +1321,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1553,7 +1557,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1719,7 +1723,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1779,12 +1783,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1794,7 +1798,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2067,7 +2071,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2138,8 +2142,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2191,8 +2195,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2220,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2232,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2358,7 +2362,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2506,7 +2510,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2826,7 +2830,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2840,11 +2844,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2890,7 +2894,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2898,7 +2902,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2920,11 +2924,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3060,15 +3064,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3087,8 +3091,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3455,11 +3459,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3850,12 +3854,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3991,9 +3995,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4012,7 +4016,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4071,11 +4075,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4091,15 +4095,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4130,7 +4134,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4182,8 +4186,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4317,7 +4321,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4355,11 +4359,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4373,7 +4377,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4386,11 +4390,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4415,7 +4419,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4449,7 +4453,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4467,7 +4471,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4615,7 +4619,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4689,7 +4693,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4723,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4732,7 +4736,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5017,15 +5021,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5077,7 +5081,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5397,11 +5401,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5486,7 +5490,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5635,7 +5639,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5707,11 +5711,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5816,7 +5820,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5898,11 +5902,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5920,32 +5924,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6083,10 +6063,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6178,7 +6154,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6194,7 +6170,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6203,7 +6179,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6267,13 +6243,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6306,7 +6282,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6339,7 +6315,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6411,7 +6387,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6463,7 +6439,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6512,13 +6488,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6585,7 +6561,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6636,7 +6612,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6927,7 +6903,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7075,7 +7051,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7110,21 +7086,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7140,15 +7116,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7167,7 +7143,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7277,7 +7253,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7546,7 +7522,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7761,13 +7737,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -752,6 +752,11 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
+#: lxc/move.go:294
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--refresh só pode ser usado com containers"
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 #, fuzzy
@@ -1011,7 +1016,7 @@ msgstr "Alias %s já existe"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -1145,16 +1150,16 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1170,7 +1175,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1218,7 +1223,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1271,7 +1276,7 @@ msgstr "Em cache: %s"
 msgid "Caches:"
 msgstr "Em cache: %s"
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1305,7 +1310,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -1432,7 +1437,7 @@ msgstr "Dispositivo %s removido de %s"
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1452,11 +1457,11 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1473,7 +1478,7 @@ msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1513,7 +1518,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1545,7 +1550,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "Ignorar o estado do container"
@@ -1611,7 +1616,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1868,7 +1873,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1888,7 +1893,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -2048,7 +2053,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -2108,12 +2113,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr "Descrição"
@@ -2123,7 +2128,7 @@ msgstr "Descrição"
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
@@ -2428,7 +2433,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2485,7 +2490,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2499,8 +2504,8 @@ msgstr "Editar propriedades da imagem"
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2553,8 +2558,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2578,7 +2583,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2590,11 +2595,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
@@ -2869,7 +2874,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3209,7 +3214,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3223,11 +3228,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3275,7 +3280,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3283,7 +3288,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3305,11 +3310,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3445,16 +3450,16 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3473,8 +3478,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -3521,7 +3526,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3852,11 +3857,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4275,12 +4280,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4430,9 +4435,9 @@ msgstr "Nome de membro do cluster"
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4451,7 +4456,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4513,11 +4518,11 @@ msgstr "Adicionar perfis aos containers"
 msgid "Mounted: %v"
 msgstr "Marca: %v"
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4533,15 +4538,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4572,7 +4577,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4624,8 +4629,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4759,7 +4764,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4797,11 +4802,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4815,7 +4820,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4828,11 +4833,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4857,7 +4862,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4891,7 +4896,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4909,7 +4914,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -5060,7 +5065,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -5137,7 +5142,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5167,7 +5172,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5180,7 +5185,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5485,15 +5490,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5552,7 +5557,7 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5888,11 +5893,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5983,7 +5988,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -6151,7 +6156,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -6227,11 +6232,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -6336,7 +6341,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -6419,11 +6424,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -6442,35 +6447,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-#, fuzzy
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr "--refresh só pode ser usado com containers"
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-#, fuzzy
-msgid "The --storage flag can't be used with --target"
-msgstr "--refresh só pode ser usado com containers"
-
-#: lxc/move.go:195
-#, fuzzy
-msgid "The --target-project flag can't be used with --target"
-msgstr "--refresh só pode ser usado com containers"
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6608,10 +6586,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6705,7 +6679,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6721,7 +6695,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6730,7 +6704,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -6796,13 +6770,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6836,7 +6810,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6871,7 +6845,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -6958,7 +6932,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -7017,7 +6991,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7068,13 +7042,13 @@ msgstr "Editar arquivos no container"
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7141,7 +7115,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7192,7 +7166,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7515,7 +7489,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7679,7 +7653,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -7719,22 +7693,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7751,17 +7725,17 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Criar perfis"
@@ -7784,7 +7758,7 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
@@ -7907,7 +7881,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
@@ -8180,7 +8154,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8395,13 +8369,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8468,6 +8442,18 @@ msgstr ""
 #: lxc/image.go:1207
 msgid "yes"
 msgstr "sim"
+
+#, fuzzy
+#~ msgid "The --mode flag can't be used with --storage or --target-project"
+#~ msgstr "--refresh só pode ser usado com containers"
+
+#, fuzzy
+#~ msgid "The --storage flag can't be used with --target"
+#~ msgstr "--refresh só pode ser usado com containers"
+
+#, fuzzy
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr "--refresh só pode ser usado com containers"
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "Ação (padrão para o GET)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -752,6 +752,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -1012,7 +1016,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -1142,16 +1146,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1167,7 +1171,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1215,7 +1219,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1269,7 +1273,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1432,7 +1436,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1452,11 +1456,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1473,7 +1477,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1536,7 +1540,7 @@ msgstr "Авто-обновление: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 #, fuzzy
 msgid "Copy a stateful instance as stateless"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1602,7 +1606,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1859,7 +1863,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1879,7 +1883,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2035,7 +2039,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -2095,12 +2099,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -2110,7 +2114,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
@@ -2405,7 +2409,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2462,7 +2466,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2476,8 +2480,8 @@ msgstr "Копирование образа: %s"
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2533,8 +2537,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2559,7 +2563,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2574,12 +2578,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2705,7 +2709,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
@@ -2854,7 +2858,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3191,7 +3195,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3205,11 +3209,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3256,7 +3260,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3264,7 +3268,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -3289,11 +3293,11 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3432,16 +3436,16 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3460,8 +3464,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -3508,7 +3512,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3846,12 +3850,12 @@ msgstr "Копирование образа: %s"
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4274,12 +4278,12 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4429,9 +4433,9 @@ msgstr "Имя контейнера: %s"
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4451,7 +4455,7 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
@@ -4514,11 +4518,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4534,16 +4538,16 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4574,7 +4578,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4626,8 +4630,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4763,7 +4767,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4802,11 +4806,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4820,7 +4824,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -4834,11 +4838,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4863,7 +4867,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4897,7 +4901,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4915,7 +4919,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -5064,7 +5068,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5138,7 +5142,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5168,7 +5172,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5181,7 +5185,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5481,17 +5485,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5546,7 +5550,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -5878,11 +5882,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5974,7 +5978,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -6138,7 +6142,7 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -6214,12 +6218,12 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -6327,7 +6331,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -6410,11 +6414,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -6432,32 +6436,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6595,10 +6575,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6691,7 +6667,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6707,7 +6683,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6716,7 +6692,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6781,13 +6757,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6820,7 +6796,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6855,7 +6831,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6936,7 +6912,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6996,7 +6972,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -7048,13 +7024,13 @@ msgstr "Копирование образа: %s"
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7121,7 +7097,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -7172,7 +7148,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7711,7 +7687,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -7987,7 +7963,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8054,7 +8030,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8064,7 +8040,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8072,7 +8048,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8080,7 +8056,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8112,7 +8088,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8120,7 +8096,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8128,7 +8104,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8163,7 +8139,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8381,7 +8357,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8666,7 +8642,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -8881,13 +8857,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -496,6 +496,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -745,7 +749,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -870,16 +874,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -895,7 +899,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -943,7 +947,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -995,7 +999,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1028,7 +1032,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1153,7 +1157,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1173,11 +1177,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1194,7 +1198,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1226,7 +1230,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1257,7 +1261,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1321,7 +1325,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1557,7 +1561,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1577,7 +1581,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1723,7 +1727,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1783,12 +1787,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1798,7 +1802,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2071,7 +2075,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,7 +2132,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2142,8 +2146,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2195,8 +2199,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2220,7 +2224,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2232,11 +2236,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2362,7 +2366,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2510,7 +2514,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2830,7 +2834,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2844,11 +2848,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2894,7 +2898,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2902,7 +2906,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2924,11 +2928,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3064,15 +3068,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3091,8 +3095,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3138,7 +3142,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3459,11 +3463,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3854,12 +3858,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3995,9 +3999,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4016,7 +4020,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4075,11 +4079,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4095,15 +4099,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4134,7 +4138,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4186,8 +4190,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4321,7 +4325,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4359,11 +4363,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4377,7 +4381,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4390,11 +4394,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4419,7 +4423,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4453,7 +4457,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4471,7 +4475,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4619,7 +4623,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4693,7 +4697,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4723,7 +4727,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4736,7 +4740,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5021,15 +5025,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5081,7 +5085,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5401,11 +5405,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5490,7 +5494,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5639,7 +5643,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5711,11 +5715,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5820,7 +5824,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5902,11 +5906,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5924,32 +5928,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6087,10 +6067,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6182,7 +6158,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6198,7 +6174,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6207,7 +6183,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6271,13 +6247,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6310,7 +6286,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6343,7 +6319,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6415,7 +6391,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6467,7 +6443,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6516,13 +6492,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6589,7 +6565,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6640,7 +6616,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6931,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7079,7 +7055,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7114,21 +7090,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7144,15 +7120,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7171,7 +7147,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7281,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7550,7 +7526,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7765,13 +7741,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -496,6 +496,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -745,7 +749,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -870,16 +874,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -895,7 +899,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -943,7 +947,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -995,7 +999,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1028,7 +1032,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1153,7 +1157,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1173,11 +1177,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1194,7 +1198,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1226,7 +1230,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1257,7 +1261,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1321,7 +1325,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1557,7 +1561,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1577,7 +1581,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1723,7 +1727,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1783,12 +1787,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1798,7 +1802,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2071,7 +2075,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,7 +2132,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2142,8 +2146,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2195,8 +2199,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2220,7 +2224,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2232,11 +2236,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2362,7 +2366,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2510,7 +2514,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2830,7 +2834,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2844,11 +2848,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2894,7 +2898,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2902,7 +2906,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2924,11 +2928,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3064,15 +3068,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3091,8 +3095,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3138,7 +3142,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3459,11 +3463,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3854,12 +3858,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3995,9 +3999,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4016,7 +4020,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4075,11 +4079,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4095,15 +4099,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4134,7 +4138,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4186,8 +4190,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4321,7 +4325,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4359,11 +4363,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4377,7 +4381,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4390,11 +4394,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4419,7 +4423,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4453,7 +4457,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4471,7 +4475,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4619,7 +4623,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4693,7 +4697,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4723,7 +4727,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4736,7 +4740,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5021,15 +5025,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5081,7 +5085,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5401,11 +5405,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5490,7 +5494,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5639,7 +5643,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5711,11 +5715,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5820,7 +5824,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5902,11 +5906,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5924,32 +5928,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6087,10 +6067,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6182,7 +6158,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6198,7 +6174,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6207,7 +6183,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6271,13 +6247,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6310,7 +6286,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6343,7 +6319,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6415,7 +6391,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6467,7 +6443,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6516,13 +6492,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6589,7 +6565,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6640,7 +6616,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6931,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7079,7 +7055,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7114,21 +7090,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7144,15 +7120,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7171,7 +7147,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7281,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7550,7 +7526,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7765,13 +7741,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -492,6 +492,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -741,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -866,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -891,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -939,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +995,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1024,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1149,7 +1153,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1169,11 +1173,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1190,7 +1194,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1222,7 +1226,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1253,7 +1257,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1317,7 +1321,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1553,7 +1557,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1719,7 +1723,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1779,12 +1783,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1794,7 +1798,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2067,7 +2071,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2138,8 +2142,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2191,8 +2195,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2216,7 +2220,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2228,11 +2232,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2358,7 +2362,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2506,7 +2510,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2826,7 +2830,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2840,11 +2844,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2890,7 +2894,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2898,7 +2902,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2920,11 +2924,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3060,15 +3064,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3087,8 +3091,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3455,11 +3459,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3850,12 +3854,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3991,9 +3995,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4012,7 +4016,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4071,11 +4075,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4091,15 +4095,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4130,7 +4134,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4182,8 +4186,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4317,7 +4321,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4355,11 +4359,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4373,7 +4377,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4386,11 +4390,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4415,7 +4419,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4449,7 +4453,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4467,7 +4471,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4615,7 +4619,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4689,7 +4693,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4719,7 +4723,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4732,7 +4736,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5017,15 +5021,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5077,7 +5081,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5397,11 +5401,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5486,7 +5490,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5635,7 +5639,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5707,11 +5711,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5816,7 +5820,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5898,11 +5902,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5920,32 +5924,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6083,10 +6063,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6178,7 +6154,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6194,7 +6170,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6203,7 +6179,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6267,13 +6243,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6306,7 +6282,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6339,7 +6315,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6411,7 +6387,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6463,7 +6439,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6512,13 +6488,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6585,7 +6561,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6636,7 +6612,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6927,7 +6903,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7075,7 +7051,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7110,21 +7086,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7140,15 +7116,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7167,7 +7143,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7277,7 +7253,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7546,7 +7522,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7761,13 +7737,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -496,6 +496,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -745,7 +749,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -870,16 +874,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -895,7 +899,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -943,7 +947,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -995,7 +999,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1028,7 +1032,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1153,7 +1157,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1173,11 +1177,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1194,7 +1198,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1226,7 +1230,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1257,7 +1261,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1321,7 +1325,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1557,7 +1561,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1577,7 +1581,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1723,7 +1727,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1783,12 +1787,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1798,7 +1802,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2071,7 +2075,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2128,7 +2132,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2142,8 +2146,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2195,8 +2199,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2220,7 +2224,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2232,11 +2236,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2362,7 +2366,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2510,7 +2514,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2830,7 +2834,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2844,11 +2848,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2894,7 +2898,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2902,7 +2906,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2924,11 +2928,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3064,15 +3068,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3091,8 +3095,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3138,7 +3142,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3459,11 +3463,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3854,12 +3858,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3995,9 +3999,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4016,7 +4020,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4075,11 +4079,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4095,15 +4099,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4134,7 +4138,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4186,8 +4190,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4321,7 +4325,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4359,11 +4363,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4377,7 +4381,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4390,11 +4394,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4419,7 +4423,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4453,7 +4457,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4471,7 +4475,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4619,7 +4623,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4693,7 +4697,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4723,7 +4727,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4736,7 +4740,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5021,15 +5025,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5081,7 +5085,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5401,11 +5405,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5490,7 +5494,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5639,7 +5643,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5711,11 +5715,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5820,7 +5824,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5902,11 +5906,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5924,32 +5928,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6087,10 +6067,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6182,7 +6158,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6198,7 +6174,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6207,7 +6183,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6271,13 +6247,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6310,7 +6286,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6343,7 +6319,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6415,7 +6391,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6467,7 +6443,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6516,13 +6492,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6589,7 +6565,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6640,7 +6616,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6931,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7079,7 +7055,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7114,21 +7090,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7144,15 +7120,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7171,7 +7147,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7281,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7550,7 +7526,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7765,13 +7741,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -656,6 +656,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -905,7 +909,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -1030,16 +1034,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -1055,7 +1059,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1103,7 +1107,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1155,7 +1159,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1188,7 +1192,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1313,7 +1317,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1333,11 +1337,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1354,7 +1358,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1386,7 +1390,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1417,7 +1421,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1481,7 +1485,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1717,7 +1721,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1737,7 +1741,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1883,7 +1887,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1943,12 +1947,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1958,7 +1962,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2231,7 +2235,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2302,8 +2306,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2355,8 +2359,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2380,7 +2384,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2392,11 +2396,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2522,7 +2526,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2670,7 +2674,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3004,11 +3008,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3054,7 +3058,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3062,7 +3066,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3084,11 +3088,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3224,15 +3228,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3251,8 +3255,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3298,7 +3302,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3619,11 +3623,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4014,12 +4018,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4155,9 +4159,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4176,7 +4180,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4235,11 +4239,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4255,15 +4259,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4294,7 +4298,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4346,8 +4350,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4481,7 +4485,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4519,11 +4523,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4537,7 +4541,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4550,11 +4554,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4579,7 +4583,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4613,7 +4617,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4631,7 +4635,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4779,7 +4783,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4853,7 +4857,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4883,7 +4887,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4896,7 +4900,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5181,15 +5185,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5241,7 +5245,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5561,11 +5565,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5799,7 +5803,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5871,11 +5875,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5980,7 +5984,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -6062,11 +6066,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -6084,32 +6088,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6247,10 +6227,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6358,7 +6334,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6367,7 +6343,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6431,13 +6407,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6470,7 +6446,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6503,7 +6479,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6575,7 +6551,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6627,7 +6603,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6676,13 +6652,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6749,7 +6725,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6800,7 +6776,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7091,7 +7067,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7239,7 +7215,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7274,21 +7250,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7304,15 +7280,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7331,7 +7307,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7441,7 +7417,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7710,7 +7686,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7925,13 +7901,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"POT-Creation-Date: 2025-07-30 16:03-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -495,6 +495,10 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: lxc/move.go:294
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: lxc/config.go:211 lxc/config.go:482 lxc/config.go:657 lxc/config.go:864
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1622
 msgid "All projects"
 msgstr ""
 
@@ -869,16 +873,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2745
+#: lxc/storage_volume.go:2744
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:209 lxc/storage_volume.go:2823
+#: lxc/export.go:209 lxc/storage_volume.go:2822
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1554
+#: lxc/info.go:666 lxc/storage_volume.go:1553
 msgid "Backups:"
 msgstr ""
 
@@ -894,7 +898,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:401 lxc/project.go:169
+#: lxc/copy.go:153 lxc/init.go:245 lxc/move.go:340 lxc/project.go:169
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -942,7 +946,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1766
+#: lxc/storage_volume.go:1765
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -994,7 +998,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:136
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:608 lxc/storage_volume.go:1776 lxc/warning.go:226
+#: lxc/list.go:608 lxc/storage_volume.go:1775 lxc/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: lxc/config.go:147 lxc/config.go:439 lxc/config.go:590 lxc/config.go:797
 #: lxc/config.go:928 lxc/copy.go:63 lxc/info.go:45 lxc/init.go:65
-#: lxc/move.go:68 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
+#: lxc/move.go:67 lxc/network.go:338 lxc/network.go:809 lxc/network.go:890
 #: lxc/network.go:1025 lxc/network.go:1291 lxc/network.go:1382
 #: lxc/network.go:1454 lxc/network_forward.go:185 lxc/network_forward.go:267
 #: lxc/network_forward.go:508 lxc/network_forward.go:658
@@ -1172,11 +1176,11 @@ msgstr ""
 #: lxc/storage_bucket.go:1181 lxc/storage_volume.go:400
 #: lxc/storage_volume.go:628 lxc/storage_volume.go:733
 #: lxc/storage_volume.go:1035 lxc/storage_volume.go:1261
-#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1881
-#: lxc/storage_volume.go:1983 lxc/storage_volume.go:2122
-#: lxc/storage_volume.go:2280 lxc/storage_volume.go:2396
-#: lxc/storage_volume.go:2457 lxc/storage_volume.go:2584
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2845
+#: lxc/storage_volume.go:1390 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1982 lxc/storage_volume.go:2121
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2395
+#: lxc/storage_volume.go:2456 lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2674 lxc/storage_volume.go:2844
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1118 lxc/list.go:133 lxc/profile.go:737
-#: lxc/storage_volume.go:1622 lxc/warning.go:94
+#: lxc/storage_volume.go:1621 lxc/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/move.go:66
+#: lxc/move.go:65
 msgid "Copy a stateful instance as stateless"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:69 lxc/profile.go:291
+#: lxc/copy.go:64 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:291
 #: lxc/storage_volume.go:403
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1556,7 +1560,7 @@ msgstr ""
 #: lxc/network_zone.go:165 lxc/network_zone.go:847 lxc/operation.go:173
 #: lxc/profile.go:763 lxc/project.go:582 lxc/storage.go:724
 #: lxc/storage_bucket.go:529 lxc/storage_bucket.go:851
-#: lxc/storage_volume.go:1765
+#: lxc/storage_volume.go:1764
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1580,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2672
+#: lxc/storage_volume.go:2671
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1722,7 +1726,7 @@ msgstr ""
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:50 lxc/main.go:85 lxc/manpage.go:22
-#: lxc/monitor.go:34 lxc/move.go:39 lxc/network.go:36 lxc/network.go:139
+#: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:36 lxc/network.go:139
 #: lxc/network.go:241 lxc/network.go:331 lxc/network.go:418 lxc/network.go:476
 #: lxc/network.go:573 lxc/network.go:670 lxc/network.go:806 lxc/network.go:887
 #: lxc/network.go:1020 lxc/network.go:1146 lxc/network.go:1225
@@ -1782,12 +1786,12 @@ msgstr ""
 #: lxc/storage_volume.go:730 lxc/storage_volume.go:817
 #: lxc/storage_volume.go:922 lxc/storage_volume.go:1026
 #: lxc/storage_volume.go:1247 lxc/storage_volume.go:1378
-#: lxc/storage_volume.go:1540 lxc/storage_volume.go:1624
-#: lxc/storage_volume.go:1877 lxc/storage_volume.go:1980
-#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2263
-#: lxc/storage_volume.go:2384 lxc/storage_volume.go:2446
-#: lxc/storage_volume.go:2582 lxc/storage_volume.go:2666
-#: lxc/storage_volume.go:2840 lxc/version.go:22 lxc/warning.go:31
+#: lxc/storage_volume.go:1539 lxc/storage_volume.go:1623
+#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2262
+#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2445
+#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2665
+#: lxc/storage_volume.go:2839 lxc/version.go:22 lxc/warning.go:31
 #: lxc/warning.go:73 lxc/warning.go:264 lxc/warning.go:305 lxc/warning.go:359
 msgid "Description"
 msgstr ""
@@ -1797,7 +1801,7 @@ msgstr ""
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:401 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:401 lxc/storage_volume.go:1881
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2070,7 +2074,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1162 lxc/list.go:620 lxc/profile.go:779
-#: lxc/storage_volume.go:1799 lxc/warning.go:237
+#: lxc/storage_volume.go:1798 lxc/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2127,7 +2131,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:562 lxc/network_peer.go:524
 #: lxc/network_zone.go:480 lxc/network_zone.go:1166 lxc/profile.go:1100
 #: lxc/project.go:728 lxc/storage.go:813 lxc/storage_bucket.go:623
-#: lxc/storage_volume.go:2198 lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2197 lxc/storage_volume.go:2235
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2141,8 +2145,8 @@ msgstr ""
 #: lxc/network_forward.go:577 lxc/network_load_balancer.go:556
 #: lxc/network_peer.go:518 lxc/network_zone.go:474 lxc/network_zone.go:1160
 #: lxc/profile.go:1094 lxc/project.go:722 lxc/storage.go:807
-#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2192
-#: lxc/storage_volume.go:2230
+#: lxc/storage_bucket.go:617 lxc/storage_volume.go:2191
+#: lxc/storage_volume.go:2229
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2194,8 +2198,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1541
-#: lxc/storage_volume.go:1591
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1540
+#: lxc/storage_volume.go:1590
 msgid "Expires at"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2665 lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2664 lxc/storage_volume.go:2665
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2231,11 +2235,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2669
+#: lxc/storage_volume.go:2668
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:169 lxc/storage_volume.go:2806
+#: lxc/export.go:169 lxc/storage_volume.go:2805
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2361,7 +2365,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:312 lxc/move.go:388
+#: lxc/move.go:290
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2509,7 +2513,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:740 lxc/project.go:482
 #: lxc/project.go:925 lxc/remote.go:795 lxc/storage.go:658
 #: lxc/storage_bucket.go:463 lxc/storage_bucket.go:793
-#: lxc/storage_volume.go:1641 lxc/warning.go:95
+#: lxc/storage_volume.go:1640 lxc/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2456
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2455
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2455
+#: lxc/storage_volume.go:2454
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:67 lxc/move.go:70
+#: lxc/copy.go:67 lxc/move.go:69
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2840
+#: lxc/storage_volume.go:2839
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2839
+#: lxc/storage_volume.go:2838
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2923,11 +2927,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2847
+#: lxc/storage_volume.go:2846
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2921
+#: lxc/storage_volume.go:2920
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3063,15 +3067,15 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:154 lxc/storage_volume.go:2043
+#: lxc/move.go:153 lxc/storage_volume.go:2042
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2039
+#: lxc/storage_volume.go:2038
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,8 +3094,8 @@ msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:1094 lxc/storage_volume.go:1311
-#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2028
-#: lxc/storage_volume.go:2175 lxc/storage_volume.go:2325
+#: lxc/storage_volume.go:1435 lxc/storage_volume.go:2027
+#: lxc/storage_volume.go:2174 lxc/storage_volume.go:2324
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 
 #: lxc/list.go:604 lxc/network.go:1208 lxc/network_forward.go:166
 #: lxc/network_load_balancer.go:168 lxc/operation.go:178
-#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1772 lxc/warning.go:222
+#: lxc/storage_bucket.go:533 lxc/storage_volume.go:1771 lxc/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,11 +3462,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1619
+#: lxc/storage_volume.go:1618
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1623
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3853,12 +3857,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:330 lxc/move.go:450
+#: lxc/move.go:374
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:355 lxc/move.go:455
+#: lxc/move.go:393
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3994,9 +3998,9 @@ msgstr ""
 #: lxc/storage_volume.go:362 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:766 lxc/storage_volume.go:857
 #: lxc/storage_volume.go:962 lxc/storage_volume.go:1083
-#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2017
-#: lxc/storage_volume.go:2158 lxc/storage_volume.go:2314
-#: lxc/storage_volume.go:2505 lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:1300 lxc/storage_volume.go:2016
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2504 lxc/storage_volume.go:2621
 msgid "Missing pool name"
 msgstr ""
 
@@ -4015,7 +4019,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:448 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:448 lxc/storage_volume.go:1926
 msgid "Missing source volume name"
 msgstr ""
 
@@ -4074,11 +4078,11 @@ msgstr ""
 msgid "Mounted: %v"
 msgstr ""
 
-#: lxc/move.go:38
+#: lxc/move.go:37
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:38
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4094,15 +4098,15 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1876 lxc/storage_volume.go:1877
+#: lxc/storage_volume.go:1875 lxc/storage_volume.go:1876
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:64
+#: lxc/move.go:63
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1883
+#: lxc/storage_volume.go:1882
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4133,7 +4137,7 @@ msgstr ""
 #: lxc/network_acl.go:172 lxc/network_peer.go:149 lxc/network_zone.go:164
 #: lxc/network_zone.go:846 lxc/profile.go:761 lxc/project.go:575
 #: lxc/remote.go:853 lxc/storage.go:716 lxc/storage_bucket.go:528
-#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1764
+#: lxc/storage_bucket.go:850 lxc/storage_volume.go:1763
 msgid "NAME"
 msgstr ""
 
@@ -4185,8 +4189,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1539
-#: lxc/storage_volume.go:1589
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1538
+#: lxc/storage_volume.go:1588
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:61
+#: lxc/copy.go:56 lxc/import.go:37 lxc/init.go:60 lxc/move.go:60
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4358,11 +4362,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:462 lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:462 lxc/storage_volume.go:1935
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:512 lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:512 lxc/storage_volume.go:1946
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4376,7 +4380,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2055
+#: lxc/storage_volume.go:2054
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4389,11 +4393,11 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2721
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2518
+#: lxc/storage_volume.go:2517
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1593
+#: lxc/info.go:705 lxc/storage_volume.go:1592
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4452,7 +4456,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1783
+#: lxc/storage_volume.go:1782
 msgid "POOL"
 msgstr ""
 
@@ -4470,7 +4474,7 @@ msgstr ""
 
 #: lxc/image.go:1141 lxc/list.go:565 lxc/network.go:1128 lxc/network_acl.go:178
 #: lxc/network_zone.go:170 lxc/profile.go:762 lxc/storage_bucket.go:537
-#: lxc/storage_volume.go:1789 lxc/warning.go:214
+#: lxc/storage_volume.go:1788 lxc/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
@@ -4618,7 +4622,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -4692,7 +4696,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2265
+#: lxc/storage_volume.go:2264
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4722,7 +4726,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2112
+#: lxc/storage_volume.go:2111
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4735,7 +4739,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2386
+#: lxc/storage_volume.go:2385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5020,15 +5024,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1979
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1978
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2068 lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2067 lxc/storage_volume.go:2087
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5080,7 +5084,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2581 lxc/storage_volume.go:2582
+#: lxc/storage_volume.go:2580 lxc/storage_volume.go:2581
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5400,11 +5404,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2105
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2106
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5489,7 +5493,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2122
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2263
+#: lxc/storage_volume.go:2261 lxc/storage_volume.go:2262
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5710,11 +5714,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2445 lxc/storage_volume.go:2446
+#: lxc/storage_volume.go:2444 lxc/storage_volume.go:2445
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2210
+#: lxc/storage_volume.go:2209
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:67
+#: lxc/copy.go:62 lxc/import.go:36 lxc/init.go:63 lxc/move.go:66
 msgid "Storage pool name"
 msgstr ""
 
@@ -5901,11 +5905,11 @@ msgstr ""
 #: lxc/auth.go:966 lxc/config_trust.go:407 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:577 lxc/network.go:1118
 #: lxc/network.go:1204 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1763 lxc/warning.go:217
+#: lxc/storage_volume.go:1762 lxc/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1590
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1589
 msgid "Taken at"
 msgstr ""
 
@@ -5923,32 +5927,8 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:187
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:225 lxc/move.go:246
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: lxc/move.go:199
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: lxc/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: lxc/move.go:191
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:195
-msgid "The --target-project flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:211
-msgid "The destination LXD server is not clustered"
 msgstr ""
 
 #: lxc/config_device.go:247 lxc/config_device.go:264 lxc/config_device.go:522
@@ -6086,10 +6066,6 @@ msgstr ""
 msgid "The server doesn't support setting the metadata format version"
 msgstr ""
 
-#: lxc/move.go:317
-msgid "The source LXD server is not clustered"
-msgstr ""
-
 #: lxc/network.go:546 lxc/network.go:643 lxc/storage_volume.go:898
 #: lxc/storage_volume.go:1002
 msgid "The specified device doesn't exist"
@@ -6181,7 +6157,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1879
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6197,7 +6173,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:65
+#: lxc/move.go:64
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6206,7 +6182,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:390 lxc/move.go:335
+#: lxc/copy.go:390 lxc/move.go:379
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6270,13 +6246,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1768
+#: lxc/project.go:1001 lxc/storage_volume.go:1767
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1123 lxc/network_acl.go:174 lxc/network_allocations.go:23
 #: lxc/network_zone.go:166 lxc/profile.go:764 lxc/project.go:583
-#: lxc/storage.go:725 lxc/storage_volume.go:1767
+#: lxc/storage.go:725 lxc/storage_volume.go:1766
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6285,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1168 lxc/list.go:629 lxc/profile.go:785
-#: lxc/storage_volume.go:1805 lxc/warning.go:243
+#: lxc/storage_volume.go:1804 lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6342,7 +6318,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6414,7 +6390,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2383 lxc/storage_volume.go:2384
+#: lxc/storage_volume.go:2382 lxc/storage_volume.go:2383
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6466,7 +6442,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2397
+#: lxc/storage_volume.go:2396
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6515,13 +6491,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:46 lxc/storage_volume.go:2674
+#: lxc/export.go:46 lxc/storage_volume.go:2673
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
 "server (to support imports on older LXD versions)"
 msgstr ""
 
-#: lxc/export.go:43 lxc/storage_volume.go:2671
+#: lxc/export.go:43 lxc/storage_volume.go:2670
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6588,7 +6564,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1591
 msgid "Volume Only"
 msgstr ""
 
@@ -6639,7 +6615,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:99 lxc/move.go:301 lxc/move.go:377
+#: lxc/copy.go:99 lxc/move.go:279
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6930,7 +6906,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7078,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2838
+#: lxc/storage_volume.go:2837
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7113,21 +7089,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1978
+#: lxc/storage_volume.go:1977
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2580
+#: lxc/storage_volume.go:2579
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2664
+#: lxc/storage_volume.go:2663
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2444
+#: lxc/storage_volume.go:2443
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7143,15 +7119,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2382
+#: lxc/storage_volume.go:2381
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2261
+#: lxc/storage_volume.go:2260
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -7170,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1874
+#: lxc/storage_volume.go:1873
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1617
+#: lxc/storage_volume.go:1616
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7549,7 +7525,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:49
+#: lxc/move.go:48
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7764,13 +7740,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2842
+#: lxc/storage_volume.go:2841
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2448
+#: lxc/storage_volume.go:2447
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/test/suites/clustering_move.sh
+++ b/test/suites/clustering_move.sh
@@ -65,7 +65,11 @@ test_clustering_move() {
 
   # c1 can be moved to a new target project.
   lxc move cluster:c1 --target-project test-project
-  lxc move cluster:c1 --target-project default --project test-project
+
+  # c1 can be moved to a new target project and location.
+  lxc move cluster:c1 --target node3 --target-project default --project test-project
+  lxc info cluster:c1 | grep -xF "Location: node3"
+  lxc query cluster:/1.0/instances/c1 | jq -re '.project == "default"'
 
   lxc move cluster:c1 --target @foobar1
   lxc info cluster:c1 | grep -xF "Location: node1"

--- a/test/suites/clustering_move.sh
+++ b/test/suites/clustering_move.sh
@@ -43,6 +43,10 @@ test_clustering_move() {
   LXD_DIR="${LXD_ONE_DIR}" lxc init testimage c3 --target node3
 
   LXD_DIR="${LXD_ONE_DIR}" lxc project create test-project --force-local # Create test project using unix socket.
+  LXD_DIR="${LXD_ONE_DIR}" lxc storage create test-pool dir --target node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc storage create test-pool dir --target node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc storage create test-pool dir --target node3
+  LXD_DIR="${LXD_ONE_DIR}" lxc storage create test-pool dir
 
   # Set up a fine-grained TLS identity.
   token="$(LXD_DIR=${LXD_ONE_DIR} lxc auth identity create tls/test --quiet)"
@@ -70,6 +74,13 @@ test_clustering_move() {
   lxc move cluster:c1 --target node3 --target-project default --project test-project
   lxc info cluster:c1 | grep -xF "Location: node3"
   lxc query cluster:/1.0/instances/c1 | jq -re '.project == "default"'
+
+  # c1 can be moved to a new target project, pool, and location.
+  lxc move cluster:c1 --target node2 --target-project test-project --project default --storage test-pool
+  lxc info cluster:c1 --project test-project | grep -xF "Location: node2"
+  lxc query cluster:/1.0/instances/c1?project=test-project | jq -re '.project == "test-project"'
+  lxc query cluster:/1.0/instances/c1?project=test-project | jq -re '.devices.root.pool == "test-pool"'
+  lxc move cluster:c1 --target-project default --project test-project --storage data
 
   lxc move cluster:c1 --target @foobar1
   lxc info cluster:c1 | grep -xF "Location: node1"


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/15525.

This is a significant rework of server-side migration cherry-picked from https://github.com/lxc/incus/pull/727, improving instance migration logic. 

Key changes include refactoring the instance migration logic and adding support for changing one or more of name, project, location and storage pool.

`instancePost` now handles all request validation, and `migrateInstance` acts as an entry point that calls the following functions (in order):

`migrateFromOfflineNode`: Manages the specific case of migrating an instance from a server that is offline but uses shared storage.
`prepareMigration`: Prepares the target instance's configuration by applying overrides for config, devices, profiles, and storage pools.
`migrateHandleRename`: Handles the renaming of an instance during a migration. Note that simple rename requests (rename only, no pool, project, or location changes) are handled by `instancePost`.
`migrateLocal`: Handles local migrations, where the instance moves between projects or storage pools on the same server.
`migrateRemote`: Handles remote migrations, where the instance is moved to a different cluster member.

`migrateFromOfflineNode` simply updates the database records, imports the instance into the storage, and performs any renames. The rest of the functions sequentially update the instance's properties, first preparing the target configuration, then handling any renames, followed by local moves (project or storage pool changes), and finally executing a remote migration to a new cluster member if required. Therefore, clearing certain parts of the request throughout the steps allows for indication of "what is left to do".

This also includes a bug-fix cherry-pick from https://github.com/lxc/incus/pull/1019 (https://github.com/lxc/incus/pull/1019/commits/c84cd644a7ea9e9e17aff9577a884634ec4ab310) that correctly sets the target project in `migrateLocal`.