### PR TITLE
github: ask codeql to check actions themselves

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,6 @@ on:
       - stable-*
   pull_request:
     paths-ignore:
-      - '.github/**'
       - 'doc/**'
       - 'po/**'
       - 'tests/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['go', 'python']
+        language: ['actions', 'go', 'python']
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both


### PR DESCRIPTION
The simple CodeQL config (which requires **not** having any `.github/workflows/codeql.yml` file) started scanning GH actions.
Add that to our advanced configuration.

https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/
https://codeql.github.com/docs/codeql-language-guides/codeql-for-actions/
