### PR TITLE
lxd/devices/proxy: Fix unix socket cleanup

### DIFF
--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -687,7 +687,7 @@ func (d *proxy) killProxyProc(pidPath string) error {
 
 	// Remove socket file if needed.
 	// Unix non-abstract sockets are addressed to the host filesystem, not scoped inside the LXD snap.
-	if listenAddr.ConnType == "unix" && !listenAddr.Abstract {
+	if listenAddr.ConnType == "unix" && !listenAddr.Abstract && d.config["bind"] == "host" {
 		err = os.Remove(shared.HostPath(listenAddr.Address))
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("Failed to remove socket file: %w", err)

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -686,8 +686,9 @@ func (d *proxy) killProxyProc(pidPath string) error {
 	}
 
 	// Remove socket file if needed.
+	// Unix non-abstract sockets are addressed to the host filesystem, not scoped inside the LXD snap.
 	if listenAddr.ConnType == "unix" && !listenAddr.Abstract {
-		err = os.Remove(listenAddr.Address)
+		err = os.Remove(shared.HostPath(listenAddr.Address))
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("Failed to remove socket file: %w", err)
 		}


### PR DESCRIPTION
Fixes #15784 and #15782.