### PR TITLE
test/suites/basic: check `--version` and `--help` for all binaries

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -366,6 +366,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_authorization "Authorization"
     run_test test_certificate_edit "Certificate edit"
     run_test test_basic_usage "basic usage"
+    run_test test_basic_version "basic version"
     run_test test_server_info "server info"
     run_test test_remote_url "remote url handling"
     run_test test_remote_url_with_token "remote token handling"

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -745,6 +745,14 @@ EOF
   [ -z "${remaining_instances}" ]
 }
 
+test_basic_version() {
+  # XXX: add `fuidshift` to the list
+  for bin in lxc lxd lxd-agent lxd-benchmark lxd-migrate lxd-user; do
+    "${bin}" --version
+    "${bin}" --help
+  done
+}
+
 test_server_info() {
   # Ensure server always reports support for containers.
   lxc query /1.0 | jq -e '.environment.instance_types | contains(["container"])'

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -611,7 +611,7 @@ test_basic_usage() {
   lxc delete --force c1 c2
 
   # Ephemeral
-  lxc launch testimage foo -e
+  lxc launch testimage foo --ephemeral
   OLD_INIT=$(lxc info foo | awk '/^PID:/ {print $2}')
 
   REBOOTED="false"

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -734,13 +734,13 @@ EOF
   lxc profile delete foo
 
   # Multiple ephemeral instances delete
-  lxc launch testimage c1
-  lxc launch testimage c2
-  lxc launch testimage c3
+  lxc launch testimage c1 --ephemeral
+  lxc launch testimage c2 --ephemeral
+  lxc launch testimage c3 --ephemeral
 
   fingerprint="$(lxc config trust ls --format csv | cut -d, -f4)"
   lxc config trust remove "${fingerprint}"
-  lxc delete -f c1 c2 c3
+  lxc stop -f c1 c2 c3
   [ "$(lxc list -c n)" = "" ]
 }
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -738,10 +738,12 @@ EOF
   lxc launch testimage c2 --ephemeral
   lxc launch testimage c3 --ephemeral
 
-  fingerprint="$(lxc config trust ls --format csv | cut -d, -f4)"
-  lxc config trust remove "${fingerprint}"
   lxc stop -f c1 c2 c3
   [ "$(lxc list -f csv -c n)" = "" ]
+
+  # Cleanup
+  fingerprint="$(lxc config trust ls --format csv | cut -d, -f4)"
+  lxc config trust remove "${fingerprint}"
 }
 
 test_basic_version() {

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -741,7 +741,7 @@ EOF
   fingerprint="$(lxc config trust ls --format csv | cut -d, -f4)"
   lxc config trust remove "${fingerprint}"
   lxc stop -f c1 c2 c3
-  [ "$(lxc list -c n)" = "" ]
+  [ "$(lxc list -f csv -c n)" = "" ]
 }
 
 test_basic_version() {

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -741,8 +741,7 @@ EOF
   fingerprint="$(lxc config trust ls --format csv | cut -d, -f4)"
   lxc config trust remove "${fingerprint}"
   lxc delete -f c1 c2 c3
-  remaining_instances="$(lxc list --format csv)"
-  [ -z "${remaining_instances}" ]
+  [ "$(lxc list -c n)" = "" ]
 }
 
 test_basic_version() {


### PR DESCRIPTION
The first commit also ensures that `LXD_TMPFS` reaches the system-tests env.
The rest of the PR does minor tweaks to the `basic_usage` test and add a `basic_version` one which mostly aims at providing minimal code coverage for TiCS.