### PR TITLE
shared: Add context to `GetRemoteCertificate`

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -223,7 +224,7 @@ func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token stri
 
 	_, err = conf.GetInstanceServer(server)
 	if err != nil {
-		certificate, err = shared.GetRemoteCertificate(addr, c.global.conf.UserAgent)
+		certificate, err = shared.GetRemoteCertificate(context.Background(), addr, c.global.conf.UserAgent)
 		if err != nil {
 			return api.StatusErrorf(http.StatusServiceUnavailable, "%s: %w", i18n.G("Unavailable remote server"), err)
 		}
@@ -509,7 +510,7 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 	var certificate *x509.Certificate
 	if err != nil {
 		// Failed to connect using the system CA, so retrieve the remote certificate
-		certificate, err = shared.GetRemoteCertificate(addr, c.global.conf.UserAgent)
+		certificate, err = shared.GetRemoteCertificate(context.Background(), addr, c.global.conf.UserAgent)
 		if err != nil {
 			return err
 		}

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -214,7 +214,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 		InsecureSkipVerify: true,
 	}
 
-	certificate, err := shared.GetRemoteCertificate(serverURL, args.UserAgent)
+	certificate, err := shared.GetRemoteCertificate(context.Background(), serverURL, args.UserAgent)
 	if err != nil {
 		return nil, "", fmt.Errorf("Failed to get remote certificate: %w", err)
 	}

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -212,7 +212,7 @@ func (c *cmdMigrate) connectTarget(url string, certPath string, keyPath string, 
 	var certificate *x509.Certificate
 	if err != nil {
 		// Failed to connect using the system CA, so retrieve the remote certificate
-		certificate, err = shared.GetRemoteCertificate(url, args.UserAgent)
+		certificate, err = shared.GetRemoteCertificate(context.Background(), url, args.UserAgent)
 		if err != nil {
 			return nil, "", err
 		}

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -174,7 +175,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 			config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 
 			// Cluster certificate
-			cert, err := shared.GetRemoteCertificate("https://"+config.Cluster.ClusterAddress, version.UserAgent)
+			cert, err := shared.GetRemoteCertificate(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
 			if err != nil {
 				fmt.Printf("Error connecting to existing cluster member %q: %v\n", clusterAddress, err)
 				continue

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -201,7 +201,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, server *api.Server) err
 				config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 
 				// Cluster certificate
-				cert, err := shared.GetRemoteCertificate("https://"+config.Cluster.ClusterAddress, version.UserAgent)
+				cert, err := shared.GetRemoteCertificate(context.Background(), "https://"+config.Cluster.ClusterAddress, version.UserAgent)
 				if err != nil {
 					fmt.Printf("Error connecting to existing cluster member %q: %v\n", clusterAddress, err)
 					continue

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -6,6 +6,7 @@
 package shared
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -472,7 +473,7 @@ func CertFingerprintStr(c string) (string, error) {
 }
 
 // GetRemoteCertificate returns the unverified peer certificate found at a remote address.
-func GetRemoteCertificate(address string, useragent string) (*x509.Certificate, error) {
+func GetRemoteCertificate(ctx context.Context, address string, useragent string) (*x509.Certificate, error) {
 	// Setup a permissive TLS config
 	tlsConfig, err := GetTLSConfig(nil)
 	if err != nil {
@@ -491,7 +492,7 @@ func GetRemoteCertificate(address string, useragent string) (*x509.Certificate, 
 	}
 
 	// Connect
-	req, err := http.NewRequest(http.MethodGet, address, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request adds a context parameter to `GetRemoteCertificate` in preparation for https://github.com/canonical/lxd/pull/14884. When creating and connecting to cluster links, it is necessary to retrieve the remote cluster member's certificates concurrently and verify their fingerprints. Therefore, we should include context when calling `GetRemoteCertificate`.