### PR TITLE
Storage: Fix comment and error message

### DIFF
--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -173,7 +173,7 @@ func (c *Config) CustomVolume() (*Volume, error) {
 
 	volume, err := c.primaryVolume()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get custom volume: %w", err)
+		return nil, fmt.Errorf("Failed to get primary volume: %w", err)
 	}
 
 	return volume, nil

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6979,7 +6979,7 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 }
 
 // GenerateInstanceBackupConfig returns the backup config entry for this instance.
-// The Container field is only populated for non-snapshot instances.
+// The Instance field is only populated for non-snapshot instances.
 func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, _ *operations.Operation) (*backupConfig.Config, error) {
 	// Generate the YAML.
 	ci, _, err := inst.Render()


### PR DESCRIPTION
Small PR to move unrelated commits from https://github.com/canonical/lxd/pull/15523.

- When trying to fetch the primary vol from the backup config, in case of failure the correct error message should be returned
- The `Container` field was deprecated with v2 of the backup config and is now called `Instance`