### PR TITLE
devlxd: Separate UbutuPro type used in LXD and in devLXD

### DIFF
--- a/client/devlxd_ubuntu_pro.go
+++ b/client/devlxd_ubuntu_pro.go
@@ -7,8 +7,8 @@ import (
 )
 
 // GetUbuntuPro retrieves the guest's Ubuntu Pro settings.
-func (r *ProtocolDevLXD) GetUbuntuPro() (*api.UbuntuProSettings, error) {
-	var info api.UbuntuProSettings
+func (r *ProtocolDevLXD) GetUbuntuPro() (*api.DevLXDUbuntuProSettings, error) {
+	var info api.DevLXDUbuntuProSettings
 
 	_, err := r.queryStruct(http.MethodGet, "/ubuntu-pro", nil, "", &info)
 	if err != nil {
@@ -19,8 +19,8 @@ func (r *ProtocolDevLXD) GetUbuntuPro() (*api.UbuntuProSettings, error) {
 }
 
 // CreateUbuntuProToken creates a new Ubuntu Pro token.
-func (r *ProtocolDevLXD) CreateUbuntuProToken() (*api.UbuntuProGuestTokenResponse, error) {
-	var token api.UbuntuProGuestTokenResponse
+func (r *ProtocolDevLXD) CreateUbuntuProToken() (*api.DevLXDUbuntuProGuestTokenResponse, error) {
+	var token api.DevLXDUbuntuProGuestTokenResponse
 
 	_, err := r.queryStruct(http.MethodPost, "/ubuntu-pro/token", nil, "", &token)
 	if err != nil {

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -498,8 +498,8 @@ type DevLXDServer interface {
 	GetImageFile(fingerprint string, req ImageFileRequest) (resp *ImageFileResponse, err error)
 
 	// DevLXD Ubuntu Pro.
-	GetUbuntuPro() (*api.UbuntuProSettings, error)
-	CreateUbuntuProToken() (*api.UbuntuProGuestTokenResponse, error)
+	GetUbuntuPro() (*api.DevLXDUbuntuProSettings, error)
+	CreateUbuntuProToken() (*api.DevLXDUbuntuProGuestTokenResponse, error)
 
 	// Internal functions (for internal use)
 	RawQuery(method string, path string, data any, queryETag string) (resp *api.DevLXDResponse, ETag string, err error)

--- a/lxd/ubuntupro/client.go
+++ b/lxd/ubuntupro/client.go
@@ -61,7 +61,7 @@ type Client struct {
 
 // pro is an internal interface that is used for mocking calls to the pro CLI.
 type pro interface {
-	getGuestToken(ctx context.Context) (*api.UbuntuProGuestTokenResponse, error)
+	getGuestToken(ctx context.Context) (*api.DevLXDUbuntuProGuestTokenResponse, error)
 }
 
 // proCLI calls the actual Ubuntu Pro CLI to implement the interface.
@@ -72,7 +72,7 @@ type proCLI struct{}
 type proAPIGetGuestTokenV1 struct {
 	Result string `json:"result"`
 	Data   struct {
-		Attributes api.UbuntuProGuestTokenResponse `json:"attributes"`
+		Attributes api.DevLXDUbuntuProGuestTokenResponse `json:"attributes"`
 	} `json:"data"`
 	Errors []struct {
 		Title string `json:"title"`
@@ -80,7 +80,7 @@ type proAPIGetGuestTokenV1 struct {
 }
 
 // getTokenJSON runs `pro api u.pro.attach.guest.get_guest_token.v1` and returns the result.
-func (proCLI) getGuestToken(ctx context.Context) (*api.UbuntuProGuestTokenResponse, error) {
+func (proCLI) getGuestToken(ctx context.Context) (*api.DevLXDUbuntuProGuestTokenResponse, error) {
 	// Run pro guest attach command.
 	response, err := shared.RunCommandContext(ctx, "pro", "api", "u.pro.attach.guest.get_guest_token.v1")
 	if err != nil {
@@ -143,13 +143,13 @@ func (s *Client) getGuestAttachSetting(instanceSetting string) string {
 }
 
 // GuestAttachSettings returns UbuntuProSettings based on the instance configuration and the GuestAttachSetting of the host.
-func (s *Client) GuestAttachSettings(instanceSetting string) api.UbuntuProSettings {
-	return api.UbuntuProSettings{GuestAttach: s.getGuestAttachSetting(instanceSetting)}
+func (s *Client) GuestAttachSettings(instanceSetting string) api.DevLXDUbuntuProSettings {
+	return api.DevLXDUbuntuProSettings{GuestAttach: s.getGuestAttachSetting(instanceSetting)}
 }
 
 // GetGuestToken returns a 403 Forbidden error if the host or the instance has guestAttachSettingOff, otherwise
 // it calls the pro shim to get a token.
-func (s *Client) GetGuestToken(ctx context.Context, instanceSetting string) (*api.UbuntuProGuestTokenResponse, error) {
+func (s *Client) GetGuestToken(ctx context.Context, instanceSetting string) (*api.DevLXDUbuntuProGuestTokenResponse, error) {
 	if s.getGuestAttachSetting(instanceSetting) == guestAttachSettingOff {
 		return nil, api.NewStatusError(http.StatusForbidden, "Guest attachment not allowed")
 	}
@@ -244,7 +244,7 @@ func (s *Client) parseConfigFile(lxdConfigFile string) error {
 
 	defer f.Close()
 
-	var settings api.UbuntuProSettings
+	var settings api.DevLXDUbuntuProSettings
 	err = json.NewDecoder(f).Decode(&settings)
 	if err != nil {
 		return fmt.Errorf("Failed to read Ubuntu Pro configuration file: %w", err)

--- a/lxd/ubuntupro/client_test.go
+++ b/lxd/ubuntupro/client_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 type proCLIMock struct {
-	mockResponse *api.UbuntuProGuestTokenResponse
+	mockResponse *api.DevLXDUbuntuProGuestTokenResponse
 	mockErr      error
 }
 
-func (p proCLIMock) getGuestToken(_ context.Context) (*api.UbuntuProGuestTokenResponse, error) {
+func (p proCLIMock) getGuestToken(_ context.Context) (*api.DevLXDUbuntuProGuestTokenResponse, error) {
 	return p.mockResponse, p.mockErr
 }
 
@@ -36,7 +36,7 @@ func TestClient(t *testing.T) {
 		if raw != "" {
 			d = []byte(raw)
 		} else {
-			d, err = json.Marshal(api.UbuntuProSettings{GuestAttach: setting})
+			d, err = json.Marshal(api.DevLXDUbuntuProSettings{GuestAttach: setting})
 			require.NoError(t, err)
 		}
 
@@ -45,7 +45,7 @@ func TestClient(t *testing.T) {
 		sleep()
 	}
 
-	mockTokenResponse := api.UbuntuProGuestTokenResponse{
+	mockTokenResponse := api.DevLXDUbuntuProGuestTokenResponse{
 		Expires:    time.Now().String(),
 		GuestToken: "token",
 		ID:         uuid.New().String(),
@@ -60,7 +60,7 @@ func TestClient(t *testing.T) {
 		instanceSetting   string
 		expectedSetting   string
 		expectErr         bool
-		expectedToken     *api.UbuntuProGuestTokenResponse
+		expectedToken     *api.DevLXDUbuntuProGuestTokenResponse
 		expectedErrorCode int
 	}
 
@@ -152,7 +152,7 @@ func TestClient(t *testing.T) {
 
 	runAssertions := func(assertions []assertion) {
 		for _, a := range assertions {
-			assert.Equal(t, api.UbuntuProSettings{GuestAttach: a.expectedSetting}, s.GuestAttachSettings(a.instanceSetting))
+			assert.Equal(t, api.DevLXDUbuntuProSettings{GuestAttach: a.expectedSetting}, s.GuestAttachSettings(a.instanceSetting))
 			token, err := s.GetGuestToken(ctx, a.instanceSetting)
 			assert.Equal(t, a.expectedToken, token)
 			if a.expectErr {

--- a/shared/api/devlxd.go
+++ b/shared/api/devlxd.go
@@ -39,11 +39,11 @@ type DevLXDGet struct {
 	Location string `json:"location" yaml:"location"`
 }
 
-// UbuntuProGuestTokenResponse contains the expected fields of proAPIGetGuestTokenV1 that must be passed back to
+// DevLXDUbuntuProGuestTokenResponse contains the expected fields of proAPIGetGuestTokenV1 that must be passed back to
 // the guest for pro attachment to succeed.
 //
 // API extension: ubuntu_pro_guest_attach.
-type UbuntuProGuestTokenResponse struct {
+type DevLXDUbuntuProGuestTokenResponse struct {
 	// Expires denotes the time at which the token will expire.
 	//
 	// Example: 2025-03-23T20:00:00-04:00
@@ -60,10 +60,10 @@ type UbuntuProGuestTokenResponse struct {
 	ID string `json:"id"`
 }
 
-// UbuntuProSettings contains Ubuntu Pro settings relevant to LXD.
+// DevLXDUbuntuProSettings contains Ubuntu Pro settings relevant to LXD.
 //
 // API extension: ubuntu_pro_guest_attach.
-type UbuntuProSettings struct {
+type DevLXDUbuntuProSettings struct {
 	// GuestAttach indicates the availability of ubuntu pro guest attachment.
 	//
 	// Example: on


### PR DESCRIPTION
As part of devLXD refactoring, we want devLXD response types to be prefixed with `DevLXD`.
This change only rename the UbuntuPro response types, but the actual responses from devLXD are intact.

~Since UbuntuPro types (without DevLXD prefix) are not used outside devLXD, I would also prefer moving them into `lxd/ubuntupro` package - to be used only internally.~

Let me know if we want to proceed with the renaming for consistency.