### PR TITLE
test: Omit escape sequences from prompt length in inspect subshell.

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -137,10 +137,10 @@ cleanup() {
     if [ "${TEST_RESULT}" != "success" ]; then
       echo "==> FAILED TEST: ${TEST_CURRENT#test_} (${TEST_CURRENT_DESCRIPTION})"
       # red
-      PS1_PREFIX="\033[0;31mLXD-TEST\033[0m"
+      PS1_PREFIX="\[\033[0;31m\]LXD-TEST\[\033[0m\]"
     else
       # green
-      PS1_PREFIX="\033[0;32mLXD-TEST\033[0m"
+      PS1_PREFIX="\[\033[0;32m\]LXD-TEST\[\033[0m\]"
     fi
     echo "==> Test result: ${TEST_RESULT}"
 


### PR DESCRIPTION
Wraps the escape sequences (colours) so that they don't contribute to what bash thinks are the number of characters in the prompt. This seems to fix text wrapping in the LXD_INSPECT subshell for me.