### PR TITLE
Add util to get both "project" and "all-projects" parameters

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -352,13 +352,18 @@ func allowProjectResourceList(d *Daemon, r *http.Request) response.Response {
 		return response.Forbidden(nil)
 	}
 
+	requestProjectName, allProjects, err := request.ProjectParams(r)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	// all-projects requests are not allowed
-	if shared.IsTrue(request.QueryParam(r, "all-projects")) {
+	if allProjects {
 		return response.Forbidden(errors.New("Certificate is restricted"))
 	}
 
 	// Disallow listing resources in projects the caller does not have access to.
-	if !slices.Contains(id.Projects, request.ProjectParam(r)) {
+	if !slices.Contains(id.Projects, requestProjectName) {
 		return response.Forbidden(errors.New("Certificate is restricted"))
 	}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1767,8 +1767,6 @@ func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectN
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func imagesGet(d *Daemon, r *http.Request) response.Response {
-	projectName := request.ProjectParam(r)
-	allProjects := shared.IsTrue(r.FormValue("all-projects"))
 	filterStr := r.FormValue("filter")
 
 	recursion := util.IsRecursionRequest(r)
@@ -1777,24 +1775,22 @@ func imagesGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// ProjectParam returns default if not set
-	if allProjects && projectName != api.ProjectDefaultName {
-		return response.BadRequest(errors.New("Cannot specify a project when requesting all projects"))
-	}
-
-	s := d.State()
-	var effectiveProjectName string
-	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		var err error
-		effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)
-		return err
-	})
+	projectName, allProjects, err := request.ProjectParams(r)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	reqInfo := request.SetupContextInfo(r)
-	reqInfo.EffectiveProjectName = effectiveProjectName
+	s := d.State()
+	if !allProjects {
+		reqInfo := request.SetupContextInfo(r)
+		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			reqInfo.EffectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)
+			return err
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
 
 	// If the caller is not trusted, we only want to list public images in the default project.
 	trusted := auth.IsTrusted(r.Context())

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -247,20 +247,15 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 
 	mustLoadObjects := recursion > 0 || (recursion == 0 && clauses != nil && len(clauses.Clauses) > 0)
 
-	// Detect project mode.
-	projectName := request.QueryParam(r, "project")
-	allProjects := shared.IsTrue(r.FormValue("all-projects"))
+	projectName, allProjects, err := request.ProjectParams(r)
+	if err != nil {
+		return response.SmartError(err)
+	}
 
 	// Detect if we want to also return entitlements for each instance.
 	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeInstance, true)
 	if err != nil {
 		return response.SmartError(err)
-	}
-
-	if allProjects && projectName != "" {
-		return response.BadRequest(errors.New("Cannot specify a project when requesting all projects"))
-	} else if !allProjects && projectName == "" {
-		projectName = api.ProjectDefaultName
 	}
 
 	// Get the list and location of all instances.

--- a/lxd/network_acls.go
+++ b/lxd/network_acls.go
@@ -20,7 +20,6 @@ import (
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/util"
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
@@ -160,21 +159,13 @@ var networkACLLogCmd = APIEndpoint{
 func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	allProjects := shared.IsTrue(request.QueryParam(r, "all-projects"))
-	requestProjectName := request.QueryParam(r, "project")
-
-	// requestProjectName is only valid for project specific requests.
-	if allProjects && requestProjectName != "" {
-		return response.BadRequest(errors.New("Cannot specify a project when requesting all projects"))
+	requestProjectName, allProjects, err := request.ProjectParams(r)
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	var effectiveProjectName string
-	var err error
 	if !allProjects {
-		if requestProjectName == "" {
-			requestProjectName = api.ProjectDefaultName
-		}
-
 		// Project specific requests require an effective project, when "features.networks" is enabled this is the requested project, otherwise it is the default project.
 		effectiveProjectName, _, err = project.NetworkProject(s.DB.Cluster, requestProjectName)
 		if err != nil {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -321,7 +321,7 @@ func networksGet(d *Daemon, r *http.Request) response.Response {
 
 	// Get list of actual network interfaces on the host if the effective project is default and the caller has permission.
 	var getUnmanagedNetworks bool
-	if reqInfo.EffectiveProjectName == api.ProjectDefaultName {
+	if reqInfo.EffectiveProjectName == api.ProjectDefaultName || allProjects {
 		err := s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanViewUnmanagedNetworks)
 		if err == nil {
 			getUnmanagedNetworks = true
@@ -342,9 +342,14 @@ func networksGet(d *Daemon, r *http.Request) response.Response {
 				continue
 			}
 
+			unmanagedNetworkProject := requestProjectName
+			if allProjects {
+				unmanagedNetworkProject = api.ProjectDefaultName
+			}
+
 			// Append to the list of networks if a managed network of same name doesn't exist.
-			if !slices.Contains(networks[managed][requestProjectName], iface.Name) {
-				networks[unmanaged][requestProjectName] = append(networks[unmanaged][requestProjectName], iface.Name)
+			if !slices.Contains(networks[managed][unmanagedNetworkProject], iface.Name) {
+				networks[unmanaged][unmanagedNetworkProject] = append(networks[unmanaged][unmanagedNetworkProject], iface.Name)
 			}
 		}
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -989,9 +989,10 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 // If the network being requested is a managed network and allNodes is true then node specific config is removed.
 // Otherwise if allNodes is false then the network's local status is returned.
 func doNetworkGet(s *state.State, r *http.Request, allNodes bool, requestProjectName string, reqProjectConfig map[string]string, networkName string) (api.Network, error) {
-	var effectiveProjectName string
+	// Effective project may not be set if getting networks for all projects.
+	effectiveProjectName := requestProjectName
 	reqInfo := request.GetContextInfo(r.Context())
-	if reqInfo != nil {
+	if reqInfo != nil && reqInfo.EffectiveProjectName != "" {
 		effectiveProjectName = reqInfo.EffectiveProjectName
 	}
 

--- a/lxd/request/parse.go
+++ b/lxd/request/parse.go
@@ -4,9 +4,26 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
+
+// ProjectParams returns the project name and the value of the all projects query parameter. It returns an
+// [api.StatusError] with [http.StatusBadRequest] if both parameters are specified.
+func ProjectParams(r *http.Request) (string, bool, error) {
+	projectName := QueryParam(r, "project")
+	allProjects := shared.IsTrue(QueryParam(r, "all-projects"))
+
+	// The requested project name is only valid for project specific requests.
+	if allProjects && projectName != "" {
+		return "", false, api.StatusErrorf(http.StatusBadRequest, "Cannot specify a project when requesting all projects")
+	} else if !allProjects && projectName == "" {
+		projectName = api.ProjectDefaultName
+	}
+
+	return projectName, allProjects, nil
+}
 
 // ProjectParam returns the project query parameter from the given request or "default" if parameter is not set.
 func ProjectParam(request *http.Request) string {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -669,13 +669,9 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Detect project mode.
-	requestProjectName := request.QueryParam(r, "project")
-	allProjects := shared.IsTrue(request.QueryParam(r, "all-projects"))
-
-	if allProjects && requestProjectName != "" {
-		return response.SmartError(api.StatusErrorf(http.StatusBadRequest, "Cannot specify a project when requesting all projects"))
-	} else if !allProjects && requestProjectName == "" {
-		requestProjectName = api.ProjectDefaultName
+	requestProjectName, allProjects, err := request.ProjectParams(r)
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	var dbVolumes []*db.StorageVolume

--- a/test/includes/ovn.sh
+++ b/test/includes/ovn.sh
@@ -1,0 +1,51 @@
+ovn_enabled() {
+  [ -n "${LXD_OVN_NB_CONNECTION:-}" ]
+}
+
+setup_ovn() {
+  # Not available, fail.
+  if ! ovn_enabled; then
+    false
+  fi
+
+  # Already configured.
+  if [ "$(lxc config get network.ovn.northbound_connection)" != "" ]; then
+    return
+  fi
+
+  if [[ "${LXD_OVN_NB_CONNECTION}" =~ ^ssl: ]]; then
+    # If the connection uses SSL we have more required environment variables.
+    # Set the connection string and client cert, key, and CA cert.
+    lxc config set network.ovn.northbound_connection="${LXD_OVN_NB_CONNECTION}" network.ovn.client_cert="$(< "${LXD_OVN_NB_CLIENT_CRT_FILE}")" network.ovn.client_key="$(< "${LXD_OVN_NB_CLIENT_KEY_FILE}")" network.ovn.ca_cert="$(< "${LXD_OVN_NB_CA_CRT_FILE}")"
+  else
+    # Otherwise just set the connection.
+    lxc config set network.ovn.northbound_connection "${LXD_OVN_NB_CONNECTION}"
+  fi
+}
+
+unset_ovn_configuration() {
+  if ! ovn_enabled; then
+    return
+  fi
+
+  # Unset the config keys. Can't unset multiple values at once (yet - see https://github.com/canonical/lxd/issues/15933).
+  lxc config set network.ovn.northbound_connection="" network.ovn.client_cert="" network.ovn.client_key="" network.ovn.ca_cert=""
+}
+
+clear_ovn_nb_db() {
+  # Not configured - don't modify host.
+  if ! ovn_enabled; then
+    return
+  fi
+
+  # List tables with ovsdb client.
+  for tbl in $(ovsdb-client list-tables "${LXD_OVN_NB_CONNECTION}" --format csv --no-headings); do
+    # Don't modify NB_Global (should always have one row).
+    if [ "${tbl}" = "NB_Global" ]; then
+      continue
+    fi
+
+    # Delete any remaining data.
+    ovn-nbctl --format csv --no-headings list "${tbl}" | cut -d, -f1 | ovn-nbctl destroy "${tbl}"
+  done
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -190,6 +190,7 @@ cleanup() {
     [ -e "${LXD_TEST_IMAGE:-}" ] && rm "${LXD_TEST_IMAGE}"
 
     kill_oidc
+    clear_ovn_nb_db
     mountpoint -q "${TEST_DIR}/dev" && umount -l "${TEST_DIR}/dev"
     cleanup_lxds "$TEST_DIR"
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -231,8 +231,10 @@ fine_grained: true"
 
   # Perform access check compatibility with project feature flags
   auth_project_features "oidc"
-  entities_enrichment_with_entitlements
   LXD_CONF="${LXD_CONF2}" auth_project_features "tls"
+
+  # Entitlement enrichment
+  entities_enrichment_with_entitlements
 
   # The OIDC identity should be able to delete themselves without any permissions.
   lxc auth identity group remove oidc/test-user@example.com test-group

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -221,6 +221,7 @@ fine_grained: true"
   lxc auth group permission remove test-group server viewer
   lxc auth group permission remove test-group server project_manager
 
+  # Check storage pool used-by URLs
   storage_pool_used_by "oidc"
   LXD_CONF="${LXD_CONF2}" storage_pool_used_by "tls"
 

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -944,8 +944,8 @@ run_projects_restrictions() {
   # Check with restricted unset and restricted.devices.nic unset that managed & unmanaged networks are accessible.
   lxc network list | grep -F "${netManaged}"
   lxc network list | grep -F "${netUnmanaged}"
-  lxc network show ${netManaged}
-  lxc network show ${netUnmanaged}
+  lxc network show "${netManaged}"
+  lxc network show "${netUnmanaged}"
   if [ "${remote}" = "local" ] || [ "${remote}" = "localhost" ] || [ "${remote}" = "fine-grained" ]; then
     lxc network list --all-projects | grep -F "${netManaged}"
     lxc network list --all-projects | grep -F "${netUnmanaged}"
@@ -957,8 +957,8 @@ run_projects_restrictions() {
   lxc project set local:p1 restricted.devices.nic=block
   lxc network list | grep -F "${netManaged}"
   lxc network list | grep -F "${netUnmanaged}"
-  lxc network show ${netManaged}
-  lxc network show ${netUnmanaged}
+  lxc network show "${netManaged}"
+  lxc network show "${netUnmanaged}"
   if [ "${remote}" = "local" ] || [ "${remote}" = "localhost" ] || [ "${remote}" = "fine-grained" ]; then
     lxc network list --all-projects | grep -F "${netManaged}"
     lxc network list --all-projects | grep -F "${netUnmanaged}"
@@ -969,9 +969,9 @@ run_projects_restrictions() {
   # Check with restricted=true and restricted.devices.nic=block that managed & unmanaged networks are inaccessible.
   lxc project set local:p1 restricted=true
   ! lxc network list | grep -F "${netManaged}"|| false
-  ! lxc network show ${netManaged} || false
+  ! lxc network show "${netManaged}" || false
   ! lxc network list | grep -F "${netUnmanaged}"|| false
-  ! lxc network show ${netUnmanaged} || false
+  ! lxc network show "${netUnmanaged}" || false
   if [ "${remote}" = "local" ] || [ "${remote}" = "localhost" ] || [ "${remote}" = "fine-grained" ]; then
     # Can view when performing an --all-projects request because the network is actually defined in the default project,
     # and the default project is not restricted.
@@ -985,7 +985,7 @@ run_projects_restrictions() {
   # unmanaged networks are inaccessible.
   lxc project set local:p1 restricted.devices.nic=managed
   lxc network list | grep -F "${netManaged}"
-  lxc network show ${netManaged}
+  lxc network show "${netManaged}"
   ! lxc network list | grep -F "${netUnmanaged}"|| false
   if [ "${remote}" = "local" ] || [ "${remote}" = "localhost" ] || [ "${remote}" = "fine-grained" ]; then
     # Can view when performing an --all-projects request because the network is actually defined in the default project,
@@ -1001,8 +1001,8 @@ run_projects_restrictions() {
   lxc project set local:p1 restricted.devices.nic=allow
   lxc project set local:p1 restricted.networks.access=foo
   ! lxc network list | grep -F "${netManaged}"|| false
-  ! lxc network show ${netManaged} || false
-  ! lxc network info ${netManaged}|| false
+  ! lxc network show "${netManaged}" || false
+  ! lxc network info "${netManaged}" || false
   if [ "${remote}" = "local" ] || [ "${remote}" = "localhost" ] || [ "${remote}" = "fine-grained" ]; then
     # Can view when performing an --all-projects request because the network is actually defined in the default project,
     # and the default project is not restricted.
@@ -1012,8 +1012,8 @@ run_projects_restrictions() {
   fi
 
   ! lxc network list | grep -F "${netUnmanaged}"|| false
-  ! lxc network show ${netUnmanaged} || false
-  ! lxc network info ${netUnmanaged}|| false
+  ! lxc network show "${netUnmanaged}" || false
+  ! lxc network info "${netUnmanaged}" || false
   if [ "${remote}" = "local" ] || [ "${remote}" = "localhost" ] || [ "${remote}" = "fine-grained" ]; then
     # Can view when performing an --all-projects request because the network is actually defined in the default project,
     # and the default project is not restricted.
@@ -1022,10 +1022,10 @@ run_projects_restrictions() {
     ! lxc network list --all-projects || false
   fi
 
-  ! lxc network set ${netManaged} user.foo=bah || false
-  ! lxc network get ${netManaged} ipv4.address || false
-  ! lxc network info ${netManaged}|| false
-  ! lxc network delete ${netManaged} || false
+  ! lxc network set "${netManaged}" user.foo=bah || false
+  ! lxc network get "${netManaged}" ipv4.address || false
+  ! lxc network info "${netManaged}" || false
+  ! lxc network delete "${netManaged}" || false
 
   ! lxc profile device add default eth0 nic nictype=bridge parent=netManaged || false
   ! lxc profile device add default eth0 nic nictype=bridge parent=netUnmanaged || false


### PR DESCRIPTION
I noticed that multiple handlers were performing close to identical logic to get the project and all-projects parameters - returning an error if both are set.

This just factors it out into one place.