### PR TITLE
Makefile: add `make tics` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ ifeq ($(shell command -v go-licenses),)
 	(cd / ; go install github.com/google/go-licenses@latest)
 endif
 ifeq ($(shell command -v golangci-lint),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.1.6
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v2.1.6
 endif
 ifneq ($(shell command -v yamllint),)
 	yamllint .github/workflows/*.yml

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,11 @@ env:
 .PHONY: deps
 deps: dqlite liblxc env
 
+.PHONY: tics
+tics: deps
+	go build -a -x -v ./...
+	CC="cc" CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" go install -v -tags "libsqlite3" -trimpath -a -x -v ./...
+
 .PHONY: update-gomod
 update-gomod:
 ifneq "$(LXD_OFFLINE)" ""

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,12 @@ DQLITE_PATH=$(DEPS_PATH)/dqlite
 LIBLXC_PATH=$(DEPS_PATH)/liblxc
 LIBLXC_ROOTFS_MOUNT_PATH=$(GOPATH)/bin/liblxc/rootfs
 
+export CGO_CFLAGS ?= -I$(DQLITE_PATH)/include/ -I$(LIBLXC_PATH)/include/
+export CGO_LDFLAGS ?= -L$(DQLITE_PATH)/.libs/ -L$(LIBLXC_PATH)/lib/$(ARCH)-linux-gnu/
+export LD_LIBRARY_PATH ?= $(DQLITE_PATH)/.libs/:$(LIBLXC_PATH)/lib/$(ARCH)-linux-gnu/
+export PKG_CONFIG_PATH ?= $(LIBLXC_PATH)/lib/$(ARCH)-linux-gnu/pkgconfig
+export CGO_LDFLAGS_ALLOW ?= (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
+
 .PHONY: default
 default: all
 
@@ -158,11 +164,11 @@ endif
 env:
 	@echo ""
 	@echo "# Please set the following in your environment (possibly ~/.bashrc)"
-	@echo "export CGO_CFLAGS=\"-I$(DQLITE_PATH)/include/ -I$(LIBLXC_PATH)/include/\""
-	@echo "export CGO_LDFLAGS=\"-L$(DQLITE_PATH)/.libs/ -L$(LIBLXC_PATH)/lib/$(ARCH)-linux-gnu/\""
-	@echo "export LD_LIBRARY_PATH=\"$(DQLITE_PATH)/.libs/:$(LIBLXC_PATH)/lib/$(ARCH)-linux-gnu/\""
-	@echo "export PKG_CONFIG_PATH=\"$(LIBLXC_PATH)/lib/$(ARCH)-linux-gnu/pkgconfig\""
-	@echo "export CGO_LDFLAGS_ALLOW=\"(-Wl,-wrap,pthread_create)|(-Wl,-z,now)\""
+	@echo "export CGO_CFLAGS=\"$(CGO_CFLAGS)\""
+	@echo "export CGO_LDFLAGS=\"$(CGO_LDFLAGS)\""
+	@echo "export LD_LIBRARY_PATH=\"$(LD_LIBRARY_PATH)\""
+	@echo "export PKG_CONFIG_PATH=\"$(PKG_CONFIG_PATH)\""
+	@echo "export CGO_LDFLAGS_ALLOW=\"$(CGO_LDFLAGS_ALLOW)\""
 
 .PHONY: deps
 deps: dqlite liblxc env


### PR DESCRIPTION
One of the nice side effect of those changes is that it's now possible to easily build LXD without having to bother exporting an variables. One just needs a machine with all the build-deps already installed and `make deps && make` is all it takes.

```
$ lxc launch ubuntu-minimal-daily:24.04 v1 --vm -p lxd-test
Launching v1
root@v1:~# cd lxd
root@v1:~/lxd# make deps && make
...
LXD agent built successfully
CGO_ENABLED=0 go install -v -trimpath -tags netgo ./lxd-migrate
github.com/canonical/lxd/shared/i18n
archive/tar
github.com/canonical/lxd/lxd/linux
github.com/canonical/lxd/lxd/backup/config
github.com/canonical/lxd/lxd/storage/block
github.com/canonical/lxd/lxd/rsync
github.com/canonical/lxd/lxd/migration
github.com/canonical/lxd/shared/cmd
github.com/canonical/lxd/shared/eagain
github.com/canonical/lxd/lxd-migrate
LXD-MIGRATE built successfully
```