### PR TITLE
lxd/instance/drivers: Don't return post-migration errors

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5705,7 +5705,6 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) (err error) {
 			postMigrateSendErr := d.postMigrateSendCommon(d, args.ClusterMoveSourceName)
 			if postMigrateSendErr != nil {
 				d.logger.Error("Post-migration steps failed on source", logger.Ctx{"err": postMigrateSendErr})
-				return postMigrateSendErr
 			}
 		}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6744,7 +6744,6 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) (err error) {
 		err = d.postMigrateSendCommon(d, args.ClusterMoveSourceName)
 		if err != nil {
 			d.logger.Error("Post-migration steps failed on source", logger.Ctx{"err": err})
-			return err
 		}
 
 		return nil


### PR DESCRIPTION
Follow-up to https://github.com/canonical/lxd/pull/15873.