### PR TITLE
Add `musttag` linter now to catch newly missed tags

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@ linters:
   enable:
     - godot
     - misspell
+    - musttag
     - perfsprint
     - prealloc
     - revive

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ ifeq ($(shell command -v go-licenses),)
 	(cd / ; go install github.com/google/go-licenses@latest)
 endif
 ifeq ($(shell command -v golangci-lint),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.1.5
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.1.6
 endif
 ifneq ($(shell command -v yamllint),)
 	yamllint .github/workflows/*.yml


### PR DESCRIPTION
This is the first step to addressing https://github.com/canonical/lxd/issues/15648. It however does not deal with fixing existing violation as our `test/lint/golangci.sh` script only looks at new code.

Also update `golangci-lint` itself as it ships an updated `musttag` version.