### PR TITLE
 test/lint/bad-grep: check test scripts for `grep` misuse

### DIFF
--- a/test/lint/bad-grep.sh
+++ b/test/lint/bad-grep.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+RC=0
+
+# `grep -q` should be avoided in pipelines when using `set -o pipefail` (and
+# `set -e`) as when the first pattern match occurs, `grep` terminates leading
+# to a `SIGPIPE` to be sent to the process writing into the pipe. If that
+# command does not gracefully handle `SIGPIPE`, it will error out causing the
+# whole pipeline to fail.
+# XXX: the `echo` (builtin) command gracefully handles `SIGPIPE` so it is
+# permitted.
+OUTPUT="$(grep --exclude-dir=lint -rE ' ?\| ?grep -[^ ]*q' test/ | grep -vE 'echo [^ ]+ \| grep -[^ ]*q' || true)"
+if [ -n "${OUTPUT}" ]; then
+    echo "FAIL: avoid using 'grep -q' in command pipelines with 'set -o pipefail'"
+    echo "${OUTPUT}"
+    echo
+    RC=1
+fi
+
+# `grep -v` should not be used **at the end** of pipelines to verify if a
+# pattern is or isn't present as the return code does not reflect if the
+# pattern was found and suppressed or not found:
+#
+#   ```
+#   $ echo -e 'a\nb' | grep -v a; echo $?
+#   b
+#   0
+#
+#   $ echo -e 'a\nb' | grep -v c; echo $?
+#   a
+#   b
+#   0
+#   ```
+# XXX: this search pattern is not perfect but should catch most use of
+# `grep -v` at the end of pipelines and when not used inside a shell
+# comparison.
+OUTPUT="$(grep --exclude-dir=lint -rE ' ?\| ?grep -v[^(\|=)]+$' test/ || true)"
+if [ -n "${OUTPUT}" ]; then
+    echo "FAIL: unreliable use of 'grep -v' at the end of command pipelines"
+    echo "${OUTPUT}"
+    echo
+    RC=1
+fi
+
+exit "${RC}"

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -135,8 +135,8 @@ test_authorization() {
 
   # Check users have been added to the group.
   tls_identity_fingerprint="$(cert_fingerprint "${LXD_CONF2}/client.crt")"
-  lxc auth identity list --format csv | grep -Fq 'oidc,OIDC client," ",test-user@example.com,test-group'
-  lxc auth identity list --format csv | grep -Fq "tls,Client certificate,test-user,${tls_identity_fingerprint},test-group"
+  lxc auth identity list --format csv | grep -F 'oidc,OIDC client," ",test-user@example.com,test-group'
+  lxc auth identity list --format csv | grep -F "tls,Client certificate,test-user,${tls_identity_fingerprint},test-group"
 
   # Test `lxc auth identity info`
   expectedOIDCInfo='authentication_method: oidc
@@ -235,23 +235,23 @@ fine_grained: true"
 
   # The OIDC identity should be able to delete themselves without any permissions.
   lxc auth identity group remove oidc/test-user@example.com test-group
-  lxc_remote auth identity info oidc: | grep -Fq 'effective_permissions: []'
+  lxc_remote auth identity info oidc: | grep -F 'effective_permissions: []'
   lxc_remote auth identity delete oidc:oidc/test-user@example.com
-  ! lxc auth identity list --format csv | grep -Fq 'test-user@example.com' || false
+  ! lxc auth identity list --format csv | grep -F 'test-user@example.com' || false
 
   # When the OIDC identity re-authenticates they should reappear in the database
   [ "$(lxc_remote query oidc:/1.0 | jq -r '.auth')" = "trusted" ]
-  lxc auth identity list --format csv | grep -Fq 'test-user@example.com'
-  lxc_remote auth identity info oidc: | grep -Fq 'effective_permissions: []'
+  lxc auth identity list --format csv | grep -F 'test-user@example.com'
+  lxc_remote auth identity info oidc: | grep -F 'effective_permissions: []'
 
   # The OIDC identity cannot see or delete the TLS identity.
   ! lxc_remote auth identity show "oidc:tls/${tls_identity_fingerprint}" || false
   ! lxc_remote auth identity delete "oidc:tls/${tls_identity_fingerprint}" || false
 
   # But the TLS identity can see and delete itself
-  LXD_CONF="${LXD_CONF2}" lxc_remote auth identity list tls: --format csv | grep -Fq "${tls_identity_fingerprint}"
+  LXD_CONF="${LXD_CONF2}" lxc_remote auth identity list tls: --format csv | grep -wF "${tls_identity_fingerprint}"
   LXD_CONF="${LXD_CONF2}" lxc_remote auth identity delete "tls:tls/${tls_identity_fingerprint}"
-  ! lxc auth identity list --format csv | grep -Fq "${tls_identity_fingerprint}" || false
+  ! lxc auth identity list --format csv | grep -F "${tls_identity_fingerprint}" || false
 
   # The TLS identity is not trusted after deletion.
   [ "$(LXD_CONF="${LXD_CONF2}" lxc_remote query tls:/1.0 | jq -r '.auth')" = "untrusted" ]
@@ -509,7 +509,7 @@ user_is_not_server_admin() {
   lxc_remote info "${remote}:" > /dev/null
 
   # Cannot see any config.
-  ! lxc_remote info "${remote}:" | grep -Fq 'core.https_address' || false
+  ! lxc_remote info "${remote}:" | grep -F 'core.https_address' || false
 
   # Cannot set any config.
   ! lxc_remote config set "${remote}:" core.proxy_https=https://example.com || false
@@ -518,7 +518,7 @@ user_is_not_server_admin() {
   [ "$(lxc_remote storage list "${remote}:" -f csv | wc -l)" = 1 ]
   lxc_remote storage create test-pool dir
   ! lxc_remote storage set "${remote}:test-pool" rsync.compression=true || false
-  ! lxc_remote storage show "${remote}:test-pool" | grep -Fq 'source:' || false
+  ! lxc_remote storage show "${remote}:test-pool" | grep -F 'source:' || false
   ! lxc_remote storage delete "${remote}:test-pool" || false
   lxc_remote storage delete test-pool
 
@@ -544,7 +544,7 @@ user_is_server_admin() {
   remote="${1}"
 
   # Should be able to see server config.
-  lxc_remote info "${remote}:" | grep -Fq 'core.https_address'
+  lxc_remote info "${remote}:" | grep -F 'core.https_address'
 
   ## Should be able to add/remove certificates.
   # Create a temporary lxc config directory with some certs to test with.
@@ -565,7 +565,7 @@ user_is_server_admin() {
   ## Should be able to create/edit/delete a storage pool.
   lxc_remote storage create "${remote}:test-pool" dir
   lxc_remote storage set "${remote}:test-pool" rsync.compression=true
-  lxc_remote storage show "${remote}:test-pool" | grep -Fq 'rsync.compression:'
+  lxc_remote storage show "${remote}:test-pool" | grep -F 'rsync.compression:'
   lxc_remote storage delete "${remote}:test-pool"
 
   # Should be able to view all managed and unmanaged networks
@@ -578,7 +578,7 @@ user_is_server_operator() {
   remote="${1}"
 
   # Should be able to see projects.
-  lxc_remote project list "${remote}:" -f csv | grep -Fq 'default'
+  lxc_remote project list "${remote}:" -f csv | grep -wF "default"
 
   # Should be able to create/edit/delete a project.
   lxc_remote project create "${remote}:test-project"
@@ -696,7 +696,7 @@ user_is_not_project_operator() {
 
   # Should be able to list public images.
   lxc_remote image show testimage | sed -e "s/public: false/public: true/" | lxc_remote image edit testimage
-  lxc_remote image list "${remote}:" -f csv | grep -Fq "${test_image_fingerprint_short}"
+  lxc_remote image list "${remote}:" -f csv | grep -wF "${test_image_fingerprint_short}"
   lxc_remote image show testimage | sed -e "s/public: true/public: false/" | lxc_remote image edit testimage
 }
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -526,7 +526,7 @@ user_is_not_server_admin() {
   ! lxc_remote storage create "${remote}:test" dir || false
 
   # Should not be able to see certificates
-  [ "$(lxc_remote config trust list "${remote}:" -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote config trust list "${remote}:" -f csv)" = "" ]
 
   # Cannot edit certificates.
   fingerprint="$(lxc config trust list -f csv | cut -d, -f4)"
@@ -628,22 +628,22 @@ user_is_not_project_operator() {
   remote="${1}"
 
   # Project list will not fail but there will be no output.
-  [ "$(lxc project list "${remote}:" -f csv | wc -l)" = 0 ]
+  [ "$(lxc project list "${remote}:" -f csv)" = "" ]
   ! lxc project show "${remote}:default" || false
 
   # Should not be able to see or create any instances.
   lxc_remote init testimage c1
-  [ "$(lxc_remote list "${remote}:" -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote list "${remote}:" -f csv --all-projects | wc -l)" = 0 ]
+  [ "$(lxc_remote list "${remote}:" -f csv)" = "" ]
+  [ "$(lxc_remote list "${remote}:" -f csv --all-projects)" = "" ]
   ! lxc_remote init testimage "${remote}:test-instance" || false
   lxc_remote delete c1 -f
 
   # Should not be able to see network allocations.
-  [ "$(lxc_remote network list-allocations "${remote}:" -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote network list-allocations "${remote}:" --all-projects -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote network list-allocations "${remote}:" -f csv)" = "" ]
+  [ "$(lxc_remote network list-allocations "${remote}:" --all-projects -f csv)" = "" ]
 
   # Should not be able to see or create networks.
-  [ "$(lxc_remote network list "${remote}:" -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote network list "${remote}:" -f csv)" = "" ]
   ! lxc_remote network create "${remote}:test-network" || false
 
   # Should not be able to see or create network ACLs.
@@ -661,32 +661,32 @@ user_is_not_project_operator() {
   lxc_remote network zone delete zone1
 
   # Should not be able to see or create profiles.
-  [ "$(lxc_remote profile list "${remote}:" -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote profile list "${remote}:" -f csv)" = "" ]
   [ "$(lxc_remote profile list "${remote}:" -f csv --all-projects)" = "" ]
   ! lxc_remote profile create "${remote}:test-profile" || false
 
   # Should not be able to see or create image aliases
   test_image_fingerprint="$(lxc_remote image info testimage | awk '/^Fingerprint/ {print $2}')"
-  [ "$(lxc_remote image alias list "${remote}:" -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote image alias list "${remote}:" -f csv)" = "" ]
   ! lxc_remote image alias create "${remote}:testimage2" "${test_image_fingerprint}" || false
 
   # Should not be able to see or create storage pool volumes.
   pool_name="$(lxc_remote storage list "${remote}:" -f csv | cut -d, -f1)"
   lxc_remote storage volume create "${pool_name}" vol1
-  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" --all-projects -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote storage volume list "${remote}:" -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote storage volume list "${remote}:" --all-projects -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" -f csv)" = "" ]
+  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" --all-projects -f csv)" = "" ]
+  [ "$(lxc_remote storage volume list "${remote}:" -f csv)" = "" ]
+  [ "$(lxc_remote storage volume list "${remote}:" --all-projects -f csv)" = "" ]
   ! lxc_remote storage volume create "${remote}:${pool_name}" test-volume || false
   lxc_remote storage volume delete "${pool_name}" vol1
 
   # Should not be able to see any operations.
-  [ "$(lxc_remote operation list "${remote}:" -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote operation list "${remote}:" --all-projects -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote operation list "${remote}:" -f csv)" = "" ]
+  [ "$(lxc_remote operation list "${remote}:" --all-projects -f csv)" = "" ]
 
   # Image list will still work but none will be shown because none are public.
-  [ "$(lxc_remote image list "${remote}:" -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote image list "${remote}:" -f csv --all-projects | wc -l)" = 0 ]
+  [ "$(lxc_remote image list "${remote}:" -f csv)" = "" ]
+  [ "$(lxc_remote image list "${remote}:" -f csv --all-projects)" = "" ]
 
   # Image edit will fail. Note that this fails with "not found" because we fail to resolve the alias (image is not public
   # so it is not returned from the DB).
@@ -725,7 +725,7 @@ auth_project_features() {
   lxc project create blah
 
   # Validate view with no permissions
-  [ "$(lxc_remote project list "${remote}:" --format csv | wc -l)" -eq 0 ]
+  [ "$(lxc_remote project list "${remote}:" --format csv)" = "" ]
 
   # Allow operator permissions on project blah
   lxc auth group permission add test-group project blah operator
@@ -866,7 +866,7 @@ auth_project_features() {
   # The network we created in the default project is not visible in project blah.
   ! lxc_remote network show "${remote}:${networkName}" --project blah || false
   ! lxc_remote network list "${remote}:" --project blah | grep -F "${networkName}" || false
-  [ "$(lxc_remote network list "${remote}:" --all-projects -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote network list "${remote}:" --all-projects -f csv)" = "" ]
 
   # Make networks in the default project viewable to members of test-group
   lxc auth group permission add test-group project default can_view_networks
@@ -1062,7 +1062,7 @@ auth_project_features() {
   # The storage bucket we created in the default project is not visible in project blah.
   ! lxc_remote storage bucket show "${remote}:s3" "${bucketName}" --project blah || false
   ! lxc_remote storage bucket list "${remote}:s3" --project blah | grep -F "${bucketName}" || false
-  [ "$(lxc_remote storage bucket list "${remote}:s3" --all-projects -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote storage bucket list "${remote}:s3" --all-projects -f csv)" = "" ]
 
   # Grant view permission on storage buckets in project default to members of test-group
   lxc auth group permission add test-group project default can_view_storage_buckets

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -127,12 +127,12 @@ test_basic_usage() {
   # Check volatile.apply_template is altered during rename.
   lxc config get bar volatile.apply_template | grep rename
 
-  lxc list | grep -v foo
-  lxc list | grep bar
+  [ "$(lxc list | grep -F foo)" = "" ]
+  [ "$(lxc list | grep -F bar)" != "" ]
 
   lxc rename bar foo
-  lxc list | grep -v bar
-  lxc list | grep foo
+  [ "$(lxc list | grep -F bar)" = "" ]
+  [ "$(lxc list | grep -F foo)" != "" ]
   lxc rename foo bar
 
   # Test container copy

--- a/test/suites/container_devices_infiniband_physical.sh
+++ b/test/suites/container_devices_infiniband_physical.sh
@@ -80,7 +80,7 @@ test_container_devices_infiniband_physical() {
   fi
 
   # Check volatile cleanup on stop.
-  if lxc config show "${ctName}" | grep volatile.eth0 | grep -v volatile.eth0.name ; then
+  if [ "$(lxc config show "${ctName}" | grep -F volatile.eth0 | grep -vF volatile.eth0.name)" != "" ]; then
     echo "unexpected volatile key remains"
     false
   fi

--- a/test/suites/container_devices_infiniband_sriov.sh
+++ b/test/suites/container_devices_infiniband_sriov.sh
@@ -90,7 +90,7 @@ test_container_devices_infiniband_sriov() {
   fi
 
   # Check volatile cleanup on stop.
-  if lxc config show "${ctName}" | grep volatile.eth0 | grep -v volatile.eth0.name ; then
+  if [ "$(lxc config show "${ctName}" | grep -F volatile.eth0 | grep -vF volatile.eth0.name)" != "" ]; then
     echo "unexpected volatile key remains"
     false
   fi

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -549,7 +549,7 @@ test_container_devices_nic_bridged_filtering() {
   fi
 
   # Check volatile cleanup on stop.
-  if lxc config show "${ctPrefix}A" | grep volatile.eth0 | grep -v volatile.eth0.hwaddr ; then
+  if [ "$(lxc config show "${ctPrefix}A" | grep -F volatile.eth0 | grep -vF volatile.eth0.hwaddr)" != "" ]; then
     echo "unexpected volatile key remains"
     false
   fi

--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -65,7 +65,7 @@ test_container_devices_nic_macvlan() {
 
   echo "==> Check volatile cleanup on stop."
   lxc stop -f "${ctName}"
-  if lxc config show "${ctName}" | grep volatile.eth0 | grep -v volatile.eth0.hwaddr ; then
+  if [ "$(lxc config show "${ctName}" | grep -F volatile.eth0 | grep -vF volatile.eth0.hwaddr)" != "" ]; then
     echo "unexpected volatile key remains"
     false
   fi

--- a/test/suites/container_devices_nic_sriov.sh
+++ b/test/suites/container_devices_nic_sriov.sh
@@ -77,7 +77,7 @@ test_container_devices_nic_sriov() {
 
   # Check volatile cleanup on stop.
   lxc stop -f "${ctName}"
-  if lxc config show "${ctName}" | grep volatile.eth0 | grep -v volatile.eth0.hwaddr | grep -v volatile.eth0.name ; then
+  if [ "$(lxc config show "${ctName}" | grep -F volatile.eth0 | grep -vF volatile.eth0.hwaddr | grep -vF volatile.eth0.name)" != "" ]; then
     echo "unexpected volatile key remains"
     false
   fi

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -198,8 +198,8 @@ migration() {
   lxc storage volume set "${pool}" container/cccp user.foo=postsnap1
 
   # Check storage volume creation times are set.
-  lxc query /1.0/storage-pools/"${pool}"/volumes/container/cccp | jq .created_at | grep -Fv '0001-01-01T00:00:00Z'
-  lxc query /1.0/storage-pools/"${pool}"/volumes/container/cccp/snapshots/snap0 | jq .created_at | grep -Fv '0001-01-01T00:00:00Z'
+  [ "$(lxc query /1.0/storage-pools/"${pool}"/volumes/container/cccp | jq -r .created_at)" != "0001-01-01T00:00:00Z" ]
+  [ "$(lxc query /1.0/storage-pools/"${pool}"/volumes/container/cccp/snapshots/snap0 | jq -r .created_at)" != "0001-01-01T00:00:00Z" ]
 
   # Local container only copy.
   lxc copy cccp udssr --instance-only

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -11,7 +11,7 @@ test_server_config() {
 
 _server_config_access() {
   # test untrusted server GET
-  my_curl -X GET "https://$(cat "${LXD_SERVERCONFIG_DIR}/lxd.addr")/1.0" | grep -v -q environment
+  ! my_curl -X GET "https://$(cat "${LXD_SERVERCONFIG_DIR}/lxd.addr")/1.0" | grep -wF "environment" || false
 
   # test authentication type, only tls is enabled by default
   [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq -r '.metadata.auth_methods | .[]')" = "tls" ]

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -13,11 +13,8 @@ _server_config_access() {
   # test untrusted server GET
   my_curl -X GET "https://$(cat "${LXD_SERVERCONFIG_DIR}/lxd.addr")/1.0" | grep -v -q environment
 
-  # test authentication type
-  curl --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq .metadata.auth_methods | grep tls
-
-  # only tls is enabled by default
-  ! curl --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq .metadata.auth_methods | grep oidc || false
+  # test authentication type, only tls is enabled by default
+  [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq -r '.metadata.auth_methods | .[]')" = "tls" ]
 }
 
 _server_config_storage() {

--- a/test/suites/waitready.sh
+++ b/test/suites/waitready.sh
@@ -38,8 +38,8 @@ test_waitready() {
   lxd waitready
 
   # The CLI reports the network and storage pool to be unavailable.
-  lxc network show "${br_name}" | grep -q "status: Unavailable"
-  lxc storage show "${storage_pool}" | grep -q "status: Unavailable"
+  lxc network show "${br_name}" | grep -xF "status: Unavailable"
+  lxc storage show "${storage_pool}" | grep -xF "status: Unavailable"
 
   echo "==> Restore the network by unsetting the external interface"
   lxd sql global 'DELETE FROM networks_config WHERE key="bridge.external_interfaces"'
@@ -57,8 +57,8 @@ test_waitready() {
   lxd waitready
 
   # The CLI reports only the storage pool to be unavailable.
-  lxc network show "${br_name}" | grep -q "status: Created"
-  lxc storage show "${storage_pool}" | grep -q "status: Unavailable"
+  lxc network show "${br_name}" | grep -xF "status: Created"
+  lxc storage show "${storage_pool}" | grep -xF "status: Unavailable"
 
   echo "==> Restore the storage pool directory"
   rm "${LXD_DIR}/storage-pools/${storage_pool}"
@@ -73,8 +73,8 @@ test_waitready() {
   lxd waitready
 
   # The CLI reports both network and storage pool to be created.
-  lxc network show "${br_name}" | grep -q "status: Created"
-  lxc storage show "${storage_pool}" | grep -q "status: Created"
+  lxc network show "${br_name}" | grep -xF "status: Created"
+  lxc storage show "${storage_pool}" | grep -xF "status: Created"
 
   # Cleanup.
   lxc storage delete "${storage_pool}"


### PR DESCRIPTION
Also, updated a few places using `[ "$(... | wc -l)" = 0 ]` to directly check for no output `[ "$(...)" = "" ]` instead.