### PR TITLE
github: use actions/setup-python to cache pip dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,16 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Install Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          cache: 'pip' # caching pip dependencies
+          cache-dependency-path: |
+            doc/.sphinx/build_requirements.py
+            doc/.sphinx/requirements.txt
+            doc/custom_conf.py
+          python-version: '3.x'  # satisfied by any 3.x version already installed
+
       - name: Install build dependencies
         uses: ./.github/actions/install-lxd-builddeps
 
@@ -796,6 +806,16 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Install Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          cache: 'pip' # caching pip dependencies
+          cache-dependency-path: |
+            doc/.sphinx/build_requirements.py
+            doc/.sphinx/requirements.txt
+            doc/custom_conf.py
+          python-version: '3.x'  # satisfied by any 3.x version already installed
+
       - name: Install dependencies
         run: |
           set -eux
@@ -847,6 +867,16 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: 'go.mod'
+
+      - name: Install Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          cache: 'pip' # caching pip dependencies
+          cache-dependency-path: |
+            doc/.sphinx/build_requirements.py
+            doc/.sphinx/requirements.txt
+            doc/custom_conf.py
+          python-version: '3.x'  # satisfied by any 3.x version already installed
 
       - name: Build LXD client
         run: make client

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -828,7 +828,6 @@ jobs:
           make doc-lint
 
       - name: Build docs (Sphinx)
-        shell: 'script -q -e -c "export TERM=xterm-256color; bash {0}"'
         run: |
           set -eux
           make doc


### PR DESCRIPTION
This slightly improves the speed of everything needing the Python venv for the `doc` actions. ATM, there are 2 different cached copies due to having some steps running on 22.04 and some on 24.04:

* `setup-python-Linux-x64-22.04-Ubuntu-python-3.13.3-pip-7d...9c`
* `setup-python-Linux-x64-24.04-Ubuntu-python-3.13.4-pip-7d...9c`

It still provides a benefit and also reduces the amount of stuff we needlessly pull from PyPi.