### PR TITLE
VM: Fix `limits.memory` when using % of host memory (from Incus)

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1111,24 +1111,9 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 
 		// Configure the memory limits
 		if memory != "" {
-			var valueInt int64
-			if strings.HasSuffix(memory, "%") {
-				percent, err := strconv.ParseInt(strings.TrimSuffix(memory, "%"), 10, 64)
-				if err != nil {
-					return nil, err
-				}
-
-				memoryTotal, err := shared.DeviceTotalMemory()
-				if err != nil {
-					return nil, err
-				}
-
-				valueInt = int64((memoryTotal / 100) * percent)
-			} else {
-				valueInt, err = units.ParseByteSizeString(memory)
-				if err != nil {
-					return nil, err
-				}
+			valueInt, err := parseMemoryStr(memory)
+			if err != nil {
+				return nil, err
 			}
 
 			if memoryEnforce == "soft" {
@@ -4604,20 +4589,8 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 				// Parse memory
 				if memory == "" {
 					memoryInt = -1
-				} else if strings.HasSuffix(memory, "%") {
-					percent, err := strconv.ParseInt(strings.TrimSuffix(memory, "%"), 10, 64)
-					if err != nil {
-						return err
-					}
-
-					memoryTotal, err := shared.DeviceTotalMemory()
-					if err != nil {
-						return err
-					}
-
-					memoryInt = int64((memoryTotal / 100) * percent)
 				} else {
-					memoryInt, err = units.ParseByteSizeString(memory)
+					memoryInt, err = parseMemoryStr(memory)
 					if err != nil {
 						return err
 					}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5943,7 +5943,7 @@ func (d *qemu) updateMemoryLimit(newLimit string) error {
 	}
 
 	// Check new size string is valid and convert to bytes.
-	newSizeBytes, err := units.ParseByteSizeString(newLimit)
+	newSizeBytes, err := parseMemoryStr(newLimit)
 	if err != nil {
 		return fmt.Errorf("Invalid memory size: %w", err)
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1039,7 +1039,7 @@ func (d *qemu) validateRootDiskStatefulStop() error {
 		memoryLimitStr = d.expandedConfig["limits.memory"]
 	}
 
-	memoryLimit, err := units.ParseByteSizeString(memoryLimitStr)
+	memoryLimit, err := parseMemoryStr(memoryLimitStr)
 	if err != nil {
 		return fmt.Errorf("Failed parsing limits.memory: %w", err)
 	}
@@ -3682,7 +3682,7 @@ func (d *qemu) addCPUMemoryConfig(cfg *[]cfgSection, cpuInfo *cpuTopology) error
 		memSize = QEMUDefaultMemSize // Default if no memory limit specified.
 	}
 
-	memSizeBytes, err := units.ParseByteSizeString(memSize)
+	memSizeBytes, err := parseMemoryStr(memSize)
 	if err != nil {
 		return fmt.Errorf("limits.memory invalid: %w", err)
 	}

--- a/lxd/instance/drivers/util.go
+++ b/lxd/instance/drivers/util.go
@@ -1,0 +1,32 @@
+package drivers
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/units"
+)
+
+// parseMemoryStr parses a human-readable representation of a memory value.
+func parseMemoryStr(memory string) (valueInt int64, err error) {
+	if strings.HasSuffix(memory, "%") {
+		var percent, memoryTotal int64
+
+		percent, err = strconv.ParseInt(strings.TrimSuffix(memory, "%"), 10, 64)
+		if err != nil {
+			return 0, err
+		}
+
+		memoryTotal, err = shared.DeviceTotalMemory()
+		if err != nil {
+			return 0, err
+		}
+
+		valueInt = (memoryTotal / 100) * percent
+	} else {
+		valueInt, err = units.ParseByteSizeString(memory)
+	}
+
+	return valueInt, err
+}

--- a/test/suites/vm.sh
+++ b/test/suites/vm.sh
@@ -24,9 +24,6 @@ test_vm_empty() {
   echo "Too small VMs"
   ! lxc launch --vm --empty v1 -c limits.memory=0 -d "${SMALL_ROOT_DISK}" || false
   ! lxc launch --vm --empty v1 -c limits.memory=0% -d "${SMALL_ROOT_DISK}" || false
-  # VMs don't support limits.memory in % but it's only detect at start time so needs cleanup
-  ! lxc launch --vm --empty v1 -c limits.memory=10% -d "${SMALL_ROOT_DISK}" || false
-  lxc delete v1
 
   echo "Tiny VMs with snapshots"
   lxc init --vm --empty v1 -c limits.memory=128MiB -d "${SMALL_ROOT_DISK}"
@@ -42,7 +39,7 @@ test_vm_empty() {
   [ "$(lxc list -f csv -c S)" = "2" ]
   lxc delete --force v1
 
-  lxc launch --vm --empty v1 -c limits.memory=128MiB -d "${SMALL_ROOT_DISK}"
+  lxc launch --vm --empty v1 -c limits.memory=1% -d "${SMALL_ROOT_DISK}"
   lxc delete --force v1
 
   echo "Ephemeral cleanup"


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/15882.

We should allow setting `limits.memory` to a percentage of host memory to match container `limits.memory` behavior.