### PR TITLE
doc: update howto/instances_routed_nic_vm.md

### DIFF
--- a/doc/howto/instances_routed_nic_vm.md
+++ b/doc/howto/instances_routed_nic_vm.md
@@ -66,7 +66,7 @@ For example:
 ```
 ````
 
-In this configuration, `my-parent-network` is your parent network, and the IPv4 and IPv6 addresses are within the subnet of the parent.
+In this configuration, `my-parent` is your parent network, and the IPv4 and IPv6 addresses are within the subnet of the parent.
 
 Next we will add some `netplan` configuration to the instance using the `cloud-init.network-config` configuration key:
 


### PR DESCRIPTION
small fix: command examples in this page refer to a parent network named `my-parent`, and the text called it `my-parent-network` instead