### PR TITLE
Initial refactor of image API handlers

### DIFF
--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -393,6 +393,15 @@ func getImgInfo(d lxd.InstanceServer, conf *config.Config, imgRemote string, ins
 		if err != nil {
 			return nil, nil, err
 		}
+
+		// If the image server is a private LXD server, conf.GetImageServer will set the project of the image server to
+		// the value of `--project`. This means for `lxc init A:img B:inst --project foo` the client will try to get
+		// "img" from project "foo" and not the default project. Since there is no way to specify the project on the image
+		// remote we reset it to the default project.
+		privateServer, ok := imgRemoteServer.(*lxd.ProtocolLXD)
+		if ok {
+			imgRemoteServer = privateServer.UseProject(api.ProjectDefaultName)
+		}
 	}
 
 	// Optimisation for simplestreams

--- a/lxd/db/cluster/images.go
+++ b/lxd/db/cluster/images.go
@@ -23,6 +23,7 @@ import (
 //go:generate mapper stmt -e image objects
 //go:generate mapper stmt -e image objects-by-ID
 //go:generate mapper stmt -e image objects-by-Project
+//go:generate mapper stmt -e image objects-by-Project-and-Fingerprint
 //go:generate mapper stmt -e image objects-by-Project-and-Cached
 //go:generate mapper stmt -e image objects-by-Project-and-Public
 //go:generate mapper stmt -e image objects-by-Fingerprint

--- a/lxd/db/db_internal_test.go
+++ b/lxd/db/db_internal_test.go
@@ -242,7 +242,7 @@ func (s *dbTestSuite) Test_ImageExists_false() {
 
 func (s *dbTestSuite) Test_GetImageAlias_alias_exists() {
 	_ = s.db.Transaction(context.Background(), func(ctx context.Context, tx *ClusterTx) error {
-		_, alias, err := tx.GetImageAlias(ctx, "default", "somealias", true)
+		_, _, alias, err := tx.GetImageAlias(ctx, "default", "somealias", true)
 		s.NoError(err)
 		s.Equal("fingerprint", alias.Target)
 
@@ -252,7 +252,7 @@ func (s *dbTestSuite) Test_GetImageAlias_alias_exists() {
 
 func (s *dbTestSuite) Test_GetImageAlias_alias_does_not_exists() {
 	_ = s.db.Transaction(context.Background(), func(ctx context.Context, tx *ClusterTx) error {
-		_, _, err := tx.GetImageAlias(ctx, "default", "whatever", true)
+		_, _, _, err := tx.GetImageAlias(ctx, "default", "whatever", true)
 		s.True(api.StatusErrorCheck(err, http.StatusNotFound))
 
 		return nil
@@ -264,7 +264,7 @@ func (s *dbTestSuite) Test_CreateImageAlias() {
 		err := tx.CreateImageAlias(ctx, "default", "Chaosphere", 1, "Someone will like the name")
 		s.NoError(err)
 
-		_, alias, err := tx.GetImageAlias(ctx, "default", "Chaosphere", true)
+		_, _, alias, err := tx.GetImageAlias(ctx, "default", "Chaosphere", true)
 		s.NoError(err)
 		s.Equal("fingerprint", alias.Target)
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -4207,16 +4207,12 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// Verify the auth method in the request context to determine if the request comes from the /dev/lxd socket.
-	authMethod, _ := auth.GetAuthenticationMethodFromCtx(r.Context())
-	isDevLXDQuery := authMethod == auth.AuthenticationMethodDevLXD
-
 	secret := r.FormValue("secret")
 	trusted := auth.IsTrusted(r.Context())
 
 	// Unauthenticated remote clients that do not provide a secret may only view public images.
 	// For devlxd, we allow querying for private images. We'll subsequently perform additional access checks.
-	publicOnly := !trusted && secret == "" && !isDevLXDQuery
+	publicOnly := !trusted && secret == ""
 
 	// Get the image. We need to do this before the permission check because the URL in the permission check will not
 	// work with partial fingerprints.
@@ -4260,20 +4256,6 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	if isDevLXDQuery {
-		// A devlxd query must contain the full fingerprint of the image (no partials).
-		if fingerprint != imgInfo.Fingerprint {
-			return response.NotFound(nil)
-		}
-
-		// A devlxd query must be for a public or cached image.
-		if !imgInfo.Public && !imgInfo.Cached {
-			return response.NotFound(nil)
-		}
-
-		userCanViewImage = true
-	}
-
 	if !userCanViewImage {
 		if imgInfo.Public {
 			// If the image is public any client can view it.
@@ -4297,12 +4279,15 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 		return response.NotFound(nil)
 	}
 
+	return imageExportFiles(r.Context(), s, imgInfo)
+}
+
+func imageExportFiles(ctx context.Context, s *state.State, imgInfo *api.Image) response.Response {
 	var address string
-
-	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Check if the image is only available on another node.
+		var err error
 		address, err = tx.LocateImage(ctx, imgInfo.Fingerprint)
-
 		return err
 	})
 	if err != nil {
@@ -4311,7 +4296,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 
 	if address != "" {
 		// Forward the request to the other node
-		client, err := cluster.Connect(r.Context(), address, s.Endpoints.NetworkCert(), s.ServerCert(), false)
+		client, err := cluster.Connect(ctx, address, s.Endpoints.NetworkCert(), s.ServerCert(), false)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -4354,8 +4339,8 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 		files[1].Path = rootfsPath
 		files[1].Filename = filename
 
-		requestor := request.CreateRequestor(r.Context())
-		s.Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(imgInfo.Fingerprint, projectName, requestor, nil))
+		requestor := request.CreateRequestor(ctx)
+		s.Events.SendLifecycle(imgInfo.Project, lifecycle.ImageRetrieved.Event(imgInfo.Fingerprint, imgInfo.Project, requestor, nil))
 
 		return response.FileResponse(files, nil)
 	}
@@ -4365,8 +4350,8 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 	files[0].Path = imagePath
 	files[0].Filename = filename
 
-	requestor := request.CreateRequestor(r.Context())
-	s.Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(imgInfo.Fingerprint, projectName, requestor, nil))
+	requestor := request.CreateRequestor(ctx)
+	s.Events.SendLifecycle(imgInfo.Project, lifecycle.ImageRetrieved.Event(imgInfo.Fingerprint, imgInfo.Project, requestor, nil))
 
 	return response.FileResponse(files, nil)
 }

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -119,6 +119,22 @@ var imageAliasCmd = APIEndpoint{
 	Put:    APIEndpointAction{Handler: imageAliasPut, AccessHandler: imageAliasAccessHandler(auth.EntitlementCanEdit)},
 }
 
+// validateImageFingerprintPrefix validates that the given string is at least 12 characters long contains only lowercase
+// hex characters.
+func validateImageFingerprintPrefix(prefix string) error {
+	if len(prefix) < 12 {
+		return api.NewStatusError(http.StatusBadRequest, "Image fingerprint prefix must contain 12 characters or more")
+	}
+
+	for _, b := range []byte(prefix) {
+		if (b < '0' || b > '9') && (b < 'a' || b > 'f') {
+			return api.NewStatusError(http.StatusBadRequest, "Image fingerprint prefix must contain only lowercase hexadecimal characters")
+		}
+	}
+
+	return nil
+}
+
 const ctxImageDetails request.CtxKey = "image-details"
 
 // imageDetails contains fields that are determined prior to the access check. This is set in the request context when

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1382,7 +1382,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			for _, alias := range req.Aliases {
-				_, _, err := tx.GetImageAlias(ctx, projectName, alias.Name, true)
+				_, _, _, err := tx.GetImageAlias(ctx, projectName, alias.Name, true)
 				if !response.IsNotFoundError(err) {
 					if err != nil {
 						return fmt.Errorf("Fetch image alias %q: %w", alias.Name, err)
@@ -3476,7 +3476,7 @@ func imageAliasesPost(d *Daemon, r *http.Request) response.Response {
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// This is just to see if the alias name already exists.
-		_, _, err = tx.GetImageAlias(ctx, projectName, req.Name, true)
+		_, _, _, err = tx.GetImageAlias(ctx, projectName, req.Name, true)
 		if !response.IsNotFoundError(err) {
 			if err != nil {
 				return err
@@ -3652,7 +3652,7 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 			if !recursion {
 				responseStr = append(responseStr, api.NewURL().Path(version.APIVersion, "images", "aliases", name).String())
 			} else {
-				_, alias, err := tx.GetImageAlias(ctx, projectName, name, true)
+				_, _, alias, err := tx.GetImageAlias(ctx, projectName, name, true)
 				if err != nil {
 					continue
 				}
@@ -3801,8 +3801,7 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 	var alias api.ImageAliasesEntry
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// If `userCanViewImageAlias` is false, the query will be restricted to public images only.
-		_, alias, err = tx.GetImageAlias(ctx, projectName, name, userCanViewImageAlias)
-
+		_, _, alias, err = tx.GetImageAlias(ctx, projectName, name, details.getPrivateAliases)
 		return err
 	})
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
@@ -3856,7 +3855,7 @@ func imageAliasDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		_, _, err = tx.GetImageAlias(ctx, projectName, name, true)
+		_, _, _, err = tx.GetImageAlias(ctx, projectName, name, true)
 		if err != nil {
 			return err
 		}
@@ -3936,7 +3935,7 @@ func imageAliasPut(d *Daemon, r *http.Request) response.Response {
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var imgAliasID int
 
-		imgAliasID, imgAlias, err = tx.GetImageAlias(ctx, projectName, name, true)
+		imgAliasID, _, imgAlias, err = tx.GetImageAlias(ctx, projectName, name, true)
 		if err != nil {
 			return err
 		}
@@ -4022,7 +4021,7 @@ func imageAliasPatch(d *Daemon, r *http.Request) response.Response {
 	var imgAlias api.ImageAliasesEntry
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var imgAliasID int
-		imgAliasID, imgAlias, err = tx.GetImageAlias(ctx, projectName, name, true)
+		imgAliasID, _, imgAlias, err = tx.GetImageAlias(ctx, projectName, name, true)
 		if err != nil {
 			return err
 		}
@@ -4124,7 +4123,7 @@ func imageAliasPost(d *Daemon, r *http.Request) response.Response {
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// This is just to see if the alias name already exists.
-		_, _, err := tx.GetImageAlias(ctx, projectName, req.Name, true)
+		_, _, _, err := tx.GetImageAlias(ctx, projectName, req.Name, true)
 		if !response.IsNotFoundError(err) {
 			if err != nil {
 				return err
@@ -4133,7 +4132,7 @@ func imageAliasPost(d *Daemon, r *http.Request) response.Response {
 			return api.StatusErrorf(http.StatusConflict, "Alias %q already exists", req.Name)
 		}
 
-		imgAliasID, _, err := tx.GetImageAlias(ctx, projectName, name, true)
+		imgAliasID, _, _, err := tx.GetImageAlias(ctx, projectName, name, true)
 		if err != nil {
 			return err
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -369,6 +369,10 @@ func imageGetOrExportAccessHandler(d *Daemon, r *http.Request) response.Response
 
 	// If the caller sends a secret, then that secret must be valid, regardless of other privileges.
 	if secret != "" {
+		if projectName != api.ProjectDefaultName {
+			return response.Forbidden(errors.New("Image secrets may only be used to access private images in the default project"))
+		}
+
 		// If authenticating with a secret, the caller must have the full fingerprint.
 		if details.imageFingerprintPrefix != details.image.Fingerprint {
 			return response.NotFound(nil)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -4650,6 +4650,14 @@ func imageSecret(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	if details.image.Public {
+		return response.BadRequest(errors.New("Can't create an image secret for public images"))
+	}
+
+	if details.requestProjectName != api.ProjectDefaultName {
+		return response.BadRequest(errors.New("Can't create an image secret for images that are not in the default project"))
+	}
+
 	return createTokenResponse(s, r, details.requestProjectName, details.image.Fingerprint, nil)
 }
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -154,6 +154,11 @@ func addImageDetailsToRequestContext(s *state.State, r *http.Request) (*imageDet
 		return nil, err
 	}
 
+	err = validateImageFingerprintPrefix(imageFingerprintPrefix)
+	if err != nil {
+		return nil, err
+	}
+
 	requestProjectName := request.ProjectParam(r)
 	effectiveProjectName := requestProjectName
 	var imageID int

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -505,7 +505,7 @@ func ResolveImage(ctx context.Context, tx *db.ClusterTx, projectName string, sou
 			return source.Alias, nil
 		}
 
-		_, alias, err := tx.GetImageAlias(ctx, projectName, source.Alias, true)
+		_, _, alias, err := tx.GetImageAlias(ctx, projectName, source.Alias, true)
 		if err != nil {
 			return "", err
 		}

--- a/test/main.sh
+++ b/test/main.sh
@@ -471,6 +471,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_image_import_existing_alias "import existing image from alias"
     run_test test_image_refresh "image refresh"
     run_test test_image_acl "image acl"
+    run_test test_images_public "public images"
     run_test test_cloud_init "cloud-init"
     run_test test_exec "exec"
     run_test test_exec_exit_code "exec exit code"

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -1,5 +1,6 @@
 test_image_expiry() {
   local LXD2_DIR LXD2_ADDR
+  # shellcheck disable=2153
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   spawn_lxd "${LXD2_DIR}" true
   LXD2_ADDR=$(cat "${LXD2_DIR}/lxd.addr")

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -199,3 +199,178 @@ test_image_refresh() {
   lxc remote rm l2
   kill_lxd "${LXD2_DIR}"
 }
+
+test_images_public() {
+  echo "==> Check public image handling for untrusted callers"
+  run_images_public
+
+  echo "==> Check public image handling for restricted TLS clients with no permissions"
+  token="$(lxc config trust add --name tmp --restricted --quiet)"
+
+  # Generate certificates.
+  tmpdir="$(mktemp -d -p "${TEST_DIR}" XXX)"
+  LXD_CONF="${tmpdir}" gen_cert_and_key client
+
+  # Gain trust.
+  LXD_CONF="${tmpdir}" lxc remote add tmp "${token}"
+
+  # Rename certificates, this tells "run_images_public" which assertions to run.
+  mv "${tmpdir}/client.crt" "${tmpdir}/restricted.crt"
+  mv "${tmpdir}/client.key" "${tmpdir}/restricted.key"
+
+  # Run test.
+  CERT_DIR="${tmpdir}" CERT_NAME="restricted" run_images_public
+
+  # Clean up.
+  lxc config trust remove "$(cert_fingerprint "${tmpdir}/restricted.crt")"
+  rm -rf "${tmpdir}"
+
+  echo "==> Check public image handling for fine-grained TLS clients with no groups"
+  token="$(lxc auth identity create tls/tmp --quiet)"
+
+  # Generate certificates.
+  tmpdir="$(mktemp -d -p "${TEST_DIR}" XXX)"
+  LXD_CONF="${tmpdir}" gen_cert_and_key client
+
+  # Gain trust.
+  LXD_CONF="${tmpdir}" lxc remote add tmp "${token}"
+
+  # Rename certificates, this tells "run_images_public" which assertions to run.
+  mv "${tmpdir}/client.crt" "${tmpdir}/fine-grained.crt"
+  mv "${tmpdir}/client.key" "${tmpdir}/fine-grained.key"
+
+  # Run test.
+  CERT_DIR="${tmpdir}" CERT_NAME="fine-grained" run_images_public
+
+  # Clean up.
+  lxc auth identity delete tls/tmp
+  rm -rf "${tmpdir}"
+}
+
+run_images_public() {
+  query() {
+    # Function to use for querying. (Cant use my_curl for untrusted requests).
+    # SC2068 is disabled because we do want arguments to be re-split.
+    url="${1}"
+    shift
+    if [ -n "${CERT_DIR:-}" ]; then
+      # shellcheck disable=2153,2068
+      curl -s --cacert "${LXD_DIR}/server.crt" --cert "${CERT_DIR}/${CERT_NAME}.crt" --key "${CERT_DIR}/${CERT_NAME}.key" "https://${LXD_ADDR}${url}" ${@}
+    else
+      # shellcheck disable=2153,2068
+      curl -s --cacert "${LXD_DIR}/server.crt" "https://${LXD_ADDR}${url}" ${@}
+    fi
+  }
+
+  # Add a private image to the default project.
+  deps/import-busybox --alias default-img
+
+  # Create a project and import an image.
+  lxc project create foo
+  deps/import-busybox --project foo --alias foo-img
+
+  # All callers see an empty list of images in the default project.
+  query /1.0/images | jq -e '(.metadata | length) == 0 and .status_code == 200'
+  query /1.0/images?project=default | jq -e '(.metadata | length) == 0 and .status_code == 200'
+  query /1.0/images?recursion=1 | jq -e '(.metadata | length) == 0 and .status_code == 200'
+  query /1.0/images?recursion=1\&project=default | jq -e '(.metadata | length) == 0 and .status_code == 200'
+
+  if [ "${CERT_NAME:-}" = "restricted" ]; then
+    # Restricted TLS client cannot see images in project foo, nor use the all-projects parameter.
+    query /1.0/images?project=foo | jq -e '.error == "Certificate is restricted" and .error_code == 403'
+    query /1.0/images?all-projects=true | jq -e '.error == "Certificate is restricted" and .error_code == 403'
+    query /1.0/images?recursion=1\&project=foo | jq -e '.error == "Certificate is restricted" and .error_code == 403'
+    query /1.0/images?recursion=1\&all-projects=true | jq -e '.error == "Certificate is restricted" and .error_code == 403'
+  elif [ "${CERT_NAME:-}" = "fine-grained" ]; then
+    # Fine-grained TLS client cannot see images in project foo, nor use the all-projects parameter.
+    # However, unlike the restricted certificate they will see an empty list (in line with all other list APIs).
+    query /1.0/images?project=foo | jq -e '(.metadata | length) == 0 and .status_code == 200'
+    query /1.0/images?all-projects=true  | jq -e '(.metadata | length) == 0 and .status_code == 200'
+    query /1.0/images?recursion=1\&project=foo  | jq -e '(.metadata | length) == 0 and .status_code == 200'
+    query /1.0/images?recursion=1\&all-projects=true  | jq -e '(.metadata | length) == 0 and .status_code == 200'
+  else
+    # Untrusted callers see a generic 404 for project foo, or a 403 if using "all-projects".
+    query /1.0/images?project=foo | jq -e '.error == "Not Found" and .error_code == 404'
+    query /1.0/images?all-projects=true | jq -e '.error == "You must be authenticated" and .error_code == 403'
+    query /1.0/images?recursion=1\&project=foo | jq -e '.error == "Not Found" and .error_code == 404'
+    query /1.0/images?recursion=1\&all-projects=true | jq -e '.error == "You must be authenticated" and .error_code == 403'
+  fi
+
+  if [ "${CERT_NAME:-}" = "restricted" ]; then
+    # Restricted caller doesn't have permission on project foo.
+    query /1.0/images/aliases/foo-img?project=foo | jq -e '.error == "User does not have permission for project \"foo\"" and .error_code == 403'
+  else
+    # Untrusted and fine-grained callers cannot view the alias for the image in project foo (even though it is "public").
+    query /1.0/images/aliases/foo-img?project=foo | jq -e '.error == "Not Found" and .error_code == 404'
+  fi
+
+  # Get the image fingerprint.
+  fingerprint="$(lxc query /1.0/images/aliases/foo-img?project=foo | jq -r '.target')"
+  if [ "${CERT_NAME:-}" = "restricted" ]; then
+    # Restricted callers can't view or export the image - returning 403 in line with other APIs.
+    query "/1.0/images/${fingerprint}?project=foo" | jq -e '.error == "User does not have permission for project \"foo\"" and .error_code == 403'
+    query "/1.0/images/${fingerprint}/export?project=foo" | jq -e '.error == "User does not have permission for project \"foo\"" and .error_code == 403'
+  else
+    # Fine-grained and untrusted callers get a generic 404.
+    query "/1.0/images/${fingerprint}?project=foo" | jq -e '.error == "Not Found" and .error_code == 404'
+    query "/1.0/images/${fingerprint}/export?project=foo" | jq -e '.error == "Not Found" and .error_code == 404'
+  fi
+
+  # No callers can use an invalid secret.
+  query /1.0/images/"${fingerprint}"?project=foo\&secret=bar | jq -e '.error == "Image secrets may only be used to access private images in the default project" and .error_code == 403'
+  query /1.0/images/"${fingerprint}"/export?project=foo\&secret=bar | jq -e '.error == "Image secrets may only be used to access private images in the default project" and .error_code == 403'
+
+  # Get a secret for "default-img" (in the default project).
+  secret="$(lxc -X POST query "/1.0/images/${fingerprint}/secret" | jq -r '.metadata.secret')"
+
+  # Untrusted caller can view the image with a valid secret.
+  query /1.0/images/"${fingerprint}"?secret="${secret}" | jq -e '.status_code == 200'
+
+  # Untrusted caller can export the image with a valid secret.
+  query /1.0/images/"${fingerprint}"/export?secret="${secret}" -o "${TEST_DIR}/private.img"
+  [ -f "${TEST_DIR}/private.img" ]
+  rm "${TEST_DIR}/private.img"
+
+  # The secret does not work 5 seconds after being used.
+  sleep 5
+  query /1.0/images/"${fingerprint}"?secret="${secret}" | jq -e '.error == "Not Found" and .error_code == 404'
+  query /1.0/images/"${fingerprint}"/export?secret="${secret}" | jq -e '.error == "Not Found" and .error_code == 404'
+
+  # Set the image in the default project to public.
+  lxc image show "${fingerprint}" | sed -e "s/public: false/public: true/" | lxc image edit "${fingerprint}"
+
+  # All callers can see the public image when listing.
+  query /1.0/images | jq -e '(.metadata | length) == 1 and .status_code == 200'
+  query /1.0/images?project=default | jq -e '(.metadata | length) == 1 and .status_code == 200'
+  query /1.0/images?recursion=1 | jq -e '(.metadata | length) == 1 and .status_code == 200'
+  query /1.0/images?recursion=1\&project=default | jq -e '(.metadata | length) == 1 and .status_code == 200'
+
+  # All callers can view aliases of public images in the default project.
+  query /1.0/images/aliases/default-img | jq -e '.status_code == 200'
+  query /1.0/images/aliases/default-img?project=default | jq -e '.status_code == 200'
+
+  # All callers can get the image with a prefix of 12 characters or more.
+  query "/1.0/images/${fingerprint:0:11}" | jq -r '.error == "Image fingerprint prefix must contain 12 characters or more" and .error_code == 400'
+  query /1.0/images/%25 | jq -r '.error == "Image fingerprint prefix must contain 12 characters or more" and .error_code == 400'
+  query "/1.0/images/%25${fingerprint:0:11}" | jq -r '.error == "Image fingerprint prefix must contain only lowercase hexadecimal characters" and .error_code == 400'
+  query "/1.0/images/${fingerprint:0:12}" | jq -r '.status_code == 200'
+  query "/1.0/images/${fingerprint}" | jq -r '.status_code == 200'
+  query "/1.0/images/${fingerprint}?project=default" | jq -r '.status_code == 200'
+
+  # All callers can export the public image if using a valid prefix.
+  query /1.0/images/%25/export | jq -r '.error == "Image fingerprint prefix must contain 12 characters or more" and .error_code == 400'
+  query "/1.0/images/${fingerprint:0:11}/export" | jq -r '.error == "Image fingerprint prefix must contain 12 characters or more" and .error_code == 400'
+  query "/1.0/images/%25${fingerprint:0:11}/export" | jq -r '.error == "Image fingerprint prefix must contain only lowercase hexadecimal characters" and .error_code == 400'
+  query "/1.0/images/${fingerprint}/export" -o "${TEST_DIR}/public1.img"
+  query "/1.0/images/${fingerprint}/export?project=default" -o "${TEST_DIR}/public2.img"
+  query "/1.0/images/${fingerprint:0:12}/export?project=default" -o "${TEST_DIR}/public3.img"
+  [ -f "${TEST_DIR}/public1.img" ]
+  [ -f "${TEST_DIR}/public2.img" ]
+  [ -f "${TEST_DIR}/public3.img" ]
+  rm "${TEST_DIR}"/public{1,2,3}.img
+
+  # Clean up.
+  lxc image delete "${fingerprint}" --project foo
+  lxc project delete foo
+  lxc image delete "${fingerprint}"
+}

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -237,7 +237,7 @@ test_remote_usage() {
   lxc_remote image copy --quiet "localhost:${sum}" lxd2:
   lxc_remote image delete "lxd2:${sum}"
 
-  lxc_remote image copy --quiet "localhost:$(echo "${sum}" | cut -c 1-2)" lxd2:
+  lxc_remote image copy --quiet "localhost:$(echo "${sum}" | cut -c 1-12)" lxd2:
   lxc_remote image delete "lxd2:${sum}"
 
   # test a private image


### PR DESCRIPTION
Access handling in the image API handlers is complex because:
1. Public images in the default project can be viewed and exported by untrusted callers.
2. Private images in any project can be viewed and exported by callers that do not have permission (either untrusted or authenticated and no permissions) if they have a valid image secret.
3. Image aliases in the default project can be viewed if they reference a public image.
4. Images in the default project can be exported via DevLXD if they are public or cached.

This PR attempts to simplify the logic for how these access control decisions are made by:
1. Refactoring the image export handler to remove DevLXD related logic, and that directly to the DevLXD handler.
2. Adding an access handler to perform access control decisions for image GET and image export.
3. Secrets can now only be obtained for private images in the default project. No official client for LXD supports getting a private image from non-default projects.
4. Preventing public images from being created in non-default projects.

Additionally, all image API handlers get images by their fingerprint prefix (returning an error if more than one fingerprint matches the prefix). However, we generally expect clients to retrieve a full fingerprint via an alias and then use it. Clients should not be querying e.g. `GET /1.0/images/a`. This PR restricts the fingerprint prefix path argument to be at least 12 lowercase hexadecimal characters.

Closes #15075
