### PR TITLE
Backup: Rearrange consts to allow narrowing down volume lookup

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/canonical/lxd/lxd/backup"
+	backupConfig "github.com/canonical/lxd/lxd/backup/config"
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
@@ -240,7 +241,7 @@ func backupWriteIndex(sourceInst instance.Instance, pool storagePools.Pool, opti
 	}
 
 	backupType := backup.InstanceTypeToBackupType(api.InstanceType(sourceInst.Type().String()))
-	if backupType == backup.TypeUnknown {
+	if backupType == backupConfig.TypeUnknown {
 		return errors.New("Unrecognised instance type for backup type conversion")
 	}
 
@@ -572,7 +573,7 @@ func volumeBackupWriteIndex(projectName string, volumeName string, pool storageP
 		Backend:          pool.Driver().Info().Name,
 		OptimizedStorage: &optimized,
 		OptimizedHeader:  &poolDriverOptimizedHeader,
-		Type:             backup.TypeCustom,
+		Type:             backupConfig.TypeCustom,
 		Config:           config,
 	}
 

--- a/lxd/backup/backup_info.go
+++ b/lxd/backup/backup_info.go
@@ -14,15 +14,15 @@ import (
 const backupIndexPath = "backup/index.yaml"
 
 // InstanceTypeToBackupType converts instance type to backup type.
-func InstanceTypeToBackupType(instanceType api.InstanceType) Type {
+func InstanceTypeToBackupType(instanceType api.InstanceType) config.Type {
 	switch instanceType {
 	case api.InstanceTypeContainer:
-		return TypeContainer
+		return config.TypeContainer
 	case api.InstanceTypeVM:
-		return TypeVM
+		return config.TypeVM
 	}
 
-	return TypeUnknown
+	return config.TypeUnknown
 }
 
 // Info represents exported backup information.
@@ -34,7 +34,7 @@ type Info struct {
 	Snapshots        []string       `json:"snapshots,omitempty" yaml:"snapshots,omitempty"`
 	OptimizedStorage *bool          `json:"optimized,omitempty" yaml:"optimized,omitempty"`               // Optional field to handle older optimized backups that don't have this field.
 	OptimizedHeader  *bool          `json:"optimized_header,omitempty" yaml:"optimized_header,omitempty"` // Optional field to handle older optimized backups that don't have this field.
-	Type             Type           `json:"type,omitempty" yaml:"type,omitempty"`                         // Type of backup.
+	Type             config.Type    `json:"type,omitempty" yaml:"type,omitempty"`                         // Type of backup.
 	Config           *config.Config `json:"config,omitempty" yaml:"config,omitempty"`                     // Equivalent of backup.yaml but embedded in index for quick retrieval.
 }
 
@@ -74,8 +74,8 @@ func GetInfo(s *state.State, r io.ReadSeeker, outputPath string) (*Info, error) 
 			hasIndexFile = true
 
 			// Default to container if index doesn't specify instance type.
-			if result.Type == TypeUnknown {
-				result.Type = TypeContainer
+			if result.Type == config.TypeUnknown {
+				result.Type = config.TypeContainer
 			}
 
 			// Default to no optimized header if not specified.

--- a/lxd/backup/backup_info.go
+++ b/lxd/backup/backup_info.go
@@ -11,21 +11,6 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
-// Type indicates the type of backup.
-type Type string
-
-// TypeUnknown defines the backup type value for unknown backups.
-const TypeUnknown = Type("")
-
-// TypeContainer defines the backup type value for a container.
-const TypeContainer = Type("container")
-
-// TypeVM defines the backup type value for a virtual-machine.
-const TypeVM = Type("virtual-machine")
-
-// TypeCustom defines the backup type value for a custom volume.
-const TypeCustom = Type("custom")
-
 const backupIndexPath = "backup/index.yaml"
 
 // InstanceTypeToBackupType converts instance type to backup type.

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -16,6 +16,21 @@ const DefaultMetadataVersion = api.BackupMetadataVersion2
 // MaxMetadataVersion represents the latest supported metadata version.
 const MaxMetadataVersion = api.BackupMetadataVersion2
 
+// Type indicates the type of backup.
+type Type string
+
+// TypeUnknown defines the backup type value for unknown backups.
+const TypeUnknown = Type("")
+
+// TypeContainer defines the backup type value for a container.
+const TypeContainer = Type("container")
+
+// TypeVM defines the backup type value for a virtual-machine.
+const TypeVM = Type("virtual-machine")
+
+// TypeCustom defines the backup type value for a custom volume.
+const TypeCustom = Type("custom")
+
 // Volume represents the config of a volume including its snapshots.
 type Volume struct {
 	// Make sure to have the embedded structs fields inline to avoid nesting.

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -162,7 +162,10 @@ func (c *Config) RootVolume() (*Volume, error) {
 			continue
 		}
 
-		if volume.Name == c.Instance.Name {
+		// An instance's root volume uses the same name as its parent instance.
+		// In the list of volumes there might be a custom storage volume with an identical name.
+		// Only return the volume if its type is either virtual-machine or container.
+		if volume.Name == c.Instance.Name && Type(volume.Type) != TypeCustom {
 			return volume, nil
 		}
 	}


### PR DESCRIPTION
Small PR to move unrelated commits from https://github.com/canonical/lxd/pull/15523.

This moves some backup related constants from the main `backup` into the backup's dedicated `config` package which allows reusing them for a more narrow volume lookup (and to prevent an import cycle while doing so).

In addition when trying to retrieve the root vol from the list of vols in the backup config, the volume's type is now checked for being non-custom. 
This is in preparation for adding custom storage vols to the list of volumes in the backup config file.