### PR TITLE
doc: rename variable used by sitemap per conflict

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -805,6 +805,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # A non-shallow clone is needed for the sitemap generation
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -34,6 +34,7 @@ author = 'LXD contributors'
 # To not display any title, set this option to an empty string.
 html_title = ''
 
+# Set global version variable used in objects.inv to numeric version defined in flex.go
 with open("../shared/version/flex.go") as fd:
     version = fd.readlines()[3].split()[-1].strip("\"")
 
@@ -141,15 +142,13 @@ slug = "lxd"
 
 html_baseurl = 'https://documentation.ubuntu.com/lxd/'
 
-# URL scheme. Add language and version scheme elements.
-# When configured with RTD variables, check for RTD environment so manual runs succeed:
-
+# Configures URL scheme for sphinx-sitemap to generate correct URLs
+# based on the version if built in RTD
 if 'READTHEDOCS_VERSION' in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = '{version}{link}'
+    rtd_version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = f'{rtd_version}/{{link}}'
 else:
     sitemap_url_scheme = '{link}'
-
 
 ############################################################
 ### Redirects


### PR DESCRIPTION
In custom_conf.py, this renames the version variable (added in https://github.com/canonical/lxd/pull/15828 while adding sitemap functionality) to rtd_version. This removes a conflict with a version variable that's used when creating Sphinx's inventory of files in objects.inv.

Also updates tests.yml to use a `fetch-depth=0` for documentation job as sphinx-sitemap otherwise produces 'git clone too shallow' errors.