### PR TITLE
Makefile: use `git rev-parse HEAD` to get current commit hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,9 +280,9 @@ dist: doc
 
 	# Create build dir
 	$(eval TMP := $(shell mktemp -d))
-	$(eval HASH := $(shell git show-ref --hash HEAD))
-	git archive --prefix=lxd-$(VERSION)/ $(HASH) | tar -x -C $(TMP)
-	echo $(HASH) > $(TMP)/lxd-$(VERSION)/.gitref
+	$(eval COMMIT_HASH := $(shell git rev-parse HEAD))
+	git archive --prefix=lxd-$(VERSION)/ $(COMMIT_HASH) | tar -x -C $(TMP)
+	echo $(COMMIT_HASH) > $(TMP)/lxd-$(VERSION)/.gitref
 
 	# Download dependencies
 	(cd $(TMP)/lxd-$(VERSION) ; go mod vendor)
@@ -307,7 +307,7 @@ dist: doc
 	# * omit irrelevant information about file ownership and group
 	# * tell `gzip` to not embed the file name when compressing
 	# For more details: https://www.gnu.org/software/tar/manual/html_node/Reproducibility.html
-	$(eval SOURCE_EPOCH := $(shell TZ=UTC0 git log -1 --format=tformat:%cd --date=format:%Y-%m-%dT%H:%M:%SZ $(HASH)))
+	$(eval SOURCE_EPOCH := $(shell TZ=UTC0 git log -1 --format=tformat:%cd --date=format:%Y-%m-%dT%H:%M:%SZ $(COMMIT_HASH)))
 	LC_ALL=C tar --sort=name --format=posix \
 		--pax-option=exthdr.name=%d/PaxHeaders/%f \
 		--pax-option=delete=atime,delete=ctime \

--- a/Makefile
+++ b/Makefile
@@ -289,11 +289,11 @@ dist: doc
 
 	# Download the dqlite library
 	git clone --depth=1 --branch "$(DQLITE_BRANCH)" https://github.com/canonical/dqlite $(TMP)/lxd-$(VERSION)/vendor/dqlite
-	(cd $(TMP)/lxd-$(VERSION)/vendor/dqlite ; git show-ref HEAD | cut -d' ' -f1 > .gitref)
+	(cd $(TMP)/lxd-$(VERSION)/vendor/dqlite ; git rev-parse HEAD | tee .gitref)
 
 	# Download the liblxc library
 	git clone --depth=1 --branch "$(LIBLXC_BRANCH)" https://github.com/lxc/lxc $(TMP)/lxd-$(VERSION)/vendor/liblxc
-	(cd $(TMP)/lxd-$(VERSION)/vendor/liblxc ; git show-ref HEAD | cut -d' ' -f1 > .gitref)
+	(cd $(TMP)/lxd-$(VERSION)/vendor/liblxc ; git rev-parse HEAD | tee .gitref)
 
 	# Copy doc output
 	cp -r --preserve=mode doc/_build $(TMP)/lxd-$(VERSION)/doc/html/


### PR DESCRIPTION
Kadin found out that PR tests would be run with a `lxc` binary built from
sources that didn't match those associated with the PR. He then tracked the
issue down to a faulty commit where the archive produced by `make dist` would
use the sources from the main branch.

The problem is that `git show-ref --hash HEAD` gives the commit hash of the
origin/main's HEAD, not the one corresponding to the current branch.

Switch to using `git rev-parse HEAD` that is specifically made to get the hash
of the current commit.

Also, rename the variable to `COMMIT_HASH` to avoid shadowing the exising
`HASH` one.

Fixes https://github.com/canonical/lxd/commit/113279fb493cc638e37906c5b1afc81e0c8e888a