### PR TITLE
Improve `make test-shell` a bit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,19 @@ make deps && make
 
 # get an interactive test shell session with all the needed environment variables to use and test LXD
 make test-shell
+
+# run the `exec` and `query` tests
+./main.sh exec
+./main.sh query
+
+# or manually interact with LXD, for example:
+lxc launch ubuntu:24.04 u1
+lxc exec u1 -- hostname
+lxc delete --force u1
+
+# for a barebones test instance with just busybox (note: no IP automatically configured)
+./deps/import-busybox --alias testimage
+lxc launch testimage c1
 ```
 
 At this point you might want to learn more on {doc}`debugging`.

--- a/doc/lxd-test.yaml
+++ b/doc/lxd-test.yaml
@@ -43,6 +43,7 @@ config:
     package_upgrade: true
     packages:
     # dev comfort
+    - bash-completion
     - vim
     # build deps
     - autoconf

--- a/test/main.sh
+++ b/test/main.sh
@@ -289,7 +289,7 @@ fi
 if [ "${1:-"all"}" = "test-shell" ]; then
   # yellow
   export PS1="\[\033[0;33mLXD-TEST\033[0m ${PS1:-\u@\h:\w\$ }\]"
-  bash --norc
+  bash --norc || true
   # shellcheck disable=SC2034
   TEST_RESULT=success
   exit

--- a/test/main.sh
+++ b/test/main.sh
@@ -223,7 +223,7 @@ run_test() {
   TEST_CURRENT=${1}
   TEST_CURRENT_DESCRIPTION=${2:-${1#test_}}
   TEST_UNMET_REQUIREMENT=""
-  cwd="$(pwd)"
+  cwd="${PWD}"
 
   echo "==> TEST BEGIN: ${TEST_CURRENT_DESCRIPTION}"
   START_TIME=$(date +%s)

--- a/test/main.sh
+++ b/test/main.sh
@@ -112,11 +112,11 @@ cleanup() {
     bash --norc
   fi
 
-  echo ""
-  echo "df -h output:"
-  df -h
-
   if [ "${TEST_RESULT}" != "success" ]; then
+    echo ""
+    echo "df -h output:"
+    df -h
+
     if command -v ceph >/dev/null; then
       echo "::group::ceph status"
       ceph status --connect-timeout 5 || true

--- a/test/main.sh
+++ b/test/main.sh
@@ -53,6 +53,10 @@ import_subdir_files() {
     done
 }
 
+# `main.sh` needs to be executed from inside the `test/` directory
+if [ "${PWD}" != "$(dirname "${0}")" ]; then
+    cd "$(dirname "${0}")"
+fi
 import_subdir_files includes
 
 echo "==> Checking for dependencies"

--- a/test/main.sh
+++ b/test/main.sh
@@ -289,7 +289,7 @@ fi
 if [ "${1:-"all"}" = "test-shell" ]; then
   # yellow
   export PS1="\[\033[0;33mLXD-TEST\033[0m ${PS1:-\u@\h:\w\$ }\]"
-  bash --norc || true
+  bash --rcfile test-shell.bashrc || true
   # shellcheck disable=SC2034
   TEST_RESULT=success
   exit

--- a/test/test-shell.bashrc
+++ b/test/test-shell.bashrc
@@ -1,0 +1,10 @@
+# lxc command completion
+if [ -f /etc/profile.d/bash_completion.sh ] && command -v lxc > /dev/null; then
+    . /etc/profile.d/bash_completion.sh
+    . <(lxc completion bash)
+fi
+
+# provide useful aliases like `ll`, etc
+if [ -f ~/.bashrc ]; then
+    . ~/.bashrc
+fi


### PR DESCRIPTION
Add examples of how to make use of the interactive `test-shell` feature.
Add necessary bits to have `lxc` command completions working.