### PR TITLE
Daemon: Don't request full `State` in `activateifneeded` command to avoid running instance driver feature checks

### DIFF
--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -74,16 +74,15 @@ func (c *cmdActivateifneeded) run(cmd *cobra.Command, args []string) error {
 	d.db.Node = db.DirectAccess(sqldb)
 
 	// Load the configured address from the database
-	var localConfig *node.Config
 	err = d.db.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
-		localConfig, err = node.ConfigLoad(ctx, tx)
+		d.localConfig, err = node.ConfigLoad(ctx, tx)
 		return err
 	})
 	if err != nil {
 		return err
 	}
 
-	localHTTPAddress := localConfig.HTTPSAddress()
+	localHTTPAddress := d.localConfig.HTTPSAddress()
 
 	startLXD := func() error {
 		d, err := lxd.ConnectLXDUnix("", &lxd.ConnectionArgs{


### PR DESCRIPTION
By avoiding calling `d.State()` this PR avoids running unnecessary instance driver feature checks during `activateifneeded` command, which in turn avoids doing unnecessary work and logging errors like:

```
Unable to locate a VM UEFI firmware
```

Fixes https://github.com/canonical/lxd/issues/15038