### PR TITLE
test/suites: Use testimage for auth checks.

### DIFF
--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -1240,9 +1240,8 @@ entities_enrichment_with_entitlements() {
   lxc auth identity-provider-group delete test-idp-group3
 
   # Image
-  lxc init images:busybox/1.36.1 c1
-  lxc delete c1
-  imgFingerprint=$(lxc image list --format json | jq -r '.[] | select(.update_source.alias == "busybox/1.36.1") | .fingerprint')
+  ensure_import_testimage
+  imgFingerprint="$(lxc query /1.0/images/aliases/testimage | jq -r .target)"
   lxc auth group permission add test-group image "${imgFingerprint}" can_view project=default
   lxc auth group permission add test-group image "${imgFingerprint}" can_edit project=default
   lxc auth group permission add test-group image "${imgFingerprint}" can_delete project=default


### PR DESCRIPTION
It looks like the use of the images: remote was originally added in b0a63b97c95dfdabca2c713786d32caee1c3fab1, but there is no reason to pull an image for these tests.