### PR TITLE
dependabot: disable schedule to only deal with security updates for 5.0 `gomod`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,8 +31,6 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     labels: []
-    schedule:
-      interval: "weekly"
     security-updates: true
     target-branch: "stable-5.0"
 


### PR DESCRIPTION
Dependabot opened #15700 on a Monday and for a major version bump not justified by security fixes. It seems like the scheduled run conflicts with our desire to only be notified when a module receives a security fix so disable the schedule and only trigger "on events".