### PR TITLE
idmap: Add missing struct tags (musttag)

### DIFF
--- a/lxd/idmap/structs.go
+++ b/lxd/idmap/structs.go
@@ -2,14 +2,14 @@ package idmap
 
 // IdmapEntry is a single idmap entry (line).
 type IdmapEntry struct {
-	Isuid    bool
-	Isgid    bool
-	Hostid   int64 // id as seen on the host - i.e. 100000
-	Nsid     int64 // id as seen in the ns - i.e. 0
-	Maprange int64
+	Isuid    bool  `json:"Isuid"`
+	Isgid    bool  `json:"Isgid"`
+	Hostid   int64 `json:"Hostid"` // id as seen on the host - i.e. 100000
+	Nsid     int64 `json:"Nsid"`   // id as seen in the ns - i.e. 0
+	Maprange int64 `json:"Maprange"`
 }
 
 // IdmapSet is a list of IdmapEntry with some functions on it.
 type IdmapSet struct {
-	Idmap []IdmapEntry
+	Idmap []IdmapEntry `json:"Idmap"`
 }


### PR DESCRIPTION
Required as part of https://github.com/canonical/lxd/pull/15523

The lowercase representation can be used as it won't break existing `volatile.idmap.*` config keys. When doing `json.Unmarshal()`, the correct config key is pulled in any case:

* If the JSON key is in uppercase, it will get unmarshalled accordingly even if the lowercase tag is set
* If the JSON key is in lowercase, it matches the struct tag and will work as expected
* If the JSON key is in lowercase, but LXD expects the uppercase (no tag set, old version), it still unmarshalls accordingly

A patch is not required as all of the containers `volatile.idmap.*` config keys are getting updated progressively when LXD rewrites the keys.