### PR TITLE
lxc: Prevent panic when overwriting the progress renderer

### DIFF
--- a/lxc/export.go
+++ b/lxc/export.go
@@ -163,22 +163,23 @@ func (c *cmdExport) run(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	// Prepare the download request
-	progress = cli.ProgressRenderer{
+	// Prepare the download request.
+	// Assign the renderer to a new variable to not interfer with the old one.
+	exportProgress := cli.ProgressRenderer{
 		Format: i18n.G("Exporting the backup: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
 
 	backupFileRequest := lxd.BackupFileRequest{
 		BackupFile:      io.WriteSeeker(target),
-		ProgressHandler: progress.UpdateProgress,
+		ProgressHandler: exportProgress.UpdateProgress,
 	}
 
 	// Export tarball
 	_, err = d.GetInstanceBackupFile(name, backupName, &backupFileRequest)
 	if err != nil {
 		_ = os.Remove(targetName)
-		progress.Done("")
+		exportProgress.Done("")
 		return fmt.Errorf("Fetch instance backup file: %w", err)
 	}
 
@@ -205,6 +206,6 @@ func (c *cmdExport) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to close export file: %w", err)
 	}
 
-	progress.Done(i18n.G("Backup exported successfully!"))
+	exportProgress.Done(i18n.G("Backup exported successfully!"))
 	return nil
 }

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -2800,26 +2800,27 @@ func (c *cmdStorageVolumeExport) run(cmd *cobra.Command, args []string) error {
 
 	defer func() { _ = target.Close() }()
 
-	// Prepare the download request
-	progress = cli.ProgressRenderer{
+	// Prepare the download request.
+	// Assign the renderer to a new variable to not interfer with the old one.
+	exportProgress := cli.ProgressRenderer{
 		Format: i18n.G("Exporting the backup: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
 
 	backupFileRequest := lxd.BackupFileRequest{
 		BackupFile:      io.WriteSeeker(target),
-		ProgressHandler: progress.UpdateProgress,
+		ProgressHandler: exportProgress.UpdateProgress,
 	}
 
 	// Export tarball
 	_, err = d.GetStoragePoolVolumeBackupFile(name, volName, backupName, &backupFileRequest)
 	if err != nil {
 		_ = os.Remove(targetName)
-		progress.Done("")
+		exportProgress.Done("")
 		return fmt.Errorf("Failed to fetch storage volume backup file: %w", err)
 	}
 
-	progress.Done(i18n.G("Backup exported successfully!"))
+	exportProgress.Done(i18n.G("Backup exported successfully!"))
 	return nil
 }
 


### PR DESCRIPTION
The progress renderer's UpdateOp gets added as a handler to the operation. This allows the operation to update the progress on its own pace.

However when overwriting the initial progress renderer and assigning a new instance of it, this also replaces the underlying mutex which can cause a race if the operation is in the process of calling the orignial progress renderer's UpdateOp, obtains a lock of the mutex but the mutex is in the process of getting replaced because a new instance of the progress renderer is assigned.

This causes the following error https://github.com/canonical/lxd-ci/actions/runs/15387812020/job/43290215796?pr=485

In order to protect the initial mutex, assign the progress renderer for the actual export to a new variable.

### Reproducer

```go
func main() {
	progress := cmd.ProgressRenderer{
		Format: "Running operation: %s",
		Quiet:  false,
	}

	go func() {
		// Try to update the progress renderer in the background.
		// Under the hood the UpdateOp() calls Update() which locks/unlocks the progress renderer's mutex.
		for {
			progress.UpdateOp(api.Operation{
				Metadata: map[string]any{
					"test_progress": time.Now().String(),
				},
			})
		}
	}()

        progress.Done("")

	// Cause the next progress.UpdateOp to block after locking the progress renderer's mutex without unlocking:
	/*
		func (p *ProgressRenderer) Update(status string) {
			...
			// Acquire rendering lock
			p.lock.Lock()
			defer p.lock.Unlock()

			// Check if we're already done
			if p.done {
				if GlobalInt > 0 {
					<-GlobalCh
				}

				return
			}
			...
		}
	*/
	cmd.GlobalInt = 1
	time.Sleep(1 * time.Second)

	// Set a new progress renderer by overwriting the initial one.
	// This also replaces the progress renderer's mutex.
	progress = cmd.ProgressRenderer{
		Format: "Running new operation: %s",
		Quiet:  false,
	}

	// Release the blocking UpdateOp (Update) operation from the original progress renderer.
	// It will try to unlock the previously obtained lock which fails as the lock from the new progress renderer is already unlocked.
	close(cmd.GlobalCh)
	time.Sleep(1 * time.Second)
}
```

```
fatal error: sync: unlock of unlocked mutex

goroutine 7 [running]:
internal/sync.fatal({0x83f84c?, 0x4b?})
        /snap/go/10888/src/runtime/panic.go:1068 +0x18
internal/sync.(*Mutex).unlockSlow(0xc0000ec8ac, 0xffffffff)
        /snap/go/10888/src/internal/sync/mutex.go:204 +0x35
internal/sync.(*Mutex).Unlock(...)
        /snap/go/10888/src/internal/sync/mutex.go:198
sync.(*Mutex).Unlock(...)
        /snap/go/10888/src/sync/mutex.go:65
github.com/canonical/lxd/shared/cmd.(*ProgressRenderer).Update(0xc0000ec870, {0xc00046ca40, 0x37})
        /home/julian/dev/lxd/shared/cmd/progress.go:148 +0x38a
github.com/canonical/lxd/shared/cmd.(*ProgressRenderer).UpdateOp(0xc0000ec870, {{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0, 0x0}, ...})
        /home/julian/dev/lxd/shared/cmd/progress.go:198 +0xf9
main.main.func1()
        /home/julian/dev/test/main.go:20 +0x70
created by main.main in goroutine 1
        /home/julian/dev/test/main.go:16 +0x8f

goroutine 1 [sleep]:
time.Sleep(0x3b9aca00)
        /snap/go/10888/src/runtime/time.go:338 +0x165
main.main()
        /home/julian/dev/test/main.go:60 +0x109
exit status 2
```