### PR TITLE
Allow using the same volume for storage.images_volume and storage.backups_volume

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -730,22 +730,23 @@ func (d *Daemon) State() *state.State {
 		}, nil
 	}
 
-	storagePath := func(config string, path string) string {
+	storagePath := func(config string, target string) string {
 		if config == "" {
-			return path
+			return shared.VarPath(target)
 		}
 
 		poolName, volumeName, _ := daemonStorageSplitVolume(config)
 		volStorageName := project.StorageVolume(api.ProjectDefaultName, volumeName)
-		return storageDrivers.GetVolumeMountPath(poolName, storageDrivers.VolumeTypeCustom, volStorageName)
+		volMountPath := storageDrivers.GetVolumeMountPath(poolName, storageDrivers.VolumeTypeCustom, volStorageName)
+		return filepath.Join(volMountPath, target)
 	}
 
 	s.ImagesStoragePath = func() string {
-		return storagePath(s.LocalConfig.StorageImagesVolume(), shared.VarPath("images"))
+		return storagePath(s.LocalConfig.StorageImagesVolume(), "images")
 	}
 
 	s.BackupsStoragePath = func() string {
-		return storagePath(s.LocalConfig.StorageBackupsVolume(), shared.VarPath("backups"))
+		return storagePath(s.LocalConfig.StorageBackupsVolume(), "backups")
 	}
 
 	return s

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2309,7 +2309,7 @@ test_clustering_image_replication() {
   # The image tarball is available on both nodes
   fingerprint=$(LXD_DIR="${LXD_ONE_DIR}" lxc image info testimage | awk '/^Fingerprint/ {print $2}')
   [ -f "${LXD_ONE_DIR}/images/${fingerprint}" ]
-  [ -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/${fingerprint}" ]
+  [ -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/images/${fingerprint}" ]
 
   # Spawn a third node
   setup_clustering_netns 3
@@ -2337,7 +2337,7 @@ test_clustering_image_replication() {
   LXD_DIR="${LXD_ONE_DIR}" lxc image delete testimage
   [ ! -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false
   [ ! -f "${LXD_TWO_DIR}/images/${fingerprint}" ] || false
-  [ ! -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/${fingerprint}" ] || false
+  [ ! -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/images/${fingerprint}" ] || false
   [ ! -f "${LXD_THREE_DIR}/images/${fingerprint}" ] || false
 
   # Import the test image on node3
@@ -2351,14 +2351,14 @@ test_clustering_image_replication() {
   # The image tarball is available on all three nodes
   fingerprint=$(LXD_DIR="${LXD_ONE_DIR}" lxc image info testimage | awk '/^Fingerprint/ {print $2}')
   [ -f "${LXD_ONE_DIR}/images/${fingerprint}" ]
-  [ -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/${fingerprint}" ]
+  [ -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/images/${fingerprint}" ]
   [ -f "${LXD_THREE_DIR}/images/${fingerprint}" ]
 
   # Delete the imported image
   LXD_DIR="${LXD_ONE_DIR}" lxc image delete testimage
   [ ! -f "${LXD_ONE_DIR}/images/${fingerprint}" ]
   [ ! -f "${LXD_TWO_DIR}/images/${fingerprint}" ]
-  [ ! -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/${fingerprint}" ] || false
+  [ ! -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/images/${fingerprint}" ] || false
   [ ! -f "${LXD_THREE_DIR}/images/${fingerprint}" ]
 
   # Import the image from the container
@@ -2372,14 +2372,14 @@ test_clustering_image_replication() {
 
   fingerprint=$(LXD_DIR="${LXD_ONE_DIR}" lxc image info new-image | awk '/^Fingerprint/ {print $2}')
   [ -f "${LXD_ONE_DIR}/images/${fingerprint}" ]
-  [ -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/${fingerprint}" ]
+  [ -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/images/${fingerprint}" ]
   [ -f "${LXD_THREE_DIR}/images/${fingerprint}" ]
 
   # Delete the imported image
   LXD_DIR="${LXD_TWO_DIR}" lxc image delete new-image
   [ ! -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false
   [ ! -f "${LXD_TWO_DIR}/images/${fingerprint}" ] || false
-  [ ! -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/${fingerprint}" ] || false
+  [ ! -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/images/${fingerprint}" ] || false
   [ ! -f "${LXD_THREE_DIR}/images/${fingerprint}" ] || false
 
   # Delete the container
@@ -2390,7 +2390,7 @@ test_clustering_image_replication() {
   LXD_DIR="${LXD_ONE_DIR}" lxc image delete testimage
   [ ! -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false
   [ ! -f "${LXD_TWO_DIR}/images/${fingerprint}" ] || false
-  [ ! -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/${fingerprint}" ] || false
+  [ ! -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/images/${fingerprint}" ] || false
   [ ! -f "${LXD_THREE_DIR}/images/${fingerprint}" ] || false
 
   # Disable the image replication
@@ -2409,7 +2409,7 @@ test_clustering_image_replication() {
 
   # The image tarball is only available on node2
   fingerprint=$(LXD_DIR="${LXD_TWO_DIR}" lxc image info testimage | awk '/^Fingerprint/ {print $2}')
-  [ -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/${fingerprint}" ]
+  [ -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/images/${fingerprint}" ]
   [ ! -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false
   [ ! -f "${LXD_THREE_DIR}/images/${fingerprint}" ] || false
 
@@ -2417,7 +2417,7 @@ test_clustering_image_replication() {
   LXD_DIR="${LXD_TWO_DIR}" lxc image delete testimage
   [ ! -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false
   [ ! -f "${LXD_TWO_DIR}/images/${fingerprint}" ] || false
-  [ ! -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/${fingerprint}" ] || false
+  [ ! -f "${LXD_TWO_DIR}/storage-pools/data/custom/default_images/images/${fingerprint}" ] || false
   [ ! -f "${LXD_THREE_DIR}/images/${fingerprint}" ] || false
 
   # Unset the dedicated image storage on node2

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -68,8 +68,8 @@ _server_config_storage() {
   [ ! -e "${LXD_DIR}/images" ]
 
   # Record after
-  BACKUPS_AFTER=$(cd "${LXD_DIR}/storage-pools/${pool}/custom/default_backups/" && find . | sort)
-  IMAGES_AFTER=$(cd "${LXD_DIR}/storage-pools/${pool}/custom/default_images/" && find . | sort)
+  BACKUPS_AFTER=$(cd "${LXD_DIR}/storage-pools/${pool}/custom/default_backups/backups" && find . | sort)
+  IMAGES_AFTER=$(cd "${LXD_DIR}/storage-pools/${pool}/custom/default_images/images" && find . | sort)
 
   # Validate content
   if [ "${BACKUPS_BEFORE}" != "${BACKUPS_AFTER}" ]; then

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -101,11 +101,19 @@ _server_config_storage() {
   lxc delete -f foo2
   lxc image delete fooimage
 
+  # Put both storages on the same shared volume
+  lxc storage volume create "${pool}" shared
+  lxc config unset storage.backups_volume
+  lxc config unset storage.images_volume
+  lxc config set storage.backups_volume "${pool}/shared"
+  lxc config set storage.images_volume "${pool}/shared"
+
   # Unset the config and remove the volumes
   lxc config unset storage.backups_volume
   lxc config unset storage.images_volume
   lxc storage volume delete "${pool}" backups
   lxc storage volume delete "${pool}" images
+  lxc storage volume delete "${pool}" shared
 
   # Record again after unsetting
   BACKUPS_AFTER=$(cd "${LXD_DIR}/backups/" && find . | sort)


### PR DESCRIPTION
This depends on https://github.com/canonical/lxd/pull/15482 .

This also contains the move of images and backups to their own sub-directories if storage.{backups,images}_volume is set.