### PR TITLE
lxd/auth/drivers: Add comment to explain metrics entitlement

### DIFF
--- a/lxd/auth/drivers/tls.go
+++ b/lxd/auth/drivers/tls.go
@@ -164,6 +164,10 @@ func (t *tls) allowProjectUnspecificEntityType(entitlement auth.Entitlement, ent
 	switch entityType {
 	case entity.TypeServer:
 		// Restricted TLS certificates have the following entitlements on server.
+		//
+		// Note: We have to keep EntitlementCanViewMetrics here for backwards compatibility with older versions of LXD.
+		// Historically when viewing the metrics endpoint for a specific project with a restricted certificate also the
+		// internal server metrics get returned.
 		return slices.Contains([]auth.Entitlement{auth.EntitlementCanViewResources, auth.EntitlementCanViewMetrics, auth.EntitlementCanViewUnmanagedNetworks}, entitlement)
 	case entity.TypeIdentity:
 		// If the entity URL refers to the identity that made the request, then the second path argument of the URL is


### PR DESCRIPTION
@roosterfish fixed a regression by allowing restricted certificates to view server metrics and added a comment to explain the reasoning. This was somehow lost so I'm just re-adding it as it led to confusion.

Note that metrics are always filtered at the project level.