### PR TITLE
lxd/instance: add riscv64 QEMU definitions

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2040,7 +2040,10 @@ func (d *qemu) AgentCertificate() *x509.Certificate {
 }
 
 func (d *qemu) architectureSupportsUEFI(arch int) bool {
-	return slices.Contains([]int{osarch.ARCH_64BIT_INTEL_X86, osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN}, arch)
+	return slices.Contains([]int{osarch.ARCH_64BIT_INTEL_X86,
+		osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN,
+		osarch.ARCH_64BIT_RISCV_LITTLE_ENDIAN},
+		arch)
 }
 
 func (d *qemu) effectiveBootMode() string {
@@ -2148,6 +2151,13 @@ func (d *qemu) qemuArchConfig(arch int) (path string, bus string, err error) {
 		}
 
 		return path, "pci", nil
+	case osarch.ARCH_64BIT_RISCV_LITTLE_ENDIAN:
+		path, err := exec.LookPath(basePath + "qemu-system-riscv64")
+		if err != nil {
+			return "", "", err
+		}
+
+		return path, "pcie", nil
 	case osarch.ARCH_64BIT_S390_BIG_ENDIAN:
 		path, err := exec.LookPath(basePath + "qemu-system-s390x")
 		if err != nil {

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -79,6 +79,8 @@ func qemuMachineType(architecture int) string {
 		machineType = "virt"
 	case osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN:
 		machineType = "pseries"
+	case osarch.ARCH_64BIT_RISCV_LITTLE_ENDIAN:
+		machineType = "virt"
 	case osarch.ARCH_64BIT_S390_BIG_ENDIAN:
 		machineType = "s390-ccw-virtio"
 	}

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -148,6 +148,15 @@ var architectureInstallations = map[int][]Installation{
 			},
 		},
 	}},
+	osarch.ARCH_64BIT_RISCV_LITTLE_ENDIAN: {{
+		Paths: GetenvEdk2Paths("/usr/share/qemu-efi-riscv64"),
+		Usage: map[FirmwareUsage][]FirmwarePair{
+			GENERIC: {
+				{Code: "RISCV_VIRT_CODE.fd", Vars: "RISCV_VIRT_VARS.fd"},
+				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.fd"},
+			},
+		},
+	}},
 }
 
 // GetAchitectureFirmwareVarsCandidates returns a unique list of candidate vars names for hostArch for all usages.


### PR DESCRIPTION
Add missing definitions to run virtual RISC-V machines. This is enough to build an LXD snap that supports RISC-V VMs.

For RISC-V there is no trusted party to sign shim for all operating systems like Microsoft does for x86 and ARM. As LXD defaults to secure boot add fake entries for the firmware.