### PR TITLE
doc: backport docs config updates for sitemap and linkcheck (stable-5.21)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -808,6 +808,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # A non-shallow clone is needed for the sitemap generation
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -183,6 +183,8 @@ linkcheck_ignore = [
     'https://www.gnu.org/licenses/agpl-3.0.en.html',
     # 403 from GH runners
     'https://www.schlachter.tech/solutions/pongo2-template-engine/',
+    # Cloudflare protection on SourceForge domains might block linkcheck
+    r"https://.*\.sourceforge\.net/.*",
     ]
 
 # Pages on which to ignore anchors

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -34,6 +34,7 @@ author = 'LXD contributors'
 # To not display any title, set this option to an empty string.
 html_title = ''
 
+# Set global version variable used in objects.inv to numeric version defined in flex.go
 with open("../shared/version/flex.go") as fd:
     version = fd.readlines()[3].split()[-1].strip("\"")
 
@@ -141,15 +142,13 @@ slug = "lxd"
 
 html_baseurl = 'https://documentation.ubuntu.com/lxd/'
 
-# URL scheme. Add language and version scheme elements.
-# When configured with RTD variables, check for RTD environment so manual runs succeed:
-
+# Configures URL scheme for sphinx-sitemap to generate correct URLs
+# based on the version if built in RTD
 if 'READTHEDOCS_VERSION' in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = '{version}{link}'
+    rtd_version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = f'{rtd_version}/{{link}}'
 else:
     sitemap_url_scheme = '{link}'
-
 
 ############################################################
 ### Redirects

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -133,6 +133,24 @@ html_context = {
 # slug (for example, "lxd") here.
 slug = "lxd"
 
+#######################
+# Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
+#######################
+
+# Base URL of RTD hosted project
+
+html_baseurl = 'https://documentation.ubuntu.com/lxd/'
+
+# URL scheme. Add language and version scheme elements.
+# When configured with RTD variables, check for RTD environment so manual runs succeed:
+
+if 'READTHEDOCS_VERSION' in os.environ:
+    version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = '{version}{link}'
+else:
+    sitemap_url_scheme = '{link}'
+
+
 ############################################################
 ### Redirects
 ############################################################
@@ -214,6 +232,7 @@ custom_extensions = [
     'sphinx_remove_toctrees',
     'canonical.filtered-toc',
     'sphinxcontrib.cairosvgconverter',
+    'sphinx_sitemap',
 ]
 
 # Add custom required Python modules that must be added to the
@@ -227,7 +246,8 @@ custom_required_modules = [
     'gitpython',
     'pyyaml',
     'sphinx-remove-toctrees',
-    'sphinxcontrib-svg2pdfconverter[CairoSVG]'
+    'sphinxcontrib-svg2pdfconverter[CairoSVG]',
+    'sphinx-sitemap',
 ]
 
 # Add files or directories that should be excluded from processing.


### PR DESCRIPTION
Cherry-picks [a100d75](https://github.com/canonical/lxd/commit/a100d75c5b7ac31a15255a86591a714fe95c1cca), [0a5abb5](https://github.com/canonical/lxd/commit/0a5abb5dc2c9bfb6b21d191e0a0974781f118ce7), and [2e11304](https://github.com/canonical/lxd/commit/2e1130485ccae69b365489c112d217b15a3196ba) from `main`:
- Adds `sphinx-sitemap` to generate sitemap.xml for stable-5.21 docs version, including updating documentation test workflow to use `fetch-depth: 0` (needed by sitemap dependency `sphinx-last-updated-by-git`; this has the side effect of also fixing the "Last updated" date in docs footer)
- Adds sourceforge domain to linkcheck_ignore list per recent 403 errors during spellcheck, likely linked to cloudflare bot rejection.

  