### PR TITLE
Improve `LXD_INSPECT=1` sessions

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -5,6 +5,12 @@ if [ -z "${GOPATH:-}" ] && command -v go >/dev/null; then
     GOPATH="$(go env GOPATH)"
 fi
 
+# Avoid accidental re-execution
+if [ -n "${LXD_INSPECT_INPROGRESS:-}" ]; then
+    echo "Refusing to run tests from inside a LXD_INSPECT session" >&2
+    exit 1
+fi
+
 [ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
 
 # Don't translate lxc output for parsing in it in tests.
@@ -89,6 +95,9 @@ cleanup() {
       echo "==> FAILED TEST: ${TEST_CURRENT#test_} (${TEST_CURRENT_DESCRIPTION})"
     fi
     echo "==> Test result: ${TEST_RESULT}"
+
+    # Re-execution prevention
+    export LXD_INSPECT_INPROGRESS=true
 
     echo "Tests Completed (${TEST_RESULT})"
     echo "Dropping to a shell for inspection"

--- a/test/main.sh
+++ b/test/main.sh
@@ -93,16 +93,20 @@ cleanup() {
   if [ -n "${LXD_INSPECT:-}" ]; then
     if [ "${TEST_RESULT}" != "success" ]; then
       echo "==> FAILED TEST: ${TEST_CURRENT#test_} (${TEST_CURRENT_DESCRIPTION})"
+      # red
+      PS1_PREFIX="\033[0;31mLXD-TEST\033[0m"
+    else
+      # green
+      PS1_PREFIX="\033[0;32mLXD-TEST\033[0m"
     fi
     echo "==> Test result: ${TEST_RESULT}"
 
     # Re-execution prevention
     export LXD_INSPECT_INPROGRESS=true
 
-    echo "Tests Completed (${TEST_RESULT})"
-    echo "Dropping to a shell for inspection"
-    echo "Once done, exit (Ctrl-D) to continue"
-    bash
+    echo -e "\033[0;33mDropping to a shell for inspection.\nOnce done, exit (Ctrl-D) to continue\033[0m"
+    export PS1="${PS1_PREFIX} ${PS1:-\u@\h:\w\$ }"
+    bash --norc
   fi
 
   echo ""


### PR DESCRIPTION
This adds a colorful `$PS1` to the `LXD_INSPECT=1` session
```
# cd test
# LXD_INSPECT=1 ./main.sh network_forward
...
==> TEST DONE: network_forward (13s)
==> Test result: success
Dropping to a shell for inspection.
Once done, exit (Ctrl-D) to continue
LXD-TEST root@v1:~/lxd/test$ 
```

The `LXD-TEST` bit is red on test failures and green on successes. The welcome text is always in yellow so that it sticks out.