### PR TITLE
Device: Add thread pool option for VM filesystem `disk` shares using `virtiofsd`

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2672,3 +2672,7 @@ This adds support for listing networks across all projects using the `all-projec
 ## `clustering_restore_skip_mode`
 
 Adds a `skip` mode to the restore request. This mode restores a cluster member's status to `ONLINE` without restarting any of its stopped local instances or migrating back instances that were evacuated to other cluster members.
+
+## `disk_io_threads_virtiofsd`
+
+Adds the {config:option}`device-disk-device-conf:io.threads` option on `disk` devices which is used to control the `virtiofsd` thread pool size when sharing file systems into VMs. This can help improve I/O performance.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -68,6 +68,16 @@ Possible values are `virtio-scsi`, `virtio-blk` or `nvme`.
 Possible values are `none`, `writeback`, or `unsafe`.
 ```
 
+```{config:option} io.threads device-disk-device-conf
+:condition: "virtual machine"
+:defaultdesc: "`0`"
+:required: "no"
+:shortdesc: "Thread pool for virtiofs file system shares"
+:type: "integer"
+This option controls the `virtiofsd` thread pool size, which can help improve I/O performance. Only applies to virtiofs file system shares.
+Can only be used in a {config:option}`project-restricted:restricted` project when {config:option}`project-restricted:restricted.virtual-machines.lowlevel` is set to `allow`.
+```
+
 ```{config:option} limits.max device-disk-device-conf
 :required: "no"
 :shortdesc: "I/O limit in byte/s or IOPS for both read and write"

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -42,8 +42,8 @@ should also be installed.
 
 ## QEMU
 
-For virtual machines, QEMU 6.2 or higher is required. Some features like
-Confidential Guest support require a more recent QEMU and kernel version.
+For virtual machines, QEMU 6.2 or higher and `virtiofsd` 1.10.0 or higher are required.
+Some features like Confidential Guest support require a more recent QEMU and kernel version.
 
 Hardware-assisted virtualization (Intel VT-x, AMD-V, etc) is required for
 running virtual machines. Additional hardware support (Intel VT-d, AMD-Vi) may

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -450,8 +450,7 @@ func DiskVMVirtiofsdStart(kernelVersion version.DottedVersion, inst instance.Ins
 	args := []string{
 		"--fd=3",
 		"--shared-dir", sharePath,
-		// use -o flags for support in wider versions of virtiofsd.
-		"-o", "xattr",
+		"--xattr",
 	}
 
 	// Virtiofsd defaults to namespace sandbox mode which requires pidfd_open support.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -451,6 +451,7 @@ func DiskVMVirtiofsdStart(kernelVersion version.DottedVersion, inst instance.Ins
 		"--fd=3",
 		"--shared-dir", sharePath,
 		"--cache", "auto", // "never" and "metadata" modes do not allow execution at this time.
+		"--allow-direct-io",
 		"--xattr",
 	}
 

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -449,9 +449,9 @@ func DiskVMVirtiofsdStart(kernelVersion version.DottedVersion, inst instance.Ins
 	// Start the virtiofsd process in non-daemon mode.
 	args := []string{
 		"--fd=3",
+		"--shared-dir", sharePath,
 		// use -o flags for support in wider versions of virtiofsd.
 		"-o", "xattr",
-		"-o", "source=" + sharePath,
 	}
 
 	// Virtiofsd defaults to namespace sandbox mode which requires pidfd_open support.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -450,6 +450,7 @@ func DiskVMVirtiofsdStart(kernelVersion version.DottedVersion, inst instance.Ins
 	args := []string{
 		"--fd=3",
 		"--shared-dir", sharePath,
+		"--cache", "auto", // "never" and "metadata" modes do not allow execution at this time.
 		"--xattr",
 	}
 

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -369,7 +370,7 @@ func DiskVMVirtfsProxyStop(pidPath string) error {
 // Returns UnsupportedError error if the host system or instance does not support virtiosfd, returns normal error
 // type if process cannot be started for other reasons.
 // Returns revert function and listener file handle on success.
-func DiskVMVirtiofsdStart(kernelVersion version.DottedVersion, inst instance.Instance, socketPath string, pidPath string, logPath string, sharePath string, idmaps []idmap.IdmapEntry) (func(), net.Listener, error) {
+func DiskVMVirtiofsdStart(kernelVersion version.DottedVersion, inst instance.Instance, socketPath string, pidPath string, logPath string, sharePath string, idmaps []idmap.IdmapEntry, threadPoolSize uint16) (func(), net.Listener, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -452,6 +453,7 @@ func DiskVMVirtiofsdStart(kernelVersion version.DottedVersion, inst instance.Ins
 		"--shared-dir", sharePath,
 		"--cache", "auto", // "never" and "metadata" modes do not allow execution at this time.
 		"--allow-direct-io",
+		"--thread-pool-size", strconv.FormatUint(uint64(threadPoolSize), 10),
 		"--xattr",
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1398,7 +1398,7 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 	// This is used by the lxd-agent in preference to 9p (due to its improved performance) and in scenarios
 	// where 9p isn't available in the VM guest OS.
 	configSockPath, configPIDPath := d.configVirtiofsdPaths()
-	revertFunc, unixListener, err := device.DiskVMVirtiofsdStart(d.state.OS.KernelVersion, d, configSockPath, configPIDPath, "", configMntPath, nil)
+	revertFunc, unixListener, err := device.DiskVMVirtiofsdStart(d.state.OS.KernelVersion, d, configSockPath, configPIDPath, "", configMntPath, nil, 0)
 	if err != nil {
 		var errUnsupported device.UnsupportedError
 		if !errors.As(err, &errUnsupported) {

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -80,6 +80,16 @@
 						}
 					},
 					{
+						"io.threads": {
+							"condition": "virtual machine",
+							"defaultdesc": "`0`",
+							"longdesc": "This option controls the `virtiofsd` thread pool size, which can help improve I/O performance. Only applies to virtiofs file system shares.\nCan only be used in a {config:option}`project-restricted:restricted` project when {config:option}`project-restricted:restricted.virtual-machines.lowlevel` is set to `allow`.",
+							"required": "no",
+							"shortdesc": "Thread pool for virtiofs file system shares",
+							"type": "integer"
+						}
+					},
+					{
 						"limits.max": {
 							"longdesc": "This option is the same as setting both {config:option}`device-disk-device-conf:limits.read` and {config:option}`device-disk-device-conf:limits.write`.\n\nYou can specify a value in byte/s (various suffixes supported, see {ref}`instances-limit-units`) or in IOPS (must be suffixed with `iops`).\nSee also {ref}`storage-configure-io`.\n",
 							"required": "no",

--- a/lxd/project/limits/permissions.go
+++ b/lxd/project/limits/permissions.go
@@ -492,7 +492,7 @@ func parseHostIDMapRange(isUID bool, isGID bool, listValue string) ([]idmap.Idma
 // instances and profiles.
 func checkInstanceRestrictions(proj api.Project, instances []api.Instance, profiles []api.Profile) error {
 	containerConfigChecks := map[string]func(value string) error{}
-	devicesChecks := map[string]func(value map[string]string) error{}
+	devicesChecks := map[string][]func(value map[string]string) error{}
 
 	allowContainerLowLevel := false
 	allowVMLowLevel := false
@@ -558,79 +558,79 @@ func checkInstanceRestrictions(proj api.Project, instances []api.Instance, profi
 			}
 
 		case "restricted.devices.unix-char":
-			devicesChecks["unix-char"] = func(device map[string]string) error {
+			devicesChecks["unix-char"] = append(devicesChecks["unix-char"], func(device map[string]string) error {
 				if restrictionValue != "allow" {
 					return errors.New("Unix character devices are forbidden")
 				}
 
 				return nil
-			}
+			})
 
 		case "restricted.devices.unix-block":
-			devicesChecks["unix-block"] = func(device map[string]string) error {
+			devicesChecks["unix-block"] = append(devicesChecks["unix-block"], func(device map[string]string) error {
 				if restrictionValue != "allow" {
 					return errors.New("Unix block devices are forbidden")
 				}
 
 				return nil
-			}
+			})
 
 		case "restricted.devices.unix-hotplug":
-			devicesChecks["unix-hotplug"] = func(device map[string]string) error {
+			devicesChecks["unix-hotplug"] = append(devicesChecks["unix-hotplug"], func(device map[string]string) error {
 				if restrictionValue != "allow" {
 					return errors.New("Unix hotplug devices are forbidden")
 				}
 
 				return nil
-			}
+			})
 
 		case "restricted.devices.infiniband":
-			devicesChecks["infiniband"] = func(device map[string]string) error {
+			devicesChecks["infiniband"] = append(devicesChecks["infiniband"], func(device map[string]string) error {
 				if restrictionValue != "allow" {
 					return errors.New("Infiniband devices are forbidden")
 				}
 
 				return nil
-			}
+			})
 
 		case "restricted.devices.gpu":
-			devicesChecks["gpu"] = func(device map[string]string) error {
+			devicesChecks["gpu"] = append(devicesChecks["gpu"], func(device map[string]string) error {
 				if restrictionValue != "allow" {
 					return errors.New("GPU devices are forbidden")
 				}
 
 				return nil
-			}
+			})
 
 		case "restricted.devices.usb":
-			devicesChecks["usb"] = func(device map[string]string) error {
+			devicesChecks["usb"] = append(devicesChecks["usb"], func(device map[string]string) error {
 				if restrictionValue != "allow" {
 					return errors.New("USB devices are forbidden")
 				}
 
 				return nil
-			}
+			})
 
 		case "restricted.devices.pci":
-			devicesChecks["pci"] = func(device map[string]string) error {
+			devicesChecks["pci"] = append(devicesChecks["pci"], func(device map[string]string) error {
 				if restrictionValue != "allow" {
 					return errors.New("PCI devices are forbidden")
 				}
 
 				return nil
-			}
+			})
 
 		case "restricted.devices.proxy":
-			devicesChecks["proxy"] = func(device map[string]string) error {
+			devicesChecks["proxy"] = append(devicesChecks["proxy"], func(device map[string]string) error {
 				if restrictionValue != "allow" {
 					return errors.New("Proxy devices are forbidden")
 				}
 
 				return nil
-			}
+			})
 
 		case "restricted.devices.nic":
-			devicesChecks["nic"] = func(device map[string]string) error {
+			devicesChecks["nic"] = append(devicesChecks["nic"], func(device map[string]string) error {
 				// Check if the NICs are allowed at all.
 				switch restrictionValue {
 				case "block":
@@ -654,10 +654,10 @@ func checkInstanceRestrictions(proj api.Project, instances []api.Instance, profi
 				}
 
 				return nil
-			}
+			})
 
 		case "restricted.devices.disk":
-			devicesChecks["disk"] = func(device map[string]string) error {
+			devicesChecks["disk"] = append(devicesChecks["disk"], func(device map[string]string) error {
 				// The root device is always allowed.
 				if device["path"] == "/" && device["pool"] != "" {
 					return nil
@@ -686,7 +686,7 @@ func checkInstanceRestrictions(proj api.Project, instances []api.Instance, profi
 				}
 
 				return nil
-			}
+			})
 
 		case "restricted.idmap.uid":
 			var err error
@@ -767,16 +767,19 @@ func checkInstanceRestrictions(proj api.Project, instances []api.Instance, profi
 		}
 
 		for name, device := range devices {
-			check, ok := devicesChecks[device["type"]]
+			checks, ok := devicesChecks[device["type"]]
 			if !ok {
 				continue
 			}
 
-			err := check(device)
-			if err != nil {
-				return fmt.Errorf("Invalid device %q on %s %q of project %q: %w", name, entityTypeLabel, entityName, proj.Name, err)
+			for _, check := range checks {
+				err := check(device)
+				if err != nil {
+					return fmt.Errorf("Invalid device %q on %s %q of project %q: %w", name, entityTypeLabel, entityName, proj.Name, err)
+				}
 			}
 		}
+
 		return nil
 	}
 

--- a/lxd/project/limits/permissions.go
+++ b/lxd/project/limits/permissions.go
@@ -557,6 +557,16 @@ func checkInstanceRestrictions(proj api.Project, instances []api.Instance, profi
 				allowVMLowLevel = true
 			}
 
+			// Add check for valid usage of io.threads setting.
+			devicesChecks["disk"] = append(devicesChecks["disk"], func(device map[string]string) error {
+				_, ioThreadsUsed := device["io.threads"]
+				if ioThreadsUsed && !allowVMLowLevel {
+					return errors.New(`Use of low-level "io.threads" disk option forbidden`)
+				}
+
+				return nil
+			})
+
 		case "restricted.devices.unix-char":
 			devicesChecks["unix-char"] = append(devicesChecks["unix-char"], func(device map[string]string) error {
 				if restrictionValue != "allow" {

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -74,6 +74,16 @@ func IsUint8(value string) error {
 	return nil
 }
 
+// IsUint16 validates whether the string can be converted to an uint16.
+func IsUint16(value string) error {
+	_, err := strconv.ParseUint(value, 10, 16)
+	if err != nil {
+		return fmt.Errorf("Invalid value for uint16 %q: %w", value, err)
+	}
+
+	return nil
+}
+
 // IsUint32 validates whether the string can be converted to an uint32.
 func IsUint32(value string) error {
 	_, err := strconv.ParseUint(value, 10, 32)

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -450,6 +450,7 @@ var APIExtensions = []string{
 	"network_acls_all_projects",
 	"networks_all_projects",
 	"clustering_restore_skip_mode",
+	"disk_io_threads_virtiofsd",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
- Switches to modern flags provided by Rust implementation of `virtiofsd`, in the process fixes https://github.com/canonical/lxd/issues/15248
- Enables direct I/O passthrough from guest when using virtiofs (for correctness when an application specifies to open a file with direct I/O rather than silently converting that to a non-direct operation).
- Adds `io.threads` option for filesystem `disk` devices when being passed to the VM as `virtiofsd` based shares - this can improve performance. Fixes https://github.com/canonical/lxd/issues/15742
- Restricts use of this new `io.threads` option in restricted projects unless `restricted.virtual-machines.lowlevel` is set to `allow` to prevent restricted VMs from setting a high thread pool count and consuming extra host resources.
- Adds `disk_io_threads_virtiofsd` API extension.