### PR TITLE
Network: Show info for macvlan networks

### DIFF
--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -104,8 +104,13 @@ test_container_devices_nic_macvlan() {
 
   echo "==> Test using macvlan network."
 
-  echo "==> Create macvlan network and add NIC device using that network."
+  echo "==> Create macvlan network."
   lxc network create "${ctName}net" --type=macvlan parent="${ctName}"
+
+  echo "==> Check that lxc network info succeeds for macvlan network."
+  lxc network info "${ctName}net"
+
+  echo "==> Add NIC device using macvlan network."
   lxc config device add "${ctName}" eth0 nic \
     network="${ctName}net" \
     name=eth0


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/15479.

This is to prevent `lxc network info <net>` failing when used on a macvlan network.

Example output:
```
root@vm1:~/lxd# lxc network info net1
Name: net1
MAC address: ab:cd:ef:12:34:56
MTU: 1500
State: up
Type: broadcast

Network usage:
  Bytes received: 0B
  Bytes sent: 0B
  Packets received: 0
  Packets sent: 0
```
