### PR TITLE
API: Revert linter fixes and use legacy tags instead

### DIFF
--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -21,7 +21,8 @@ type Volume struct {
 	// Make sure to have the embedded structs fields inline to avoid nesting.
 	api.StorageVolume `yaml:",inline"` //nolint:musttag
 
-	Snapshots []*api.StorageVolumeSnapshot `json:"snapshots,omitempty" yaml:"snapshots,omitempty"`
+	// Use the uppercase representation of the field to follow the same format as the root Config struct.
+	Snapshots []*api.StorageVolumeSnapshot `json:"Snapshots" yaml:"snapshots,omitempty"`
 }
 
 // Bucket represents the config of a bucket including its snapshots.
@@ -32,21 +33,23 @@ type Bucket struct {
 
 // Config represents the config of a backup that can be stored in a backup.yaml file (or embedded in index.yaml).
 type Config struct {
-	Version   uint32                  `json:"version,omitempty" yaml:"version,omitempty"`
-	Instance  *api.Instance           `json:"instance,omitempty" yaml:"instance,omitempty"`
-	Snapshots []*api.InstanceSnapshot `json:"snapshots,omitempty" yaml:"snapshots,omitempty"`
-	Pools     []*api.StoragePool      `json:"pools,omitempty" yaml:"pools,omitempty"`
-	Profiles  []*api.Profile          `json:"profiles,omitempty" yaml:"profiles,omitempty"`
-	Volumes   []*Volume               `json:"volumes,omitempty" yaml:"volumes,omitempty"`
-	Bucket    *Bucket                 `json:"bucket,omitempty" yaml:"bucket,omitempty"`
+	// The JSON representation of the fields does not use lowercase (and omitempty) to stay backwards compatible
+	// across all versions of LXD as the Config struct is also used throughout the migration.
+	Version   uint32                  `json:"Version" yaml:"version,omitempty"`
+	Instance  *api.Instance           `json:"Instance" yaml:"instance,omitempty"`
+	Snapshots []*api.InstanceSnapshot `json:"Snapshots" yaml:"snapshots,omitempty"`
+	Pools     []*api.StoragePool      `json:"Pools" yaml:"pools,omitempty"`
+	Profiles  []*api.Profile          `json:"Profiles" yaml:"profiles,omitempty"`
+	Volumes   []*Volume               `json:"Volumes" yaml:"volumes,omitempty"`
+	Bucket    *Bucket                 `json:"Bucket" yaml:"bucket,omitempty"`
 	// Deprecated: Use Instance instead.
-	Container *api.Instance `json:"container,omitempty" yaml:"container,omitempty"`
+	Container *api.Instance `json:"Container" yaml:"container,omitempty"`
 	// Deprecated: Use Pools instead.
-	Pool *api.StoragePool `json:"pool,omitempty" yaml:"pool,omitempty"`
+	Pool *api.StoragePool `json:"Pool" yaml:"pool,omitempty"`
 	// Deprecated: Use Volumes instead.
-	Volume *api.StorageVolume `json:"volume,omitempty" yaml:"volume,omitempty"`
+	Volume *api.StorageVolume `json:"Volume" yaml:"volume,omitempty"`
 	// Deprecated: Use the list of Snapshots under Volumes.
-	VolumeSnapshots []*api.StorageVolumeSnapshot `json:"volume_snapshots,omitempty" yaml:"volume_snapshots,omitempty"`
+	VolumeSnapshots []*api.StorageVolumeSnapshot `json:"VolumeSnapshots" yaml:"volume_snapshots,omitempty"`
 }
 
 // rootVolPoolName returns the pool name of an instance's root volume.


### PR DESCRIPTION
In the PR https://github.com/canonical/lxd/pull/15657 we were trying to satisfy the new musttag linter rules. However this breaks the migration with older versions of LXD.

To stay on the safe side, explicitly define the JSON tags to use the uppercase representation.