### PR TITLE
lxd: Only run `PostMigrateSend` when migrating instances

### DIFF
--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -156,10 +156,12 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 		return fmt.Errorf("Failed migration on source: %w", err)
 	}
 
-	err = s.instance.PostMigrateSend()
-	if err != nil {
-		l.Error("Failed post-migration steps on source", logger.Ctx{"err": err})
-		return fmt.Errorf("Failed post-migration steps on source: %w", err)
+	if !shared.IsSnapshot(s.instance.Name()) {
+		err = s.instance.PostMigrateSend()
+		if err != nil {
+			l.Error("Failed post-migration steps on source", logger.Ctx{"err": err})
+			return fmt.Errorf("Failed post-migration steps on source: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/canonical/lxd/pull/15552. We only want to run `PostMigrateSend` on instance devices.