### PR TITLE
Apply `modernize` changes

### DIFF
--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -179,8 +179,9 @@ func (c *Config) getPublicRemoteByName(name string) (*Remote, error) {
 // connectRemote returns a lxd.InstanceServer for the given Remote and configures it with the given lxd.ConnectionArgs.
 func (c *Config) connectRemote(remote Remote, args *lxd.ConnectionArgs) (lxd.InstanceServer, error) {
 	// Unix socket
-	if strings.HasPrefix(remote.Addr, "unix:") {
-		d, err := lxd.ConnectLXDUnix(strings.TrimPrefix(strings.TrimPrefix(remote.Addr, "unix:"), "//"), args)
+	after, ok := strings.CutPrefix(remote.Addr, "unix:")
+	if ok {
+		d, err := lxd.ConnectLXDUnix(strings.TrimPrefix(after, "//"), args)
 		if err != nil {
 			var netErr *net.OpError
 
@@ -245,8 +246,9 @@ func (c *Config) GetImageServer(name string) (lxd.ImageServer, error) {
 	}
 
 	// Unix socket
-	if strings.HasPrefix(remote.Addr, "unix:") {
-		d, err := lxd.ConnectLXDUnix(strings.TrimPrefix(strings.TrimPrefix(remote.Addr, "unix:"), "//"), args)
+	after, ok := strings.CutPrefix(remote.Addr, "unix:")
+	if ok {
+		d, err := lxd.ConnectLXDUnix(strings.TrimPrefix(after, "//"), args)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -517,9 +517,7 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 		// Copy the old config so that the update triggers have access to it.
 		// In this case it will not be used as we are not changing any node values.
 		oldNodeConfig := make(map[string]any)
-		for k, v := range s.LocalConfig.Dump() {
-			oldNodeConfig[k] = v
-		}
+		maps.Copy(oldNodeConfig, s.LocalConfig.Dump())
 
 		// Run any update triggers.
 		err = doAPI10UpdateTriggers(d, nil, changed, oldNodeConfig, s.LocalConfig, config)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -6,6 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -849,9 +850,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		// Copy the old config so that the update triggers have access to it.
 		// In this case it will not be used as we are not changing any node values.
 		oldNodeConfig := make(map[string]any)
-		for k, v := range s.LocalConfig.Dump() {
-			oldNodeConfig[k] = v
-		}
+		maps.Copy(oldNodeConfig, s.LocalConfig.Dump())
 
 		err = doAPI10UpdateTriggers(d, nil, changes, oldNodeConfig, nodeConfig, currentClusterConfig)
 		if err != nil {

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -489,8 +489,8 @@ func (d *common) deviceVolatileGetFunc(devName string) func() map[string]string 
 		volatile := make(map[string]string)
 		prefix := fmt.Sprintf("volatile.%s.", devName)
 		for k, v := range d.localConfig {
-			if strings.HasPrefix(k, prefix) {
-				volatile[strings.TrimPrefix(k, prefix)] = v
+			if after, ok := strings.CutPrefix(k, prefix); ok {
+				volatile[after] = v
 			}
 		}
 		return volatile

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -489,7 +489,8 @@ func (d *common) deviceVolatileGetFunc(devName string) func() map[string]string 
 		volatile := make(map[string]string)
 		prefix := fmt.Sprintf("volatile.%s.", devName)
 		for k, v := range d.localConfig {
-			if after, ok := strings.CutPrefix(k, prefix); ok {
+			after, ok := strings.CutPrefix(k, prefix)
+			if ok {
 				volatile[after] = v
 			}
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6090,7 +6090,6 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			}
 
 			for _, name := range offerHeader.SnapshotNames {
-				name := name // Local var.
 				base := instance.SnapshotToProtobuf(apiInstSnap)
 				baseName := name
 				base.Name = &baseName

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7343,7 +7343,6 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			}
 
 			for _, name := range offerHeader.SnapshotNames {
-				name := name // Local var.
 				base := instance.SnapshotToProtobuf(apiInstSnap)
 				baseName := name
 				base.Name = &baseName

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -379,7 +379,6 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 					}
 
 					for _, apiInst := range apiInsts {
-						apiInst := apiInst // Local variable for append.
 						resultFullListAppend(&api.InstanceFull{Instance: apiInst})
 					}
 
@@ -396,7 +395,6 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 				}
 
 				for _, c := range cs {
-					c := c // Local variable for append.
 					resultFullListAppend(&c)
 				}
 			}(memberAddress, instances)

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1177,7 +1177,6 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		if len(req.Profiles) > 0 {
 			profileFilters := make([]dbCluster.ProfileFilter, 0, len(req.Profiles))
 			for _, profileName := range req.Profiles {
-				profileName := profileName
 				profileFilters = append(profileFilters, dbCluster.ProfileFilter{
 					Project: &profileProject,
 					Name:    &profileName,

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -1066,7 +1066,7 @@ func (n *common) forwardValidate(listenAddress net.IP, forward api.NetworkForwar
 				return nil, fmt.Errorf("Invalid listen port in port specification %d: %w", portSpecID, err)
 			}
 
-			for i := int64(0); i < portRange; i++ {
+			for i := range portRange {
 				port := portFirst + i
 				_, found := listenPorts[portSpec.Protocol][port]
 				if found {
@@ -1091,7 +1091,7 @@ func (n *common) forwardValidate(listenAddress net.IP, forward api.NetworkForwar
 					return nil, fmt.Errorf("Invalid target port in port specification %d", portSpecID)
 				}
 
-				for i := int64(0); i < portRange; i++ {
+				for i := range portRange {
 					port := portFirst + i
 					portMap.target.ports = append(portMap.target.ports, uint64(port))
 				}
@@ -1353,7 +1353,7 @@ func (n *common) loadBalancerValidate(listenAddress net.IP, forward api.NetworkL
 				return nil, fmt.Errorf("Invalid backend port specification %d in backend specification %d: %w", portSpecID, backendSpecID, err)
 			}
 
-			for i := int64(0); i < portRange; i++ {
+			for i := range portRange {
 				port := portFirst + i
 				target.ports = append(target.ports, uint64(port))
 			}
@@ -1387,7 +1387,7 @@ func (n *common) loadBalancerValidate(listenAddress net.IP, forward api.NetworkL
 				return nil, fmt.Errorf("Invalid listen port in port specification %d: %w", portSpecID, err)
 			}
 
-			for i := int64(0); i < portRange; i++ {
+			for i := range portRange {
 				port := portFirst + i
 				_, found := listenPorts[portSpec.Protocol][port]
 				if found {

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -1449,7 +1449,7 @@ func ProxyParseAddr(data string) (*deviceConfig.ProxyAddress, error) {
 			return nil, err
 		}
 
-		for i := int64(0); i < portRange; i++ {
+		for i := range portRange {
 			newProxyAddr.Ports = append(newProxyAddr.Ports, uint64(portFirst+i))
 		}
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -302,8 +302,8 @@ func (o *OVN) xbctl(southbound bool, extraArgs ...string) (string, error) {
 		cmd = "ovn-sbctl"
 	}
 
-	if strings.HasPrefix(dbAddr, "unix:") {
-		dbAddr = "unix:" + shared.HostPathFollow(strings.TrimPrefix(dbAddr, "unix:"))
+	if after, ok := strings.CutPrefix(dbAddr, "unix:"); ok {
+		dbAddr = "unix:" + shared.HostPathFollow(after)
 	}
 
 	// Figure out args.

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1372,7 +1372,7 @@ func (o *OVN) LogicalSwitchPortGetDNS(portName OVNSwitchPort) (OVNDNSUUID, []net
 	// 2. <IP>
 	// 3. <reverse IP>.in-addr.arpa=<name>
 	// We are only interested in getting the IPs in field formats 1 and 2.
-	for _, recordField := range strings.Fields(recordFields) {
+	for recordField := range strings.FieldsSeq(recordFields) {
 		a, b, found := strings.Cut(recordField, "=")
 		if found {
 			a = b // Get IP part of <name>=<IP> type fields.

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -302,7 +302,8 @@ func (o *OVN) xbctl(southbound bool, extraArgs ...string) (string, error) {
 		cmd = "ovn-sbctl"
 	}
 
-	if after, ok := strings.CutPrefix(dbAddr, "unix:"); ok {
+	after, ok := strings.CutPrefix(dbAddr, "unix:")
+	if ok {
 		dbAddr = "unix:" + shared.HostPathFollow(after)
 	}
 

--- a/lxd/resources/gpu.go
+++ b/lxd/resources/gpu.go
@@ -288,10 +288,10 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 			entryName := entry.Name()
 			entryPath := filepath.Join(drmPath, entryName)
 
-			if strings.HasPrefix(entryName, "card") {
+			after, ok := strings.CutPrefix(entryName, "card")
+			if ok {
 				// Get the card ID
-				idStr := strings.TrimPrefix(entryName, "card")
-				id, err := strconv.ParseUint(idStr, 10, 64)
+				id, err := strconv.ParseUint(after, 10, 64)
 				if err != nil {
 					return fmt.Errorf("Failed to parse card number: %w", err)
 				}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -3350,8 +3350,9 @@ func (d *zfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, e
 	// Filter only the snapshots.
 	snapshots := []string{}
 	for _, entry := range entries {
-		if strings.HasPrefix(entry, "@snapshot-") {
-			snapshots = append(snapshots, strings.TrimPrefix(entry, "@snapshot-"))
+		after, ok := strings.CutPrefix(entry, "@snapshot-")
+		if ok {
+			snapshots = append(snapshots, after)
 		}
 	}
 
@@ -3385,9 +3386,10 @@ func (d *zfs) restoreVolume(vol Volume, snapVol Volume, migration bool, op *oper
 			continue
 		}
 
-		if strings.HasPrefix(entry, "@snapshot-") {
+		after, ok := strings.CutPrefix(entry, "@snapshot-")
+		if ok {
 			// Located a normal snapshot following ours.
-			snapshots = append(snapshots, strings.TrimPrefix(entry, "@snapshot-"))
+			snapshots = append(snapshots, after)
 			continue
 		}
 

--- a/lxd/storage/s3/headers.go
+++ b/lxd/storage/s3/headers.go
@@ -8,26 +8,28 @@ import (
 func AuthorizationHeaderAccessKey(authorizationHeader string) string {
 	// Parses an Authorization header as below, trying to extract the access key "PRL470D7Q93X1ZA1L82X".
 	// AWS4-HMAC-SHA256 Credential=PRL470D7Q93X1ZA1L82X/20220825/US/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=d8fdaf67c5072d4ff7ac56e4529e66fb08255aaa79193b212cba4670d058fade
-	if strings.HasPrefix(authorizationHeader, "AWS4-HMAC-SHA256") {
-		authHeaderParts := strings.Split(strings.TrimSpace(strings.TrimPrefix(authorizationHeader, "AWS4-HMAC-SHA256")), ",")
-		if strings.HasPrefix(authHeaderParts[0], "Credential=") {
-			_, after, found := strings.Cut(authHeaderParts[0], "=")
-			if found {
-				credParts := strings.Split(after, "/")
-				credPartsLen := len(credParts)
-				if credPartsLen >= 5 {
-					// The access key can contain / characters, so perform a reverse range search.
-					return strings.Join(credParts[:credPartsLen-4], "/")
-				}
+	authHeaders, found := strings.CutPrefix(authorizationHeader, "AWS4-HMAC-SHA256")
+	if found {
+		authHeaderParts := strings.Split(strings.TrimSpace(authHeaders), ",")
+		credential, found := strings.CutPrefix(authHeaderParts[0], "Credential=")
+		if found {
+			credParts := strings.Split(credential, "/")
+			credPartsLen := len(credParts)
+			if credPartsLen >= 5 {
+				// The access key can contain / characters, so perform a reverse range search.
+				return strings.Join(credParts[:credPartsLen-4], "/")
 			}
 		}
-	} else if strings.HasPrefix(authorizationHeader, "AWS") {
-		// Parses an older Authorization header as below, to extract the access key "PRL470D7Q93X1ZA1L82X".
-		// AWS PRL470D7Q93X1ZA1L82X:dC5GcyRFCyQIr+y9BdpAwBjkOK0=
-		authHeaderParts := strings.Split(strings.TrimSpace(strings.TrimPrefix(authorizationHeader, "AWS")), ":")
-		authHeaderPartsLen := len(authHeaderParts)
-		if authHeaderPartsLen > 1 {
-			return strings.Join(authHeaderParts[:authHeaderPartsLen-1], ":")
+	} else {
+		authHeaders, found := strings.CutPrefix(authorizationHeader, "AWS")
+		if found {
+			// Parses an older Authorization header as below, to extract the access key "PRL470D7Q93X1ZA1L82X".
+			// AWS PRL470D7Q93X1ZA1L82X:dC5GcyRFCyQIr+y9BdpAwBjkOK0=
+			authHeaderParts := strings.Split(strings.TrimSpace(authHeaders), ":")
+			authHeaderPartsLen := len(authHeaderParts)
+			if authHeaderPartsLen > 1 {
+				return strings.Join(authHeaderParts[:authHeaderPartsLen-1], ":")
+			}
 		}
 	}
 

--- a/lxd/storage/s3/headers_test.go
+++ b/lxd/storage/s3/headers_test.go
@@ -1,0 +1,32 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAuthorizationHeaderAccessKey tests the AuthorizationHeaderAccessKey function.
+func TestAuthorizationHeaderAccessKey(t *testing.T) {
+	// Test with a valid AWS4-HMAC-SHA256 Authorization header.
+	headers := "AWS4-HMAC-SHA256 Credential=PRL470D7Q93X1ZA1L82X/20220825/US/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=d8fdaf67c5072d4ff7ac56e4529e66fb08255aaa79193b212cba4670d058fade"
+	expected := "PRL470D7Q93X1ZA1L82X"
+	accessKey := AuthorizationHeaderAccessKey(headers)
+	assert.Equal(t, expected, accessKey, "Expected access key to match for AWS4-HMAC-SHA256 header")
+
+	// Test with slightly broken AWS4-HMAC-SHA256 Authorization header.
+	headers = "AWS4-HMAC-SHA256 Credential=PRL470D7Q93X1ZA1L82X_20220825/US/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=d8fdaf67c5072d4ff7ac56e4529e66fb08255aaa79193b212cba4670d058fade"
+	accessKey = AuthorizationHeaderAccessKey(headers)
+	assert.Empty(t, accessKey, "Expected access key to be empty for broken AWS4-HMAC-SHA256 header")
+
+	// Test with an older AWS Authorization header.
+	headers = "AWS PRL470D7Q93X1ZA1L82X:dC5GcyRFCyQIr+y9BdpAwBjkOK0="
+	expected = "PRL470D7Q93X1ZA1L82X"
+	accessKey = AuthorizationHeaderAccessKey(headers)
+	assert.Equal(t, expected, accessKey, "Expected access key to match for older AWS header")
+
+	// Test with an invalid Authorization header.
+	headers = "InvalidHeaderFormat"
+	accessKey = AuthorizationHeaderAccessKey(headers)
+	assert.Empty(t, accessKey, "Expected access key to be empty for invalid header")
+}

--- a/shared/util.go
+++ b/shared/util.go
@@ -1485,8 +1485,9 @@ func JoinTokenDecode(input string) (*api.ClusterMemberJoinToken, error) {
 // TargetDetect returns either target node or group based on the provided prefix:
 // An invocation with `target=h1` returns "h1", "" and `target=@g1` returns "", "g1".
 func TargetDetect(target string) (targetNode string, targetGroup string) {
-	if strings.HasPrefix(target, "@") {
-		targetGroup = strings.TrimPrefix(target, "@")
+	after, found := strings.CutPrefix(target, "@")
+	if found {
+		targetGroup = after
 	} else {
 		targetNode = target
 	}

--- a/test/mini-oidc/storage/storage.go
+++ b/test/mini-oidc/storage/storage.go
@@ -698,8 +698,8 @@ func (s *Storage) ValidateTokenExchangeRequest(ctx context.Context, request op.T
 			continue
 		}
 
-		if strings.HasPrefix(scope, CustomScopeImpersonatePrefix) {
-			subject := strings.TrimPrefix(scope, CustomScopeImpersonatePrefix)
+		subject, found := strings.CutPrefix(scope, CustomScopeImpersonatePrefix)
+		if found {
 			request.SetSubject(subject)
 		}
 


### PR DESCRIPTION
The initial changes were done mechanically with:

```
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...
```

Some proposed changes were **NOT APPLIED** as I was unsure if they were safe:

```diff
 // purePort represents a network interface in Pure Storage.
 type pureNetworkInterface struct {
        Name     string `json:"name"`
        Ethernet struct {
                Address string `json:"address,omitempty"`
-       } `json:"eth,omitempty"`
+       } `json:"eth"`
 }
```

And

```diff
diff --git i/lxd/instance/drivers/driver_lxc.go w/lxd/instance/drivers/driver_lxc.go
index b59ccdeb5d..86465e7b62 100644
--- i/lxd/instance/drivers/driver_lxc.go
+++ w/lxd/instance/drivers/driver_lxc.go
@@ -6083,21 +6083,21 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
                                ExpiresAt:    time.Time{},
                                LastUsedAt:   d.LastUsedDate(),
                                Config:       d.LocalConfig(),
                                Devices:      d.LocalDevices().CloneNative(),
                                Ephemeral:    d.IsEphemeral(),
                                Stateful:     d.IsStateful(),
                                Profiles:     profileNames,
                        }
 
                        for _, name := range offerHeader.SnapshotNames {
-                               name := name // Local var.
+                               // Local var.
                                base := instance.SnapshotToProtobuf(apiInstSnap)
                                baseName := name
                                base.Name = &baseName
                                snapshots = append(snapshots, base)
                        }
                } else {
                        snapshots = offerHeader.Snapshots
                }
 
                // Default to not expecting to receive the final rootfs sync.
```

And some were manually modified to better fit with the LXD code style. As such, `modernize` produced diffs like this:

```diff
 func TargetDetect(target string) (targetNode string, targetGroup string) {
-       if strings.HasPrefix(target, "@") {
-               targetGroup = strings.TrimPrefix(target, "@")
+       if after, ok := strings.CutPrefix(target, "@"); ok {
+               targetGroup = after
        } else {
                targetNode = target
        }
 
        return targetNode, targetGroup
 }
```

Which needed to be altered like this instead:

```diff
 // TargetDetect returns either target node or group based on the provided prefix:
 // An invocation with `target=h1` returns "h1", "" and `target=@g1` returns "", "g1".
 func TargetDetect(target string) (targetNode string, targetGroup string) {
-       if strings.HasPrefix(target, "@") {
-               targetGroup = strings.TrimPrefix(target, "@")
+       after, found := strings.CutPrefix(target, "@")
+       if found {
+               targetGroup = after
        } else {
                targetNode = target
        }
 
        return targetNode, targetGroup
 }
```

Lastly, the `AuthorizationHeaderAccessKey()` received more manual edits due to `modernize` incompatible code style. This should be reviewed more carefully.