### PR TITLE
doc: css to hide rtd versions flyout when printing

### DIFF
--- a/doc/.sphinx/_static/custom.css
+++ b/doc/.sphinx/_static/custom.css
@@ -397,7 +397,13 @@ p code.literal {
 }
 
 /* Headings and section links in the configuration option index */
-
 .domainindex-table .cap, .domainindex-jumpbox {
     text-transform: uppercase;
+}
+
+/* Hide RTD flyout when printing */
+@media print {
+    readthedocs-flyout {
+        display: none;
+    }
 }


### PR DESCRIPTION
Adds CSS to hide the ReadTheDocs flyout at bottom right of page when printing only. 
Closes https://github.com/canonical/lxd/issues/15795