### PR TITLE
Auth: Improvements to network allocation used by URL checks

### DIFF
--- a/lxd/auth/drivers/tls.go
+++ b/lxd/auth/drivers/tls.go
@@ -96,6 +96,12 @@ func (t *tls) CheckPermission(ctx context.Context, entityURL *api.URL, entitleme
 	return nil
 }
 
+// CheckPermissionWithoutEffectiveProject calls CheckPermission. This is because the TLS auth driver does not need to consider
+// the effective project at all.
+func (t *tls) CheckPermissionWithoutEffectiveProject(ctx context.Context, entityURL *api.URL, entitlement auth.Entitlement) error {
+	return t.CheckPermission(ctx, entityURL, entitlement)
+}
+
 // GetPermissionChecker returns a function that can be used to check whether a user has the required entitlement on an authorization object.
 func (t *tls) GetPermissionChecker(ctx context.Context, entitlement auth.Entitlement, entityType entity.Type) (auth.PermissionChecker, error) {
 	err := auth.ValidateEntitlement(entityType, entitlement)
@@ -158,6 +164,12 @@ func (t *tls) GetPermissionChecker(ctx context.Context, entitlement auth.Entitle
 		// Otherwise, check if the project is in the list of allowed projects for the entity.
 		return slices.Contains(id.Projects, project)
 	}, nil
+}
+
+// GetPermissionCheckerWithoutEffectiveProject calls GetPermissionChecker. This is because the TLS auth driver does not need to consider
+// the effective project at all.
+func (t *tls) GetPermissionCheckerWithoutEffectiveProject(ctx context.Context, entitlement auth.Entitlement, entityType entity.Type) (auth.PermissionChecker, error) {
+	return t.GetPermissionChecker(ctx, entitlement, entityType)
 }
 
 func (t *tls) allowProjectUnspecificEntityType(entitlement auth.Entitlement, entityType entity.Type, id *identity.CacheEntry, projectName string, pathArguments []string) bool {

--- a/lxd/auth/types.go
+++ b/lxd/auth/types.go
@@ -50,14 +50,14 @@ type Authorizer interface {
 	// CheckPermission checks if the caller has the given entitlement on the entity found at the given URL.
 	//
 	// Note: When a project does not have a feature enabled, the given URL should contain the request project, and the
-	// effective project for the entity should be set in the given context as request.CtxEffectiveProjectName.
+	// effective project for the entity should be set on the request.Info in the given context.
 	CheckPermission(ctx context.Context, entityURL *api.URL, entitlement Entitlement) error
 
 	// GetPermissionChecker returns a PermissionChecker for a particular entity.Type.
 	//
 	// Note: As with CheckPermission, arguments to the returned PermissionChecker should contain the request project for
-	// the entity. The effective project for the entity must be set in the request context as request.CtxEffectiveProjectName
-	// *before* the call to GetPermissionChecker.
+	// the entity. The effective project for the entity must be set on the request.Info in the given context before
+	// calling the PermissionChecker.
 	GetPermissionChecker(ctx context.Context, entitlement Entitlement, entityType entity.Type) (PermissionChecker, error)
 
 	// CheckPermissionWithoutEffectiveProject checks a permission, but does not replace the project in the entity URL

--- a/lxd/auth/types.go
+++ b/lxd/auth/types.go
@@ -59,6 +59,18 @@ type Authorizer interface {
 	// the entity. The effective project for the entity must be set in the request context as request.CtxEffectiveProjectName
 	// *before* the call to GetPermissionChecker.
 	GetPermissionChecker(ctx context.Context, entitlement Entitlement, entityType entity.Type) (PermissionChecker, error)
+
+	// CheckPermissionWithoutEffectiveProject checks a permission, but does not replace the project in the entity URL
+	// with the effective project stored in the context.
+	//
+	// Warn: You almost never need this function. You should use CheckPermission instead.
+	CheckPermissionWithoutEffectiveProject(ctx context.Context, entityURL *api.URL, entitlement Entitlement) error
+
+	// GetPermissionCheckerWithoutEffectiveProject returns a PermissionChecker does not replace the project in the entity URL
+	// with the effective project stored in the context.
+	//
+	// Warn: You almost never need this function. You should use GetPermissionChecker instead.
+	GetPermissionCheckerWithoutEffectiveProject(ctx context.Context, entitlement Entitlement, entityType entity.Type) (PermissionChecker, error)
 }
 
 // IsDeniedError returns true if the error is not found or forbidden. This is because the CheckPermission method on

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -129,7 +129,7 @@ type imageDetails struct {
 	image                  api.Image
 }
 
-// addImageDetailsToRequestContext sets request.CtxEffectiveProjectName (string) and ctxImageDetails (imageDetails)
+// addImageDetailsToRequestContext sets the effective project in the request.Info and sets ctxImageDetails (imageDetails)
 // in the request context.
 func addImageDetailsToRequestContext(s *state.State, r *http.Request) error {
 	imageFingerprintPrefix, err := url.PathUnescape(mux.Vars(r)["fingerprint"])

--- a/lxd/network_allocations.go
+++ b/lxd/network_allocations.go
@@ -80,7 +80,7 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	requestProjectName := request.ProjectParam(r)
-	effectiveProjectName, _, err := project.NetworkProject(d.State().DB.Cluster, requestProjectName)
+	effectiveProjectName, _, err := project.NetworkProject(s.DB.Cluster, requestProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -91,7 +91,7 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 	allProjects := shared.IsTrue(request.QueryParam(r, "all-projects"))
 
 	var projectNames []string
-	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Figure out the projects to retrieve.
 		if !allProjects {
 			projectNames = []string{effectiveProjectName}
@@ -156,7 +156,7 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 
 		var networkNames []string
 
-		err := d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
 
 			networkNames, err = tx.GetNetworks(ctx, projectName)
@@ -173,7 +173,7 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 				continue
 			}
 
-			n, err := network.LoadByName(d.State(), projectName, networkName)
+			n, err := network.LoadByName(s, projectName, networkName)
 			if err != nil {
 				return response.SmartError(fmt.Errorf("Failed loading network %q in project %q: %w", networkName, projectName, err))
 			}
@@ -241,7 +241,7 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 
 			var forwards map[int64]*api.NetworkForward
 
-			err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 				forwards, err = tx.GetNetworkForwards(ctx, n.ID(), false)
 
 				return err
@@ -271,7 +271,7 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 
 			var loadBalancers map[int64]*api.NetworkLoadBalancer
 
-			err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 				loadBalancers, err = tx.GetNetworkLoadBalancers(ctx, n.ID(), false)
 
 				return err

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -54,7 +54,7 @@ type networkZoneDetails struct {
 	requestProject api.Project
 }
 
-// addNetworkZoneDetailsToRequestContext sets request.CtxEffectiveProjectName (string) and ctxNetworkZoneDetails (networkZoneDetails)
+// addNetworkZoneDetailsToRequestContext sets the effective project in the request.Info and sets ctxNetworkZoneDetails (networkZoneDetails)
 // in the request context.
 func addNetworkZoneDetailsToRequestContext(s *state.State, r *http.Request) error {
 	zoneName, err := url.PathUnescape(mux.Vars(r)["zone"])

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -90,7 +90,7 @@ type networkDetails struct {
 	requestProject api.Project
 }
 
-// addNetworkDetailsToRequestContext sets request.CtxEffectiveProjectName (string) and ctxNetworkDetails (networkDetails)
+// addNetworkDetailsToRequestContext sets the effective project on the request.Info and sets ctxNetworkDetails (networkDetails)
 // in the request context.
 func addNetworkDetailsToRequestContext(s *state.State, r *http.Request) error {
 	networkName, err := url.PathUnescape(mux.Vars(r)["networkName"])

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -64,7 +64,7 @@ type profileDetails struct {
 	effectiveProject api.Project
 }
 
-// addProfileDetailsToRequestContext sets request.CtxEffectiveProjectName (string) and ctxProfileDetails (profileDetails)
+// addProfileDetailsToRequestContext sets the effective project in the request.Info and sets ctxProfileDetails (profileDetails)
 // in the request context.
 func addProfileDetailsToRequestContext(s *state.State, r *http.Request) error {
 	profileName, err := url.PathUnescape(mux.Vars(r)["name"])

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -1205,7 +1205,7 @@ type storageBucketDetails struct {
 
 // addStorageBucketDetailsToContext extracts storageBucketDetails from the http.Request and adds it to the
 // request context with the ctxStorageBucketDetails request.CtxKey. Additionally, the effective project of the storage
-// bucket is added to the request context under request.CtxEffectiveProjectName.
+// bucket is added to the request.Info.
 func addStorageBucketDetailsToContext(d *Daemon, r *http.Request) error {
 	var details storageBucketDetails
 	defer func() {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -2728,7 +2728,7 @@ type storageVolumeDetails struct {
 
 // addStoragePoolVolumeDetailsToRequestContext extracts storageVolumeDetails from the http.Request and adds it to the
 // request context with the ctxStorageVolumeDetails request.CtxKey. Additionally, the effective project of the storage
-// bucket is added to the request context under request.CtxEffectiveProjectName.
+// volume is added to the request.Info.
 func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request) error {
 	var details storageVolumeDetails
 	var location string

--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -57,6 +57,9 @@ test_tls_restrictions() {
   # Validate restricted caller cannot create projects.
   ! lxc_remote project create localhost:blah1 || false
 
+  # Validate restricted caller cannot create instances in projects they don't have access to
+  ! lxc_remote init testimage localhost: --project default || false
+
   # Validate restricted caller cannot list resources in projects they do not have access to
   ! lxc_remote list localhost: --project default || false
   ! lxc_remote profile list localhost: --project default || false
@@ -251,6 +254,34 @@ test_tls_restrictions() {
   # The restricted client can delete the network zone.
   lxc_remote network zone delete localhost:blah-zone --project blah
 
+  ### Network allocations
+
+  # Create a network in the default project.
+  networkName="net$$"
+  lxc network create "${networkName}" --project default
+
+  # Create instances in the default project and in the blah project that use the network
+  ensure_import_testimage
+  lxc image copy testimage local: --project default --target-project blah
+  lxc init testimage foo --network "${networkName}"
+  lxc_remote init testimage localhost:bar --network "${networkName}" --project blah
+
+  # The restricted client can't view allocations in the default project
+  ! lxc network list-allocations localhost: --project default || false
+
+  # The restricted client can't view allocations for all projects
+  ! lxc network list-allocations localhost: --all-projects || false
+
+  # The restricted client can view allocations for the blah project. Since blah doesn't have networks enabled, the client
+  # should see allocations for the default project, but they can't see the foo instance
+  [ "$(lxc network list-allocations localhost: --project blah --format csv | wc -l)" = 3 ]
+  ! lxc network list-allocations localhost: --project blah --format csv | grep 'instances/foo' || false
+
+  # Clean up
+  lxc delete foo
+  lxc delete bar --project blah
+  lxc image delete testimage --project blah
+  lxc network delete "${networkName}"
 
   ### PROFILES (initial value is true for new projects)
 


### PR DESCRIPTION
Checks the URLs returned by the network allocations endpoint. This required jumping through a few feature flag related hoops (see comments).

I've confirmed the tests are failing before this change and passing afterwards.

Closes #15855
