### PR TITLE
doc: add vGPU acronym for virtual GPU

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -333,6 +333,8 @@ userspace
 UUIDs
 vCPU
 vCPUs
+vGPU
+vGPUs
 VDPA
 VFS
 VFs

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1418,7 +1418,7 @@ send/receive on top of that.
 
 ## `gpu_mdev`
 
-This adds support for virtual GPUs. It introduces the {config:option}`device-gpu-mdev-device-conf:mdev` configuration key for GPU devices which takes
+This adds support for virtual GPUs (vGPUs). It introduces the {config:option}`device-gpu-mdev-device-conf:mdev` configuration key for GPU devices which takes
 a supported `mdev` type, e.g. `i915-GVTg_V5_4`.
 
 ## `resources_pci_iommu`

--- a/doc/reference/devices_gpu.md
+++ b/doc/reference/devices_gpu.md
@@ -15,7 +15,7 @@ The following types of GPUs can be added using the `gputype` device option:
 
 - [`physical`](gpu-physical) (container and VM): Passes an entire GPU through into the instance.
   This value is the default if `gputype` is unspecified.
-- [`mdev`](gpu-mdev) (VM only): Creates and passes a virtual GPU through into the instance.
+- [`mdev`](gpu-mdev) (VM only): Creates and passes a virtual GPU (vGPU) through into the instance.
 - [`mig`](gpu-mig) (container only): Creates and passes a MIG (Multi-Instance GPU) through into the instance.
 - [`sriov`](gpu-sriov) (VM only): Passes a virtual function of an SR-IOV-enabled GPU into the instance.
 
@@ -81,7 +81,7 @@ The `mdev` GPU type is supported only for VMs.
 It does not support hotplugging.
 ```
 
-An `mdev` GPU device creates and passes a virtual GPU through into the instance.
+An `mdev` GPU device creates and passes a virtual GPU (vGPU) through into the instance.
 You can check the list of available `mdev` profiles by running [`lxc info --resources`](lxc_info.md).
 
 ### Device options


### PR DESCRIPTION
Per request from FE, mention `vGPU` where `virtual GPU` is mentioned so that references can be found through searching for `vGPU`. 