### PR TITLE
lxd: Add target request forwarding to storagePoolVolumeTypeStateGet

### DIFF
--- a/lxd/storage_volumes_state.go
+++ b/lxd/storage_volumes_state.go
@@ -76,6 +76,11 @@ var storagePoolVolumeTypeStateCmd = APIEndpoint{
 func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
+	resp := forwardedResponseIfTargetIsRemote(s, r)
+	if resp != nil {
+		return resp
+	}
+
 	// Get the name of the pool the storage volume is supposed to be attached to.
 	poolName, err := url.PathUnescape(mux.Vars(r)["poolName"])
 	if err != nil {


### PR DESCRIPTION
# Done
- Add target request forwarding to storagePoolVolumeTypeStateGet

# Problem that is solved
1. Given a clustered LXD and a cluster member local pool (driver directory or zfs).
2. Have a volume on cluster member micro2.
3. Then query the api on member micro1 for the volume size. This results in `Storage volume \"test\" in project \"default\" of type \"custom\" does not exist on pool \"dirydir\": Storage volume not found`.

The target param on the endpoint is present, but it is not used for forwarding the request to the right node. When switching the api host to the right cluster member (the one the volume lives on) then the error "...Storage volume not found" vanishes and the right response appears. 

