### PR TITLE
Revert "dependabot: disable schedule to only deal with security updat…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,8 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     labels: []
+    schedule:
+      interval: "weekly"
     security-updates: true
     target-branch: "stable-5.0"
 


### PR DESCRIPTION
…es for 5.0 `gomod`"

The `schedule` field is required:
> The property '#/updates/4' did not contain a required property of 'schedule'

This reverts commit 2fdbe92ebe48bd7ce3d2d96b5c0e41aa2daef52d.