### PR TITLE
Storage: Add reverter pattern for custom volume backend actions

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6722,6 +6722,8 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 		return err
 	}
 
+	revert.Add(func() { _ = b.driver.DeleteVolumeSnapshot(vol, op) })
+
 	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotCreated.Event(vol, string(vol.Type()), projectName, op, logger.Ctx{"type": vol.Type()}))
 
 	revert.Success()


### PR DESCRIPTION
Small PR to move unrelated bits from https://github.com/canonical/lxd/pull/15523.

Even though in some cases the "to be reverted" action is the last one in the row, having the reverter pattern in place allows adding additional instructions in the future without having to care about reverting existing actions in case of error.

This is starting to get useful with https://github.com/canonical/lxd/pull/15523 when reverting the instance's backup config file in case of errors.