### PR TITLE
Faster ping checks

### DIFF
--- a/test/includes/net.sh
+++ b/test/includes/net.sh
@@ -47,13 +47,7 @@ wait_for_dad() {
     return
   fi
 
-  while true
-  do
-    ip -6 a show
-    if ! eval "$cmd" | grep "tentative" ; then
-      break
-    fi
-
-    sleep 0.5
+  while eval "$cmd" | grep -wF "tentative" ; do
+    sleep 0.1
   done
 }

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2569,8 +2569,8 @@ test_clustering_fan() {
   LXD_DIR="${LXD_ONE_DIR}" lxc list
 
   echo "Check that the containers are reachable from each other using IPs"
-  LXD_DIR="${LXD_ONE_DIR}" lxc exec c1 -- ping -c2 -W5 "${IP_C2}"
-  LXD_DIR="${LXD_ONE_DIR}" lxc exec c2 -- ping -c2 -W5 "${IP_C1}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc exec c1 -- ping -nc2 -i0.1 -W1 "${IP_C2}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc exec c2 -- ping -nc2 -i0.1 -W1 "${IP_C1}"
 
   echo "Check that the DHCP leases are cleaned up post-migration"
   grep -qF " c1 " "${LXD_ONE_DIR}/networks/${fanbridge}/dnsmasq.leases"

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -155,10 +155,10 @@ test_container_devices_nic_bridged() {
   # Add IP alias to container and check routes actually work.
   lxc exec "${ctName}" -- ip -4 addr add "192.0.2.1${ipRand}/32" dev eth0
   lxc exec "${ctName}" -- ip -4 route add default dev eth0
-  ping -c2 -W5 "192.0.2.1${ipRand}"
+  ping -nc2 -i0.1 -W1 "192.0.2.1${ipRand}"
   lxc exec "${ctName}" -- ip -6 addr add "2001:db8::1${ipRand}/128" dev eth0
   wait_for_dad "${ctName}" eth0
-  ping6 -c2 -W5 "2001:db8::1${ipRand}"
+  ping -6 -nc2 -i0.1 -W1 "2001:db8::1${ipRand}"
 
   # Test hot plugging a container nic with different settings to profile with the same name.
   lxc config device add "${ctName}" eth0 nic \

--- a/test/suites/container_devices_nic_bridged_acl.sh
+++ b/test/suites/container_devices_nic_bridged_acl.sh
@@ -121,14 +121,14 @@ test_container_devices_nic_bridged_acl() {
   lxc exec "${ctPrefix}A" -- ip a add 2001:db8::2/64 dev eth0
 
   # Check ICMP to bridge is blocked.
-  ! lxc exec "${ctPrefix}A" -- ping -c2 -4 -W5 192.0.2.1 || false
-  ! lxc exec "${ctPrefix}A" -- ping -c2 -6 -W5 2001:db8::1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -4 -nc2 -i0.1 -W1 192.0.2.1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8::1 || false
 
   # Allow ICMP to bridge host.
   lxc network acl rule add "${brName}A" egress action=allow destination=192.0.2.1/32 protocol=icmp4 icmp_type=8
   lxc network acl rule add "${brName}A" egress action=allow destination=2001:db8::1/128 protocol=icmp6 icmp_type=128
-  lxc exec "${ctPrefix}A" -- ping -c2 -4 -W5 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -6 -W5 2001:db8::1
+  lxc exec "${ctPrefix}A" -- ping -4 -nc2 -i0.1 -W1 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8::1
 
   # Check DNS resolution (and connection tracking in the process).
   lxc exec "${ctPrefix}A" -- nslookup -type=a testhost.test 192.0.2.1
@@ -144,18 +144,18 @@ test_container_devices_nic_bridged_acl() {
   lxc network set "${brName}" security.acls="${brName}A,${brName}B"
 
   # Check egress ICMP ping to bridge is blocked.
-  ! lxc exec "${ctPrefix}A" -- ping -c2 -4 -W5 192.0.2.1 || false
-  ! lxc exec "${ctPrefix}A" -- ping -c2 -6 -W5 2001:db8::1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -4 -nc2 -i0.1 -W1 192.0.2.1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8::1 || false
 
   # Check ingress ICMPv4 ping is blocked.
-  ! ping -c1 -4 192.0.2.2 || false
+  ! ping -4 -nc2 -i0.1 -W1 192.0.2.2 || false
 
   # Allow ingress ICMPv4 ping.
   lxc network acl rule add "${brName}A" ingress action=allow destination=192.0.2.2/32 protocol=icmp4 icmp_type=8
-  ping -c1 -4 192.0.2.2
+  ping -4 -nc2 -i0.1 -W1 192.0.2.2
 
   # Check egress ICMPv6 ping from host to bridge is allowed by default (for dnsmasq probing).
-  ping -c1 -6 2001:db8::2
+  ping -6 -nc2 -i0.1 -W1 2001:db8::2
 
   # Check egress TCP.
   lxc exec "${ctPrefix}A" --disable-stdin -- nc -w2 192.0.2.1 53

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -55,8 +55,8 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}B" -- ip a add 192.0.2.3/24 dev eth0
 
   # Check basic connectivity without any filtering.
-  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3
+  lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.3
 
   # Enable MAC filtering on CT A and test.
   lxc config device set "${ctPrefix}A" eth0 security.mac_filtering true
@@ -98,13 +98,13 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address 00:11:22:33:44:56 up
 
   # Check that ping is no longer working (i.e its filtered after fake MAC setup).
-  if lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1; then
+  if lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1; then
       echo "MAC filter not working to host"
       false
   fi
 
   # Check that ping is no longer working (i.e its filtered after fake MAC setup).
-  if lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3; then
+  if lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.3; then
       echo "MAC filter not working to other container"
       false
   fi
@@ -113,8 +113,8 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address "${ctAMAC}" up
 
   # Check basic connectivity with MAC filtering but real MAC configured.
-  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3
+  lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.3
 
   # Stop CT A and check filters are cleaned up.
   lxc stop -f "${ctPrefix}A"
@@ -137,8 +137,8 @@ test_container_devices_nic_bridged_filtering() {
   lxc start "${ctPrefix}A"
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address "${ctAMAC}" up
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.254/24 dev eth0
-  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3
+  lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.3
 
   # Enable IPv4 filtering on CT A and test (disable security.mac_filtering to check its applied too).
   lxc config device set "${ctPrefix}A" eth0 ipv4.address 192.0.2.2
@@ -211,21 +211,21 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.2/24 dev eth0
 
   # Check basic connectivity with IPv4 filtering and real IPs configured.
-  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3
+  lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.3
 
   # Add a fake IP
   lxc exec "${ctPrefix}A" -- ip a flush dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.254/24 dev eth0
 
   # Check that ping is no longer working (i.e its filtered after fake IP setup).
-  if lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1; then
+  if lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1; then
       echo "IPv4 filter not working to host"
       false
   fi
 
   # Check that ping is no longer working (i.e its filtered after fake IP setup).
-  if lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3; then
+  if lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.3; then
       echo "IPv4 filter not working to other container"
       false
   fi
@@ -237,13 +237,13 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}B" -- ip r add 198.51.100.0/24 dev eth0
 
   # Check that ping is still working (i.e the filter did not apply to the ipv4.routes subnet).
-  if ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1; then
+  if ! lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1; then
       echo "IPv4 filter is preventing traffic from within ipv4.routes"
       false
   fi
 
   # Check that ping is still working (i.e the filter did not apply to the ipv4.routes subnet).
-  if ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3; then
+  if ! lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.3; then
       echo "IPv4 filter is preventing traffic from within ipv4.routes"
       false
   fi
@@ -255,13 +255,13 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}B" -- ip r add 203.0.113.0/24 dev eth0
 
   # Check that ping is still working (i.e the filter did not apply to the ipv4.routes.external subnet).
-  if ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1; then
+  if ! lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1; then
       echo "IPv4 filter is preventing traffic from within ipv4.routes.external"
       false
   fi
 
   # Check that ping is still working (i.e the filter did not apply to the ipv4.routes.external subnet).
-  if ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3; then
+  if ! lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.3; then
       echo "IPv4 filter is preventing traffic from within ipv4.routes.external"
       false
   fi
@@ -339,8 +339,8 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address "${ctAMAC}" up
   lxc exec "${ctPrefix}A" -- ip -6 a add 2001:db8:1::254 dev eth0
   wait_for_dad "${ctPrefix}A" eth0
-  lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8:1::1
-  lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8:1::3
+  lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8:1::1
+  lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8:1::3
 
   # Enable IPv6 filtering on CT A and test (disable security.mac_filtering to check its applied too).
   lxc config device set "${ctPrefix}A" eth0 ipv6.address 2001:db8:1::2
@@ -466,8 +466,8 @@ test_container_devices_nic_bridged_filtering() {
   wait_for_dad "${ctPrefix}A" eth0
 
   # Check basic connectivity with IPv6 filtering and real IPs configured.
-  lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8:1::1
-  lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8:1::3
+  lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8:1::1
+  lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8:1::3
 
   # Add a fake IP
   lxc exec "${ctPrefix}A" -- ip -6 a flush dev eth0
@@ -475,13 +475,13 @@ test_container_devices_nic_bridged_filtering() {
   wait_for_dad "${ctPrefix}A" eth0
 
   # Check that ping is no longer working (i.e its filtered after fake IP setup).
-  if lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8:1::1; then
+  if lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8:1::1; then
       echo "IPv6 filter not working to host"
       false
   fi
 
   # Check that ping is no longer working (i.e its filtered after fake IP setup).
-  if lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8:1::3; then
+  if lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8:1::3; then
       echo "IPv6 filter not working to other container"
       false
   fi
@@ -494,13 +494,13 @@ test_container_devices_nic_bridged_filtering() {
   wait_for_dad "${ctPrefix}A" eth0
 
   # Check that ping is still working (i.e the filter did not apply to the ipv6.routes subnet).
-  if ! lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8:1::1; then
+  if ! lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8:1::1; then
       echo "IPv6 filter is preventing traffic from from within ipv6.routes"
       false
   fi
 
   # Check that ping is still working (i.e the filter did not apply to the ipv6.routes subnet).
-  if ! lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8:1::3; then
+  if ! lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8:1::3; then
       echo "IPv6 filter is preventing traffic from within ipv6.routes"
       false
   fi
@@ -512,13 +512,13 @@ test_container_devices_nic_bridged_filtering() {
   wait_for_dad "${ctPrefix}A" eth0
 
   # Check that ping is still working (i.e the filter did not apply to the ipv6.routes.external subnet).
-  if ! lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8:1::1; then
+  if ! lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8:1::1; then
       echo "IPv6 filter is preventing traffic from within ipv6.routes.external"
       false
   fi
 
   # Check that ping is still working (i.e the filter did not apply to the ipv6.routes subnet).
-  if ! lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8:1::3; then
+  if ! lxc exec "${ctPrefix}A" -- ping -6 -nc2 -i0.1 -W1 2001:db8:1::3; then
       echo "IPv6 filter is preventing traffic from within ipv6.routes.external"
       false
   fi
@@ -810,16 +810,16 @@ test_container_devices_nic_bridged_filtering() {
   wait_for_dad "${ctPrefix}A" eth0
 
   # Check basic connectivity without any filtering.
-  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -W5 2001:db8::1
+  lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 2001:db8::1
 
   # Check fraudulent IPs are blocked.
   lxc exec "${ctPrefix}A" -- ip a flush dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.3/24 dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 2001:db8::3/64 dev eth0
 
-  ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1 || false
-  ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 2001:db8::1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 2001:db8::1 || false
 
   # Check IP filtering can be enabled with IP assigned as none in LXD config.
   lxc config device set "${ctPrefix}A" eth0 ipv4.address=none security.ipv4_filtering=true
@@ -827,8 +827,8 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip a flush dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.2/24 dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 2001:db8::2/64 dev eth0
-  ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1 || false
-  ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 2001:db8::1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 192.0.2.1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -nc2 -i0.1 -W1 2001:db8::1 || false
 
   lxc delete -f "${ctPrefix}A"
   ip link delete "${brName}2"

--- a/test/suites/container_devices_nic_bridged_vlan.sh
+++ b/test/suites/container_devices_nic_bridged_vlan.sh
@@ -40,8 +40,8 @@ test_container_devices_nic_bridged_vlan() {
   lxc exec "${prefix}-ctB" -- ip link add link eth0 name eth0.2 type vlan id 2
   lxc exec "${prefix}-ctB" -- ip link set eth0.2 up
   lxc exec "${prefix}-ctB" -- ip a add 192.0.2.2/24 dev eth0.2
-  lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2
-  lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1
+  lxc exec "${prefix}-ctA" -- ping -nc2 -i0.1 -W1 192.0.2.2
+  lxc exec "${prefix}-ctB" -- ping -nc2 -i0.1 -W1 192.0.2.1
   lxc stop -f "${prefix}-ctA"
 
   # Test tagged VLAN traffic is filtered when IP filtering is enabled.
@@ -51,8 +51,8 @@ test_container_devices_nic_bridged_vlan() {
     lxc exec "${prefix}-ctA" -- ip link add link eth0 name eth0.2 type vlan id 2
     lxc exec "${prefix}-ctA" -- ip link set eth0.2 up
     lxc exec "${prefix}-ctA" -- ip a add 192.0.2.1/24 dev eth0.2
-    ! lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2 || false
-    ! lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1 || false
+    ! lxc exec "${prefix}-ctA" -- ping -nc2 -i0.1 -W1 192.0.2.2 || false
+    ! lxc exec "${prefix}-ctB" -- ping -nc2 -i0.1 -W1 192.0.2.1 || false
     lxc stop -f "${prefix}-ctA"
     lxc config device remove "${prefix}-ctA" eth0
   fi
@@ -65,8 +65,8 @@ test_container_devices_nic_bridged_vlan() {
     lxc exec "${prefix}-ctA" -- ip link set eth0.2 up
     lxc exec "${prefix}-ctA" -- ip a add 192.0.2.1/24 dev eth0.2
     lxc exec "${prefix}-ctA" -- ip link set eth0.2 address 00:16:3e:92:f3:c1
-    ! lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2 || false
-    ! lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1 || false
+    ! lxc exec "${prefix}-ctA" -- ping -nc2 -i0.1 -W1 192.0.2.2 || false
+    ! lxc exec "${prefix}-ctB" -- ping -nc2 -i0.1 -W1 192.0.2.1 || false
     lxc stop -f "${prefix}-ctA"
     lxc config device remove "${prefix}-ctA" eth0
   fi
@@ -108,10 +108,10 @@ test_container_devices_nic_bridged_vlan() {
   lxc exec "${prefix}-ctB" -- ip link add link eth0 name eth0.3 type vlan id 3
   lxc exec "${prefix}-ctB" -- ip link set eth0.3 up
   lxc exec "${prefix}-ctB" -- ip a add 192.0.3.2/24 dev eth0.3
-  lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2
-  lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1
-  ! lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.3.2 || false
-  ! lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.3.1 || false
+  lxc exec "${prefix}-ctA" -- ping -nc2 -i0.1 -W1 192.0.2.2
+  lxc exec "${prefix}-ctB" -- ping -nc2 -i0.1 -W1 192.0.2.1
+  ! lxc exec "${prefix}-ctA" -- ping -nc2 -i0.1 -W1 192.0.3.2 || false
+  ! lxc exec "${prefix}-ctB" -- ping -nc2 -i0.1 -W1 192.0.3.1 || false
   lxc stop -f "${prefix}-ctA"
   lxc config device remove "${prefix}-ctA" eth0
   lxc stop -f "${prefix}-ctB"
@@ -136,10 +136,10 @@ test_container_devices_nic_bridged_vlan() {
   lxc exec "${prefix}-ctB" -- ip link add link eth0 name eth0.2 type vlan id 2
   lxc exec "${prefix}-ctB" -- ip link set eth0.2 up
   lxc exec "${prefix}-ctB" -- ip a add 192.0.2.2/24 dev eth0.2
-  lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2
-  lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1
-  ! lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.3.2 || false
-  ! lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.3.1 || false
+  lxc exec "${prefix}-ctA" -- ping -nc2 -i0.1 -W1 192.0.2.2
+  lxc exec "${prefix}-ctB" -- ping -nc2 -i0.1 -W1 192.0.2.1
+  ! lxc exec "${prefix}-ctA" -- ping -nc2 -i0.1 -W1 192.0.3.2 || false
+  ! lxc exec "${prefix}-ctB" -- ping -nc2 -i0.1 -W1 192.0.3.1 || false
   lxc stop -f "${prefix}-ctA"
   lxc config device remove "${prefix}-ctA" eth0
   lxc stop -f "${prefix}-ctB"
@@ -161,8 +161,8 @@ test_container_devices_nic_bridged_vlan() {
     lxc start "${prefix}-ctB"
     lxc exec "${prefix}-ctB" -- ip link set eth0 up
     lxc exec "${prefix}-ctB" -- ip a add 192.0.2.2/24 dev eth0
-    lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2
-    lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1
+    lxc exec "${prefix}-ctA" -- ping -nc2 -i0.1 -W1 192.0.2.2
+    lxc exec "${prefix}-ctB" -- ping -nc2 -i0.1 -W1 192.0.2.1
     lxc stop -f "${prefix}-ctA"
     lxc config device remove "${prefix}-ctA" eth0
     lxc stop -f "${prefix}-ctB"

--- a/test/suites/container_devices_nic_ipvlan.sh
+++ b/test/suites/container_devices_nic_ipvlan.sh
@@ -58,12 +58,12 @@ test_container_devices_nic_ipvlan() {
   lxc start "${ctName}2"
 
   # Check comms between containers.
-  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.2${ipRand}"
-  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.3${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::2${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::3${ipRand}"
-  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1${ipRand}"
-  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::1${ipRand}"
+  lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.3${ipRand}"
+  lxc exec "${ctName}" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::3${ipRand}"
+  lxc exec "${ctName}2" -- ping -nc2 -i0.1 -W1 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}2" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::1${ipRand}"
   lxc stop -f "${ctName}2"
 
   # Check IPVLAN ontop of VLAN parent with custom routing tables.
@@ -133,14 +133,14 @@ test_container_devices_nic_ipvlan() {
   wait_for_dad "${ctName}2" eth0
 
   # Check comms between containers.
-  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.3${ipRand}"
-  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.4${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::3${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::4${ipRand}"
-  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1${ipRand}"
-  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.2${ipRand}"
-  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::1${ipRand}"
-  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.3${ipRand}"
+  lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.4${ipRand}"
+  lxc exec "${ctName}" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::3${ipRand}"
+  lxc exec "${ctName}" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::4${ipRand}"
+  lxc exec "${ctName}2" -- ping -nc2 -i0.1 -W1 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}2" -- ping -nc2 -i0.1 -W1 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}2" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::1${ipRand}"
+  lxc exec "${ctName}2" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::2${ipRand}"
 
   lxc stop -f "${ctName}"
   lxc stop -f "${ctName}2"

--- a/test/suites/container_devices_nic_ipvlan.sh
+++ b/test/suites/container_devices_nic_ipvlan.sh
@@ -56,6 +56,7 @@ test_container_devices_nic_ipvlan() {
     ipv4.address="192.0.2.2${ipRand}, 192.0.2.3${ipRand}" \
     ipv6.address="2001:db8::2${ipRand}, 2001:db8::3${ipRand}"
   lxc start "${ctName}2"
+  wait_for_dad "${ctName}2" eth0
 
   # Check comms between containers.
   lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.2${ipRand}"

--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -37,10 +37,10 @@ test_container_devices_nic_macvlan() {
   lxc exec "${ctName}2" -- ip addr add "2001:db8::2${ipRand}/64" dev eth0
 
   echo "==> Check comms between containers."
-  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.2${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::2${ipRand}"
-  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1${ipRand}"
-  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::1${ipRand}"
+  lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}2" -- ping -nc2 -i0.1 -W1 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}2" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::1${ipRand}"
 
   echo "==> Test hot plugging a container nic with different settings to profile with the same name."
   lxc config device add "${ctName}" eth0 nic \
@@ -154,8 +154,8 @@ test_container_devices_nic_macvlan() {
   lxc exec "${ctName}" -- ip addr add "192.0.2.1${ipRand}/24" dev eth0
   lxc exec "${ctName}" -- ip addr add "2001:db8::1${ipRand}/64" dev eth0
   lxc exec "${ctName}" -- ip link set eth0 up
-  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.2${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::2${ipRand}"
   lxc config device remove "${ctName}" eth0
   lxc network delete "${ctName}net"
 

--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -35,6 +35,7 @@ test_container_devices_nic_macvlan() {
   lxc launch testimage "${ctName}2" -p "${ctName}"
   lxc exec "${ctName}2" -- ip addr add "192.0.2.2${ipRand}/24" dev eth0
   lxc exec "${ctName}2" -- ip addr add "2001:db8::2${ipRand}/64" dev eth0
+  wait_for_dad "${ctName}2" eth0
 
   echo "==> Check comms between containers."
   lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.2${ipRand}"
@@ -154,6 +155,7 @@ test_container_devices_nic_macvlan() {
   lxc exec "${ctName}" -- ip addr add "192.0.2.1${ipRand}/24" dev eth0
   lxc exec "${ctName}" -- ip addr add "2001:db8::1${ipRand}/64" dev eth0
   lxc exec "${ctName}" -- ip link set eth0 up
+  wait_for_dad "${ctName}" eth0
   lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.2${ipRand}"
   lxc exec "${ctName}" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::2${ipRand}"
   lxc config device remove "${ctName}" eth0

--- a/test/suites/container_devices_nic_p2p.sh
+++ b/test/suites/container_devices_nic_p2p.sh
@@ -70,12 +70,12 @@ test_container_devices_nic_p2p() {
   lxc exec "${ctName}" -- ip -4 addr add "192.0.2.1${ipRand}/32" dev eth0
   lxc exec "${ctName}" -- ip -4 route add default dev eth0
   wait_for_dad "${ctName}" eth0
-  ping -c2 -W5 "192.0.2.1${ipRand}"
+  ping -nc2 -i0.1 -W1 "192.0.2.1${ipRand}"
   ip -6 addr add 2001:db8::1/128 dev "${vethHostName}"
   lxc exec "${ctName}" -- ip -6 addr add "2001:db8::1${ipRand}/128" dev eth0
   lxc exec "${ctName}" -- ip -6 route add default dev eth0
   wait_for_dad "${ctName}" eth0
-  ping6 -c2 -W5 "2001:db8::1${ipRand}"
+  ping -6 -nc2 -i0.1 -W1 "2001:db8::1${ipRand}"
 
   # Test hot plugging a container nic with different settings to profile with the same name.
   lxc config device add "${ctName}" eth0 nic \

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -38,8 +38,8 @@ test_container_devices_nic_routed() {
   # Wait for IPv6 DAD to complete.
   wait_for_dad "${ctName}neigh" eth0
 
-  ping -c2 -W5 192.0.2.254
-  ping6 -c2 -W5 "2001:db8::FFFF"
+  ping -nc2 -i0.1 -W1 192.0.2.254
+  ping -6 -nc2 -i0.1 -W1 "2001:db8::FFFF"
 
   # Create dummy vlan parent.
   # Use slash notation when setting sysctls on vlan interface (that has period in interface name).
@@ -168,20 +168,20 @@ test_container_devices_nic_routed() {
   wait_for_dad "${ctName}2" eth0
 
   # Check comms between containers.
-  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.1"
-  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::1"
+  lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.1"
+  lxc exec "${ctName}" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::1"
 
-  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1"
-  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::1"
+  lxc exec "${ctName}2" -- ping -nc2 -i0.1 -W1 "192.0.2.1"
+  lxc exec "${ctName}2" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::1"
 
-  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.2${ipRand}"
-  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.3${ipRand}"
+  lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping -nc2 -i0.1 -W1 "192.0.2.3${ipRand}"
 
-  lxc exec "${ctName}" -- ping6 -c3 -W5 "2001:db8::3${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}" -- ping -6 -nc2 -i0.1 -w1 "2001:db8::3${ipRand}"
+  lxc exec "${ctName}" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::2${ipRand}"
 
-  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1${ipRand}"
-  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::1${ipRand}"
+  lxc exec "${ctName}2" -- ping -nc2 -i0.1 -W1 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}2" -- ping -6 -nc2 -i0.1 -W1 "2001:db8::1${ipRand}"
 
   lxc stop -f "${ctName}2"
   lxc stop -f "${ctName}"


### PR DESCRIPTION
The numbers below are for the `dir` backend:

### Before

Test|Time
:---           | :---
clustering_fan|13
container_devices_nic_p2p|10
container_devices_nic_bridged|77
container_devices_nic_bridged_acl|37
container_devices_nic_bridged_filtering|128
container_devices_nic_bridged_vlan|66
container_devices_nic_macvlan|15
container_devices_nic_ipvlan|18
container_devices_nic_routed|26

Total: 390s (~6.5 min)

### After

Test|Time
:---           | :---
clustering_fan|12
container_devices_nic_p2p|7
container_devices_nic_bridged|76
container_devices_nic_bridged_acl|15
container_devices_nic_bridged_filtering|58
container_devices_nic_bridged_vlan|19
container_devices_nic_macvlan|7
container_devices_nic_ipvlan|7
container_devices_nic_routed|13

Total: 214s (~3.5 min)