### PR TITLE
Makefile: Add `make update-fmt`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,12 @@ Some changes require regenerating certain files using Makefile commands.
 
 After you run any of the commands below, you'll be prompted whether to commit the changes. If you respond `Y`, only the re-generated files are committed—any other staged files are ignored.
 
+#### Formatting
+
+If you modify any Go source files, format them:
+
+	make update-fmt
+
 #### CLI tool string updates
 
 If you modify CLI strings in `lxc/`, regenerate and commit translation files:

--- a/Makefile
+++ b/Makefile
@@ -418,3 +418,7 @@ update-auth:
 			git commit -S -sm "lxd/auth: Update auth" -- ./lxd/auth/;\
 		fi;\
 	fi
+
+.PHONY: update-fmt
+update-fmt:
+	gofmt -w -s ./


### PR DESCRIPTION
Add a `make update-fmt` target that runs `gofmt` on all files and update contribution guidelines.