### PR TITLE
doc: ignore anchor when checking maas link

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -190,8 +190,9 @@ linkcheck_ignore = [
 
 custom_linkcheck_anchors_ignore_for_url = [
     r'https://snapcraft\.io/docs/.*',
-    'https://docs.docker.com/network/packet-filtering-firewalls/'
-    ]
+    'https://docs.docker.com/network/packet-filtering-firewalls/',
+    'https://maas.io/docs/how-to-manage-machines'
+]
 
 linkcheck_exclude_documents = [r'.*/manpages/.*']
 


### PR DESCRIPTION
Cherry picked from commit b0b8c1b44939d51a3f1d76708861c3f8212241f0 / PR #15915 
Adds maas.io page to ignore list for checking anchor links while still checking for a valid link to the page itself.