### PR TITLE
Daily caching of external assets

### DIFF
--- a/.github/actions/download-minio/action.yml
+++ b/.github/actions/download-minio/action.yml
@@ -1,18 +1,48 @@
 name: Download minio/mc
-description: Download minio/mc
+description: Download minio/mc binaries and cache them for the day
 
 runs:
   using: composite
   steps:
-    - name: Download minio/mc
+    - name: minio cache key
+      id: minio-cache-key
       shell: bash
       run: |
         set -eux
-        mkdir -p "$(go env GOPATH)/bin"
+        ARCH="$(dpkg --print-architecture)"
+        DATE="$(date --utc '+%Y%m%d')"
+
+        # To download the binaries for the right arch.
+        echo "ARCH=${ARCH}" >> $GITHUB_OUTPUT
+
+        # i.e: minio-amd64-${DATE}
+        echo "KEY=minio-${ARCH}-${DATE}" >> $GITHUB_OUTPUT
+
+    # GitHub will remove any cache entries that have not been accessed in over 7 days.
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+    - name: Cache minio/mc binaries
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      id: cache-minio
+      with:
+        path: |
+          /home/runner/go/bin/minio
+          /home/runner/go/bin/mc
+        key: ${{ steps.minio-cache-key.outputs.KEY }}
+
+    - name: Download minio/mc
+      if: ${{ steps.cache-minio.outputs.cache-hit != 'true' }}
+      env:
+        ARCH: ${{ steps.minio-cache-key.outputs.ARCH }}
+      shell: bash
+      run: |
+        set -eux
+
+        DIR="/home/runner/go/bin"
+        mkdir -p "${DIR}"
         # Download minio ready to include in dependencies for system tests.
-        curl -sSfL https://dl.min.io/server/minio/release/linux-amd64/minio --output "$(go env GOPATH)/bin/minio"
-        chmod +x "$(go env GOPATH)/bin/minio"
+        curl -sSfL "https://dl.min.io/server/minio/release/linux-${ARCH}/minio" --output "${DIR}/minio"
+        chmod +x "${DIR}/minio"
 
         # Also grab the latest minio client to maintain compatibility with the server.
-        curl -sSfL https://dl.min.io/client/mc/release/linux-amd64/mc --output "$(go env GOPATH)/bin/mc"
-        chmod +x "$(go env GOPATH)/bin/mc"
+        curl -sSfL "https://dl.min.io/client/mc/release/linux-${ARCH}/mc" --output "${DIR}/mc"
+        chmod +x "${DIR}/mc"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,9 @@ jobs:
           # liblxc requires a rootfs dir
           mkdir -p /home/runner/go/bin/liblxc/rootfs
 
-          # Update env variables for liblxc
+      - name: Update env variables for deps
+        run: |
+          set -eux
           LIBLXC_ARCH_LIBS="$(readlink -e /home/runner/go/bin/liblxc/libs/*-linux-gnu)"
 
           echo "CGO_LDFLAGS=${CGO_LDFLAGS} -L${LIBLXC_ARCH_LIBS}"       >> "${GITHUB_ENV}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -319,6 +319,14 @@ jobs:
 
       - name: Setup MicroCeph
         if: ${{ matrix.backend == 'ceph' }}
+        run: |
+          set -eux
+          # LXD snap holds on to the swap that prevents the clearing of the ephemeral disk for microceph
+          # https://github.com/canonical/lxd/issues/14768
+          sudo snap remove --purge lxd
+
+      - name: Setup MicroCeph
+        if: ${{ matrix.backend == 'ceph' }}
         uses: ./.github/actions/setup-microceph
         with:
           osd-count: 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,7 +123,31 @@ jobs:
           tar -xzf lxd-test.tar.gz -C /home/runner/work/lxd/
           rm lxd-test.tar.gz
 
+      - name: deps cache key
+        id: deps-cache-key
+        shell: bash
+        run: |
+          set -eux
+          . /etc/os-release
+          ARCH="$(dpkg --print-architecture)"
+          DATE="$(date --utc '+%Y%m%d')"
+
+          # i.e: deps-ubuntu-24.04-amd64-${DATE}
+          echo "KEY=deps-${ID}-${VERSION_ID}-${ARCH}-${DATE}" >> $GITHUB_OUTPUT
+
+      # GitHub will remove any cache entries that have not been accessed in over 7 days.
+      # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+      - name: Cache dqlite/liblxc deps
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: cache-deps
+        with:
+          path: |
+            /home/runner/go/bin/dqlite
+            /home/runner/go/bin/liblxc
+          key: ${{ steps.deps-cache-key.outputs.KEY }}
+
       - name: Build LXD dependencies
+        if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
         run: |
           set -eux
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -288,6 +288,10 @@ jobs:
 
       - name: Reclaim disk space
         uses: ./.github/actions/reclaim-disk-space
+        # cluster tests do not consume much space and tests on ceph use the
+        # ephemeral disk those `rm -rf` can sometimes take ~2 minutes on slow
+        # runners so skip them where possible.
+        if: ${{ matrix.suite != 'cluster' && matrix.backend != 'ceph' }}
 
       - name: Remove docker
         uses: ./.github/actions/disable-docker


### PR DESCRIPTION
Also tweak the cluster tests to **not** reclaim disk space as they don't use much so it's best to skip this operation that is sometimes very slow (~2 minutes). This required working around https://github.com/canonical/lxd/issues/14768