### PR TITLE
VM: Informative error message for QEMU version

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8716,16 +8716,16 @@ func (d *qemu) Info() instance.Info {
 		return data
 	}
 
-	out, err := exec.Command(qemuPath, "--version").Output()
+	stdout, stderr, err := shared.RunCommandSplit(context.TODO(), nil, nil, qemuPath, "--version")
 	if err != nil {
-		logger.Errorf("Failed getting version during QEMU initialization: %v", err)
+		logger.Errorf("Failed getting version during QEMU initialization: %v (%s)", err, stderr)
 		data.Error = errors.New("Failed getting QEMU version")
 		return data
 	}
 
-	qemuOutput := strings.Fields(string(out))
+	qemuOutput := strings.Fields(stdout)
 	if len(qemuOutput) >= 4 {
-		qemuVersion := strings.Fields(string(out))[3]
+		qemuVersion := qemuOutput[3]
 		data.Version = qemuVersion
 	} else {
 		data.Version = "unknown" // Not necessarily an error that should prevent us using driver.


### PR DESCRIPTION
When reading the QEMU version fails a numeric error code is the only clue to the reason why a failure occurred. It is preferable to provide the output to stderr.

In an instance that I experienced the new message was
```
Failed getting version during QEMU initialization:
/snap/lxd/x2/bin/qemu-system-riscv64:
error while loading shared libraries: libatomic.so.1:
cannot open shared object file: No such file or directory
```
instead of
```
Failed getting version during QEMU initialization: 127
```
With the new message it becomes clear why qemu-system-riscv64 cannot be executed.