### PR TITLE
lxc/remote/add: Fixed runtime error (index out of range [0])

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -532,7 +532,7 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 
 				// Continue with adding the remote if digest matches, or the user
 				// confirmed a fingerprint.
-				if string(line) == digest || strings.ToLower(string(line[0])) == i18n.G("y") {
+				if string(line) == digest || (len(line) > 0 && strings.ToLower(string(line[0])) == i18n.G("y")) {
 					break
 				}
 
@@ -544,7 +544,7 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 				}
 
 				// Error out if the user didn't confirm the fingerprint.
-				if len(line) < 1 || strings.ToLower(string(line[0])) == i18n.G("n") {
+				if len(line) < 1 || (len(line) > 0 && strings.ToLower(string(line[0])) == i18n.G("n")) {
 					return errors.New(i18n.G("Server certificate NACKed by user"))
 				}
 


### PR DESCRIPTION
When run,` lxc remote add <name> <url>`
It outputs this and waits for input

```
Certificate fingerprint: <fingerprint>
ok (y/n/[fingerprint])?
```
but when press just enter without inputting any character it return error, 

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.(*cmdRemoteAdd).run(0xc00016f2d0, 0xc00023da10?, {0xc00040e620, 0x2, 0x0?})
        github.com/canonical/lxd/lxc/remote.go:534 +0x31b0
github.com/spf13/cobra.(*Command).execute(0xc0003f8608, {0xc00040e5c0, 0x2, 0x2})
        github.com/spf13/cobra@v1.8.1/command.go:985 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc000300f08)
        github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.8.1/command.go:1041
main.main()
        github.com/canonical/lxd/lxc/main.go:294 +0x1a73
```
So i fixed it, to check if the length is greater than 0, and then read the line.