### PR TITLE
Refactor UnixSocket function (from Incus)

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -621,7 +621,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		// As ServerAddress field is required to be set it means that we're using the new join API
 		// introduced with the 'clustering_join' extension.
 		// Connect to ourselves to initialize storage pools and networks using the API.
-		localClient, err := lxd.ConnectLXDUnix(d.GetUnixSocket(), &lxd.ConnectionArgs{UserAgent: clusterRequest.UserAgentJoiner})
+		localClient, err := lxd.ConnectLXDUnix(d.os.GetUnixSocket(), &lxd.ConnectionArgs{UserAgent: clusterRequest.UserAgentJoiner})
 		if err != nil {
 			return fmt.Errorf("Failed to connect to local LXD: %w", err)
 		}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -621,7 +621,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		// As ServerAddress field is required to be set it means that we're using the new join API
 		// introduced with the 'clustering_join' extension.
 		// Connect to ourselves to initialize storage pools and networks using the API.
-		localClient, err := lxd.ConnectLXDUnix(d.UnixSocket(), &lxd.ConnectionArgs{UserAgent: clusterRequest.UserAgentJoiner})
+		localClient, err := lxd.ConnectLXDUnix(d.GetUnixSocket(), &lxd.ConnectionArgs{UserAgent: clusterRequest.UserAgentJoiner})
 		if err != nil {
 			return fmt.Errorf("Failed to connect to local LXD: %w", err)
 		}

--- a/lxd/api_cluster_test.go
+++ b/lxd/api_cluster_test.go
@@ -44,7 +44,7 @@ func TestCluster_Get(t *testing.T) {
 	daemon, cleanup := newTestDaemon(t)
 	defer cleanup()
 
-	client, err := lxd.ConnectLXDUnix(daemon.GetUnixSocket(), nil)
+	client, err := lxd.ConnectLXDUnix(daemon.os.GetUnixSocket(), nil)
 	require.NoError(t, err)
 
 	cluster, _, err := client.GetCluster()
@@ -130,7 +130,7 @@ func (f *clusterFixture) ClientUnix(daemon *Daemon) lxd.InstanceServer {
 	client, ok := f.clients[daemon]
 	if !ok {
 		var err error
-		client, err = lxd.ConnectLXDUnix(daemon.GetUnixSocket(), nil)
+		client, err = lxd.ConnectLXDUnix(daemon.os.GetUnixSocket(), nil)
 		require.NoError(f.t, err)
 	}
 

--- a/lxd/api_cluster_test.go
+++ b/lxd/api_cluster_test.go
@@ -44,7 +44,7 @@ func TestCluster_Get(t *testing.T) {
 	daemon, cleanup := newTestDaemon(t)
 	defer cleanup()
 
-	client, err := lxd.ConnectLXDUnix(daemon.UnixSocket(), nil)
+	client, err := lxd.ConnectLXDUnix(daemon.GetUnixSocket(), nil)
 	require.NoError(t, err)
 
 	cluster, _, err := client.GetCluster()
@@ -130,7 +130,7 @@ func (f *clusterFixture) ClientUnix(daemon *Daemon) lxd.InstanceServer {
 	client, ok := f.clients[daemon]
 	if !ok {
 		var err error
-		client, err = lxd.ConnectLXDUnix(daemon.UnixSocket(), nil)
+		client, err = lxd.ConnectLXDUnix(daemon.GetUnixSocket(), nil)
 		require.NoError(f.t, err)
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -752,17 +752,6 @@ func (d *Daemon) State() *state.State {
 	return s
 }
 
-// GetUnixSocket returns the full path to the unix.socket file that this daemon is
-// listening on. Used by tests.
-func (d *Daemon) GetUnixSocket() string {
-	path := os.Getenv("LXD_SOCKET")
-	if path != "" {
-		return path
-	}
-
-	return filepath.Join(d.os.VarDir, "unix.socket")
-}
-
 // createCmd creates API handlers for the provided endpoint including some useful behavior,
 // such as appropriate authentication, authorization and checking server availability.
 //
@@ -1106,7 +1095,7 @@ func (d *Daemon) init() error {
 	d.internalListener = events.NewInternalListener(d.shutdownCtx, d.events)
 
 	// Lets check if there's an existing LXD running
-	err = endpoints.CheckAlreadyRunning(d.GetUnixSocket())
+	err = endpoints.CheckAlreadyRunning(d.os.GetUnixSocket())
 	if err != nil {
 		return err
 	}
@@ -1448,7 +1437,7 @@ func (d *Daemon) init() error {
 	/* Setup the web server */
 	config := &endpoints.Config{
 		Dir:                  d.os.VarDir,
-		UnixSocket:           d.GetUnixSocket(),
+		UnixSocket:           d.os.GetUnixSocket(),
 		Cert:                 networkCert,
 		RestServer:           restServer(d),
 		DevLxdServer:         devLXDServer(d),

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -752,9 +752,9 @@ func (d *Daemon) State() *state.State {
 	return s
 }
 
-// UnixSocket returns the full path to the unix.socket file that this daemon is
+// GetUnixSocket returns the full path to the unix.socket file that this daemon is
 // listening on. Used by tests.
-func (d *Daemon) UnixSocket() string {
+func (d *Daemon) GetUnixSocket() string {
 	path := os.Getenv("LXD_SOCKET")
 	if path != "" {
 		return path
@@ -1106,7 +1106,7 @@ func (d *Daemon) init() error {
 	d.internalListener = events.NewInternalListener(d.shutdownCtx, d.events)
 
 	// Lets check if there's an existing LXD running
-	err = endpoints.CheckAlreadyRunning(d.UnixSocket())
+	err = endpoints.CheckAlreadyRunning(d.GetUnixSocket())
 	if err != nil {
 		return err
 	}
@@ -1448,7 +1448,7 @@ func (d *Daemon) init() error {
 	/* Setup the web server */
 	config := &endpoints.Config{
 		Dir:                  d.os.VarDir,
-		UnixSocket:           d.UnixSocket(),
+		UnixSocket:           d.GetUnixSocket(),
 		Cert:                 networkCert,
 		RestServer:           restServer(d),
 		DevLxdServer:         devLXDServer(d),

--- a/lxd/daemon_integration_test.go
+++ b/lxd/daemon_integration_test.go
@@ -17,7 +17,7 @@ import (
 func TestIntegration_UnixSocket(t *testing.T) {
 	daemon, cleanup := newTestDaemon(t)
 	defer cleanup()
-	client, err := lxd.ConnectLXDUnix(daemon.GetUnixSocket(), nil)
+	client, err := lxd.ConnectLXDUnix(daemon.os.GetUnixSocket(), nil)
 	require.NoError(t, err)
 
 	server, _, err := client.GetServer()

--- a/lxd/daemon_integration_test.go
+++ b/lxd/daemon_integration_test.go
@@ -17,7 +17,7 @@ import (
 func TestIntegration_UnixSocket(t *testing.T) {
 	daemon, cleanup := newTestDaemon(t)
 	defer cleanup()
-	client, err := lxd.ConnectLXDUnix(daemon.UnixSocket(), nil)
+	client, err := lxd.ConnectLXDUnix(daemon.GetUnixSocket(), nil)
 	require.NoError(t, err)
 
 	server, _, err := client.GetServer()

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -249,3 +249,13 @@ func (s *OS) InUbuntuCore() bool {
 
 	return false
 }
+
+// GetUnixSocket returns the full path to the unix.socket file that this daemon is listening on. Used by tests.
+func (s *OS) GetUnixSocket() string {
+	path := os.Getenv("LXD_SOCKET")
+	if path != "" {
+		return path
+	}
+
+	return filepath.Join(s.VarDir, "unix.socket")
+}


### PR DESCRIPTION
Cherry-picked from https://github.com/lxc/incus/pull/727.

This moves `UnixSocket` to the `sys` package and renames it to `GetUnixSocket`. This allows us to call it on `daemon.os` and `state.OS`.