### PR TITLE
doc: Add Ubuntu Pro how-to

### DIFF
--- a/doc/howto/ubuntu_pro_guest_attach.md
+++ b/doc/howto/ubuntu_pro_guest_attach.md
@@ -1,0 +1,42 @@
+(ubuntu-pro-guest-attach)=
+# How to configure Ubuntu Pro guest attachment
+
+If Ubuntu Pro is enabled on a LXD host, guest instances can be automatically attached to the Pro subscription.
+
+First, the Pro client on the host machine must be configured to allow guest attachment:
+
+    pro config set lxd_guest_attach=on
+
+The allowed values are `on`, `off`, and `available`.
+If unset, this defaults to `off`.
+
+```{note}
+The Pro client must be updated to the latest version.
+```
+
+You can now launch an Ubuntu instance:
+
+    lxc launch ubuntu:24.04 pro-guest
+
+The instance will automatically attach to the Pro subscription at start up.
+
+Pro attachment can take some time.
+You can check the status using:
+
+    lxc exec pro-guest -- pro status
+
+The `lxd_guest_attach` setting can be overridden by the {config:option}`instance-miscellaneous:ubuntu_pro.guest_attach` configuration option.
+For example, if `lxd_guest_attach` is set to `on` on the host, to prevent Pro attachment in the guest you can run:
+
+    lxc launch ubuntu:24.04 non-pro-guest -c ubuntu_pro.guest_attach=off
+
+The `ubuntu_pro.guest_attach` configuration key has three options: `on`, `off`, and `available`.
+
+All options for Pro guest attachment are described below.
+
+|                     |         `on (host)`         |     `available (host)`      |        `off (host)`       |      `unset (host)`       |
+| ------------------- | --------------------------- | --------------------------- | ------------------------- | ------------------------- |
+|        `on (guest)` | auto-attach on start        |  auto-attach on start       | guest attachment disabled | guest attachment disabled |
+| `available (guest)` | attach on `pro auto-attach` | attach on `pro-auto-attach` | guest attachment disabled | guest attachment disabled |
+|       `off (guest)` | guest attachment disabled   | guest attachment disabled   | guest attachment disabled | guest attachment disabled |
+|     `unset (guest)` | auto-attach on start        | attach on `pro-auto-attach` | guest attachment disabled | guest attachment disabled |

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -19,6 +19,7 @@ How to create and manage instances:
 :diataxis:Manage instances </howto/instances_manage.md>
 :diataxis:Use profiles </profiles.md>
 :diataxis:Troubleshoot errors </howto/instances_troubleshoot.md>
+:diataxis:Auto attach Ubuntu Pro </howto/ubuntu_pro_guest_attach.md>
 ```
 
 ```{only} diataxis

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -1879,12 +1879,8 @@ Possible values are `boot` (load the modules when booting the container) and `on
 :shortdesc: "Whether to auto-attach Ubuntu Pro."
 :type: "string"
 Indicate whether the guest should auto-attach Ubuntu Pro at start up.
-The allowed values are `off`, `on`, and `available`.
-If set to `off`, it will not be possible for the Ubuntu Pro client in the guest to obtain guest token via `devlxd`.
-If set to `available`, attachment via guest token is possible but will not be performed automatically by the Ubuntu Pro client in the guest at startup.
-If set to `on`, attachment will be performed automatically by the Ubuntu Pro client in the guest at startup.
-To allow guest attachment, the host must be an Ubuntu machine that is Pro attached, and guest attachment must be enabled via the Pro client.
-To do this, run `pro config set lxd_guest_attach=on`.
+
+See {ref}`ubuntu-pro-guest-attach` for more information.
 ```
 
 ```{config:option} user.* instance-miscellaneous

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -416,12 +416,8 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 
 	// lxdmeta:generate(entities=instance; group=miscellaneous; key=ubuntu_pro.guest_attach)
 	// Indicate whether the guest should auto-attach Ubuntu Pro at start up.
-	// The allowed values are `off`, `on`, and `available`.
-	// If set to `off`, it will not be possible for the Ubuntu Pro client in the guest to obtain guest token via `devlxd`.
-	// If set to `available`, attachment via guest token is possible but will not be performed automatically by the Ubuntu Pro client in the guest at startup.
-	// If set to `on`, attachment will be performed automatically by the Ubuntu Pro client in the guest at startup.
-	// To allow guest attachment, the host must be an Ubuntu machine that is Pro attached, and guest attachment must be enabled via the Pro client.
-	// To do this, run `pro config set lxd_guest_attach=on`.
+	//
+	// See {ref}`ubuntu-pro-guest-attach` for more information.
 	// ---
 	// type: string
 	// liveupdate: no

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2150,7 +2150,7 @@
 					{
 						"ubuntu_pro.guest_attach": {
 							"liveupdate": "no",
-							"longdesc": "Indicate whether the guest should auto-attach Ubuntu Pro at start up.\nThe allowed values are `off`, `on`, and `available`.\nIf set to `off`, it will not be possible for the Ubuntu Pro client in the guest to obtain guest token via `devlxd`.\nIf set to `available`, attachment via guest token is possible but will not be performed automatically by the Ubuntu Pro client in the guest at startup.\nIf set to `on`, attachment will be performed automatically by the Ubuntu Pro client in the guest at startup.\nTo allow guest attachment, the host must be an Ubuntu machine that is Pro attached, and guest attachment must be enabled via the Pro client.\nTo do this, run `pro config set lxd_guest_attach=on`.",
+							"longdesc": "Indicate whether the guest should auto-attach Ubuntu Pro at start up.\n\nSee {ref}`ubuntu-pro-guest-attach` for more information.",
 							"shortdesc": "Whether to auto-attach Ubuntu Pro.",
 							"type": "string"
 						}


### PR DESCRIPTION
Adds a how-to guide for Ubuntu Pro guest attachment. Including a matrix describing the interaction between the `pro` `lxd_guest_attach` setting, and the guest `ubuntu_pro.guest_attach` config option.