### PR TITLE
Partially undo switch to `ubuntu-24.04` runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -348,6 +348,15 @@ jobs:
           ls -lR /home/runner/go/bin/
           chmod uog+x /home/runner/go/bin/*
 
+      - name: Purge LXD snap
+        # TODO: drop this when moving away from `ubuntu-22.04` runners to `ubuntu-24.04`
+        if: ${{ matrix.backend == 'ceph' }}
+        run: |
+          set -eux
+          # LXD snap holds on to the swap that prevents the clearing of the ephemeral disk for microceph
+          # https://github.com/canonical/lxd/issues/14768
+          sudo snap remove --purge lxd
+
       - name: Setup MicroCeph
         if: ${{ matrix.backend == 'ceph' }}
         uses: ./.github/actions/setup-microceph

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -299,7 +299,7 @@ jobs:
       LXD_TMPFS: "1"
       GOTRACEBACK: "crash"
     name: System
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: code-tests
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       LD_RUN_PATH: "/home/runner/go/bin/dqlite/libs/"
       CGO_LDFLAGS_ALLOW: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
     name: Code
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
We ran into 2 problems when switching to 24.04 runners:

* When using ZFS in block mode, the `migration` test often fails
```
 ++ timeout --foreground 120 /home/runner/go/bin/lxc move l1:cccp l2:udssr --stateless --mode=relay --verbose
time="2025-06-10T16:38:33Z" level=info msg="Waiting for migration control connection on source" clusterMoveSourceName= instance=cccp live=false project=default push=false
time="2025-06-10T16:38:33Z" level=info msg="Creating instance" ephemeral=false instance=udssr instanceType=container project=default
time="2025-06-10T16:38:33Z" level=info msg="Created instance" ephemeral=false instance=udssr instanceType=container project=default
time="2025-06-10T16:38:33Z" level=info msg="Waiting for migration control connection on target" clusterMoveSourceName= instance=udssr live=false project=default push=true
time="2025-06-10T16:38:33Z" level=info msg="Migration control connection established on source" clusterMoveSourceName= instance=cccp live=false project=default push=false
time="2025-06-10T16:38:33Z" level=info msg="Migration send starting" instance=cccp instanceType=container project=default
time="2025-06-10T16:38:33Z" level=info msg="Migration control connection established on target" clusterMoveSourceName= instance=udssr live=false project=default push=true
time="2025-06-10T16:38:33Z" level=info msg="Migration receive starting" instance=udssr instanceType=container project=default
time="2025-06-10T16:38:33Z" level=info msg="Received migration index header, sending response" args="{IndexHeaderVersion:2 Name:udssr Description: Config:map[] Snapshots:[] MigrationType:{FSType:ZFS Features:[migration_header compress header_zvol_filesystems]} TrackProgress:true Refresh:false ConversionOptions:[] Live:true VolumeSize:0 ContentType: VolumeOnly:false ClusterMoveSourceName:}" driver=zfs instance=udssr pool=lxdtest-Hgj-block-mode project=default version=2
time="2025-06-10T16:38:33Z" level=info msg="Received migration index header response" args="&{IndexHeaderVersion:2 Name:cccp Snapshots:[] MigrationType:{FSType:ZFS Features:[migration_header compress header_zvol_filesystems]} TrackProgress:true MultiSync:false FinalSync:false Data:<nil> ContentType: AllowInconsistent:false Refresh:false Info:0xc000ef81c8 VolumeOnly:false ClusterMove:false}" driver=zfs instance=cccp pool=lxdtest-DEj-block-mode project=default response="{StatusCode:200 Error: Refresh:0xc0014ac3a8}" version=2
time="2025-06-10T16:38:33Z" level=info msg="Filesystem frozen" driver=zfs path=/tmp/lxd-test.tmp.c1i6/DEj/storage-pools/lxdtest-DEj-block-mode/containers/cccp pool=lxdtest-DEj-block-mode
time="2025-06-10T16:38:33Z" level=info msg="Filesystem unfrozen" driver=zfs path=/tmp/lxd-test.tmp.c1i6/DEj/storage-pools/lxdtest-DEj-block-mode/containers/cccp pool=lxdtest-DEj-block-mode
time="2025-06-10T16:38:34Z" level=info msg="Migration receive stopped" instance=udssr instanceType=container project=default
time="2025-06-10T16:38:34Z" level=error msg="Failed migration on target" clusterMoveSourceName= err="Failed creating instance on target: Failed to run: xfs_admin -U generate /dev/zvol/lxdtest-Hgj-block-mode/containers/udssr: exit status 1 (/dev/zvol/lxdtest-Hgj-block-mode/containers/udssr: No such file or directory\n\nfatal error -- couldn't initialize XFS library)" instance=udssr live=false project=default push=true
time="2025-06-10T16:38:34Z" level=info msg="Migration channels disconnected on target" clusterMoveSourceName= instance=udssr live=false project=default push=true
time="2025-06-10T16:38:34Z" level=info msg="Migration send stopped" instance=cccp instanceType=container project=default
time="2025-06-10T16:38:34Z" level=error msg="Failed migration on source" clusterMoveSourceName= err="Error from migration control target: Failed creating instance on target: Failed to run: xfs_admin -U generate /dev/zvol/lxdtest-Hgj-block-mode/containers/udssr: exit status 1 (/dev/zvol/lxdtest-Hgj-block-mode/containers/udssr: No such file or directory\n\nfatal error -- couldn't initialize XFS library)" instance=cccp live=false project=default push=false
time="2025-06-10T16:38:34Z" level=info msg="Migration channels disconnected on source" clusterMoveSourceName= instance=cccp live=false project=default push=false
Error: Error transferring instance data: Failed migration on target: Failed creating instance on target: Failed to run: xfs_admin -U generate /dev/zvol/lxdtest-Hgj-block-mode/containers/udssr: exit status 1 (/dev/zvol/lxdtest-Hgj-block-mode/containers/udssr: No such file or directory

fatal error -- couldn't initialize XFS library)
+ cleanup
```

* Sometimes the `action/setup-microceph` fails due to what looks like a kernel bug/race where the partitions don't show up when they should:
```
 + sudo blkdiscard /dev/sda --force
blkdiscard: Operation forced, data will be lost!
+ sudo parted /dev/sda --script mklabel gpt
++ seq 1 3
+ for i in $(seq 1 "3")
+ min=0
+ max=33
+ sudo parted /dev/sda --align optimal --script mkpart primary 0% 33%
+ for i in $(seq 1 "3")
+ min=33
+ max=66
+ sudo parted /dev/sda --align optimal --script mkpart primary 33% 66%
+ for i in $(seq 1 "3")
+ min=66
+ max=100
+ sudo parted /dev/sda --align optimal --script mkpart primary 66% 100%
+ sudo partx --update /dev/sda
++ seq 1 3
+ for i in $(seq 1 "3")
++ sudo losetup --find --nooverlap --direct-io=on --show /dev/sda1
+ disk=/dev/loop3
+ sudo microceph disk add /dev/loop3

Error: unable to list system disks: Failed to find "/dev/disk/by-id/scsi-360022480f7ede484529a3f14360468ba-part2": lstat /dev/disk/by-id/scsi-360022480f7ede484529a3f14360468ba-part2: no such file or directory
+------------+---------+
|    PATH    | STATUS  |
+------------+---------+
| /dev/loop3 | Failure |
+------------+---------+
++ cleanup
```