### PR TITLE
lxd: Expect content type header octet-stream when creating new instance file  

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1707,6 +1707,8 @@ func (r *ProtocolLXD) CreateInstanceFile(instanceName string, filePath string, a
 		req.Header.Set("X-LXD-modify-perm", strings.Join(modifyPerm, ","))
 	}
 
+	req.Header.Set("Content-Type", "application/octet-stream")
+
 	// Send the request
 	resp, err := r.DoHTTP(req)
 	if err != nil {

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -116,7 +116,7 @@ var instanceFileCmd = APIEndpoint{
 
 	Get:    APIEndpointAction{Handler: instanceFileHandler, AccessHandler: allowPermission(entity.TypeInstance, auth.EntitlementCanAccessFiles, "name")},
 	Head:   APIEndpointAction{Handler: instanceFileHandler, AccessHandler: allowPermission(entity.TypeInstance, auth.EntitlementCanAccessFiles, "name")},
-	Post:   APIEndpointAction{Handler: instanceFileHandler, AccessHandler: allowPermission(entity.TypeInstance, auth.EntitlementCanAccessFiles, "name")},
+	Post:   APIEndpointAction{Handler: instanceFileHandler, AccessHandler: allowPermission(entity.TypeInstance, auth.EntitlementCanAccessFiles, "name"), ContentTypes: []string{"application/octet-stream"}},
 	Delete: APIEndpointAction{Handler: instanceFileHandler, AccessHandler: allowPermission(entity.TypeInstance, auth.EntitlementCanAccessFiles, "name")},
 }
 


### PR DESCRIPTION
Sets the `Content-Type` in `CreateInstanceFile`, to avoid an error like:
```
Could not upload file "/path/to/file": Unsupported Content-Type for this request
```

TODO:
- [ ] Add tests