### PR TITLE
Test: Add timeout to `ceph status` command

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -102,7 +102,7 @@ cleanup() {
   if [ "${TEST_RESULT}" != "success" ]; then
     if command -v ceph >/dev/null; then
       echo "::group::ceph status"
-      ceph status || true
+      ceph status --connect-timeout 5 || true
       echo "::endgroup::"
     fi
 


### PR DESCRIPTION
In case you have leftover connection details present on your system, the 'ceph status' command will hang for a few minutes until it returns which causes unnecessary wait times when facing errors during test execution.