### PR TITLE
golangci: Disable package name checks in var-naming revive checker (stable-5.21)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,12 +31,6 @@ linters:
         - name: unchecked-type-assertion
           arguments:
             - acceptIgnoredAssertionResult: true
-        # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-naming
-        - name: var-naming
-          arguments: # The arguments here are quite odd looking. See the rule description.
-            - []
-            - []
-            - - upperCaseConst: true
         # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#early-return
         - name: early-return
         # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redundant-import-alias


### PR DESCRIPTION
It was failing on the lxd/util package naming which we dont want to change in this series.