### PR TITLE
API: Add missing 'version' struct tag

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1859,11 +1859,6 @@ definitions:
         x-go-package: github.com/canonical/lxd/shared/api
     InstanceBackupsPost:
         properties:
-            Version:
-                description: What backup format version to use
-                example: 1
-                format: uint32
-                type: integer
             compression_algorithm:
                 description: What compression algorithm to use
                 example: gzip
@@ -1895,6 +1890,12 @@ definitions:
                 example: true
                 type: boolean
                 x-go-name: OptimizedStorage
+            version:
+                description: What backup format version to use
+                example: 1
+                format: uint32
+                type: integer
+                x-go-name: Version
         title: InstanceBackupsPost represents the fields available for a new LXD instance backup.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
@@ -6585,11 +6586,6 @@ definitions:
     StoragePoolVolumeBackupsPost:
         description: StoragePoolVolumeBackupsPost represents the fields available for a new LXD volume backup
         properties:
-            Version:
-                description: What backup format version to use
-                example: 1
-                format: uint32
-                type: integer
             compression_algorithm:
                 description: What compression algorithm to use
                 example: gzip
@@ -6611,6 +6607,12 @@ definitions:
                 example: true
                 type: boolean
                 x-go-name: OptimizedStorage
+            version:
+                description: What backup format version to use
+                example: 1
+                format: uint32
+                type: integer
+                x-go-name: Version
             volume_only:
                 description: Whether to ignore snapshots
                 example: false

--- a/shared/api/instance_backup.go
+++ b/shared/api/instance_backup.go
@@ -42,7 +42,7 @@ type InstanceBackupsPost struct {
 	// Example: 1
 	//
 	// API extension: backup_metadata_version
-	Version uint32
+	Version uint32 `json:"version" yaml:"version"`
 }
 
 // InstanceBackup represents a LXD instance backup.

--- a/shared/api/storage_pool_volume_backup.go
+++ b/shared/api/storage_pool_volume_backup.go
@@ -61,7 +61,7 @@ type StoragePoolVolumeBackupsPost struct {
 	// Example: 1
 	//
 	// API extension: backup_metadata_version
-	Version uint32
+	Version uint32 `json:"version" yaml:"version"`
 }
 
 // StoragePoolVolumeBackupPost represents the fields available for the renaming of a volume backup


### PR DESCRIPTION
Not having the tag shouldn't be a big deal for those two fields as their default is 'version' anyway. But to stay consistent will all the other fields also add the 'version' struct tag for instance and custom vol backups.

The problematic piece is that the metadata used `Version` and not `version`.

Thanks @edlerd for raising this in https://github.com/canonical/lxd-ui/pull/1270#discussion_r2104038375.