### PR TITLE
lxd/instance/qemu: Fix shared storage volume setup during instance migration (from Incus)

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6927,6 +6927,11 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 			diskPools[poolName] = diskPool
 		}
 
+		// Check that we're on shared storage.
+		if !diskPool.Driver().Info().Remote {
+			continue
+		}
+
 		// Setup the volume entry.
 		extraSourceArgs := &migration.VolumeSourceArgs{
 			ClusterMove: true,
@@ -7448,6 +7453,11 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 				// Save it to the pools map to avoid loading it from the DB multiple times.
 				diskPools[poolName] = diskPool
+			}
+
+			// Check that we're on shared storage.
+			if !diskPool.Driver().Info().Remote {
+				continue
 			}
 
 			// Setup the volume entry.


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/15358.

Includes cherry-pick from https://github.com/lxc/incus/pull/1669.   

Previously `MigrateReceive()` function would incorrectly try calling `CreateVolumeFromMigration()` for attached local volumes during instance migration and fail with "not supported" error. This change fixes the issue. Now, `CreateVolumeFromMigration()` is called only for shared storage volumes in order to notify the shared storage driver to setup the volume on the receiving cluster member.