### PR TITLE
test/mini-oidc/storage: use stdlib `log/slog`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	go.starlark.net v0.0.0-20250417143717-f57e51f710eb
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.38.0
-	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.14.0
 	golang.org/x/sys v0.33.0
@@ -163,6 +162,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.6.0 // indirect
 	go.uber.org/mock v0.5.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	gonum.org/v1/gonum v0.16.0 // indirect

--- a/test/mini-oidc/storage/oidc.go
+++ b/test/mini-oidc/storage/oidc.go
@@ -1,11 +1,11 @@
 package storage
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/oidc/v3/pkg/op"
-	"golang.org/x/exp/slog"
 	"golang.org/x/text/language"
 )
 


### PR DESCRIPTION
The `log/slog` package is available in the Go standard library since Go 1.21.

Reference: https://go.dev/doc/go1.21#slog