### PR TITLE
doc: ignore anchor when checking maas link (stable-5.21)

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -173,8 +173,9 @@ linkcheck_ignore = [
 
 custom_linkcheck_anchors_ignore_for_url = [
     r'https://snapcraft\.io/docs/.*',
-    'https://docs.docker.com/network/packet-filtering-firewalls/'
-    ]
+    'https://docs.docker.com/network/packet-filtering-firewalls/',
+    'https://maas.io/docs/how-to-manage-machines'
+]
 
 linkcheck_exclude_documents = [r'.*/manpages/.*']
 


### PR DESCRIPTION
Accomplishes the same as https://github.com/canonical/lxd/pull/15913 — adds maas.io page to ignore list for checking anchor links while still checking for a valid link to the page itself. stable-5.0 docs uses a different configuration file (`conf.py` instead of `custom-conf.py`; `custom-conf.py` used in stable-5.21 and main).