### PR TITLE
actions/disable-docker: Remove passt package

### DIFF
--- a/.github/actions/disable-docker/action.yml
+++ b/.github/actions/disable-docker/action.yml
@@ -22,3 +22,6 @@ runs:
         done
         sudo ip link delete docker0
         sudo nft flush ruleset || sudo iptables -I DOCKER-USER -j ACCEPT
+
+        # Remove passt.
+        sudo apt-get remove passt


### PR DESCRIPTION
Remove `passt` package. @simondeziel suggested adding this in docker action, instead of in conversion test only.

Closes: https://github.com/canonical/lxd-ci/pull/508