### PR TITLE
Daemon: Only enforce content-type checks for browser clients

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -169,8 +169,7 @@ func restServer(d *Daemon) *http.Server {
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		ua := r.Header.Get("User-Agent")
-		if strings.Contains(ua, "Gecko") {
+		if isBrowserClient(r) {
 			http.Redirect(w, r, "/ui/", http.StatusMovedPermanently)
 			return
 		}
@@ -224,6 +223,12 @@ func restServer(d *Daemon) *http.Server {
 		Handler:     &lxdHTTPServer{r: mux, d: d},
 		ConnContext: lxdRequest.SaveConnectionInContext,
 	}
+}
+
+// isBrowserClient checks if the request is coming from a browser client.
+func isBrowserClient(r *http.Request) bool {
+	// Check if the User-Agent starts with "Mozilla" which is common for browsers.
+	return strings.HasPrefix(r.Header.Get("User-Agent"), "Mozilla")
 }
 
 func metricsServer(d *Daemon) *http.Server {

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -108,7 +108,9 @@ func restServer(d *Daemon) *http.Server {
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, err := fmt.Fprint(w, errorMessage)
-			logger.Warn("Failed sending error message to client", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr, "err": err})
+			if err != nil {
+				logger.Warn("Failed sending error message to client", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr, "err": err})
+			}
 		})
 		mux.PathPrefix("/ui").Handler(uiHandlerErrorUINotEnabled)
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -949,12 +949,14 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 				action.ContentTypes = []string{"application/json"}
 			}
 
-			// Validate Content-Type if supplied, or if non-zero Content-Length supplied.
-			contentTypeParts := shared.SplitNTrimSpace(r.Header.Get("Content-Type"), ";", 2, false) // Ignore multi-part boundary part.
-			contentLength := r.Header.Get("Content-Length")
-			hasContentLength := contentLength != "" && contentLength != "0"
-			if (hasContentLength || contentTypeParts[0] != "") && !slices.Contains(action.ContentTypes, contentTypeParts[0]) {
-				return response.ErrorResponse(http.StatusUnsupportedMediaType, "Unsupported Content-Type for this request")
+			// Validate browser Content-Type if supplied, or if non-zero Content-Length supplied.
+			if isBrowserClient(r) {
+				contentTypeParts := shared.SplitNTrimSpace(r.Header.Get("Content-Type"), ";", 2, false) // Ignore multi-part boundary part.
+				contentLength := r.Header.Get("Content-Length")
+				hasContentLength := contentLength != "" && contentLength != "0"
+				if (hasContentLength || contentTypeParts[0] != "") && !slices.Contains(action.ContentTypes, contentTypeParts[0]) {
+					return response.ErrorResponse(http.StatusUnsupportedMediaType, "Unsupported Content-Type for this request")
+				}
 			}
 
 			// All APIEndpointActions should have an access handler or should allow untrusted requests.

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -22,8 +22,9 @@ _server_config_access() {
   [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{http_code}" -o /dev/null -H 'Sec-Fetch-Site: same-site' "lxd/1.0")" = "403" ]
 
   # test content type validation.
-  [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{http_code}" -o /dev/null -H "Content-Type: application/json" "lxd/1.0")" = "200" ]
-  [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{http_code}" -o /dev/null -H "Content-Type: foo" "lxd/1.0")" = "415" ]
+  [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{http_code}" -o /dev/null -H "User-Agent: Mozilla/5.0" -H "Content-Type: application/json" "lxd/1.0")" = "200" ]
+  [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{http_code}" -o /dev/null -H "User-Agent: Mozilla/5.0" -H "Content-Type: foo" "lxd/1.0")" = "415" ]
+  [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{http_code}" -o /dev/null -H "User-Agent: LXD" -H "Content-Type: foo" "lxd/1.0")" = "200" ]
 }
 
 _server_config_storage() {

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -25,6 +25,9 @@ _server_config_access() {
   [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{http_code}" -o /dev/null -H "User-Agent: Mozilla/5.0" -H "Content-Type: application/json" "lxd/1.0")" = "200" ]
   [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{http_code}" -o /dev/null -H "User-Agent: Mozilla/5.0" -H "Content-Type: foo" "lxd/1.0")" = "415" ]
   [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{http_code}" -o /dev/null -H "User-Agent: LXD" -H "Content-Type: foo" "lxd/1.0")" = "200" ]
+
+  # test that the /ui redirect works
+  [ "$(curl --silent --unix-socket "$LXD_DIR/unix.socket" -w "%{url_effective}" -o /dev/null --location -H "User-Agent: Mozilla/5.0" "lxd/")" = "http://lxd/ui/" ]
 }
 
 _server_config_storage() {


### PR DESCRIPTION
And change browser client detection to look for user-agents that start with `Mozilla`.