### PR TITLE
doc: backport docs config updates for sitemap and linkcheck (stable-5.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -458,6 +458,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # A non-shallow clone is needed for the sitemap generation
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/doc/.sphinx/requirements.txt
+++ b/doc/.sphinx/requirements.txt
@@ -39,3 +39,4 @@ sphinx-copybutton
 gitpython
 wget
 sphinx-notfound-page
+sphinx-sitemap

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,7 +40,8 @@ extensions = [
     "sphinx.ext.intersphinx",
     "terminal-output",
     "config-options",
-    "notfound.extension"
+    "notfound.extension",
+    'sphinx_sitemap',
 ]
 
 myst_enable_extensions = [
@@ -168,3 +169,20 @@ linkcheck_ignore = [
 redirects = {
     "production-setup/index": "../explanation/performance_tuning/index.html",
 }
+
+#######################
+# Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
+#######################
+
+# Base URL of RTD hosted project
+
+html_baseurl = 'https://documentation.ubuntu.com/lxd/'
+
+# URL scheme. Add language and version scheme elements.
+# When configured with RTD variables, check for RTD environment so manual runs succeed:
+
+if 'READTHEDOCS_VERSION' in os.environ:
+    version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = '{version}{link}'
+else:
+    sitemap_url_scheme = '{link}'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -178,11 +178,10 @@ redirects = {
 
 html_baseurl = 'https://documentation.ubuntu.com/lxd/'
 
-# URL scheme. Add language and version scheme elements.
-# When configured with RTD variables, check for RTD environment so manual runs succeed:
-
+# Configures URL scheme for sphinx-sitemap to generate correct URLs
+# based on the version if built in RTD
 if 'READTHEDOCS_VERSION' in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = '{version}{link}'
+    rtd_version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = f'{rtd_version}/{{link}}'
 else:
     sitemap_url_scheme = '{link}'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -162,7 +162,9 @@ ogp_image = "https://documentation.ubuntu.com/lxd/en/stable-5.0/_static/tag.png"
 linkcheck_ignore = [
     'https://127.0.0.1:8443/1.0',
     'https://web.libera.chat/#lxd',
-    'https://www.schlachter.tech/solutions/pongo2-template-engine/'
+    'https://www.schlachter.tech/solutions/pongo2-template-engine/',
+    # Cloudflare protection on SourceForge domains might block linkcheck
+    r"https://.*\.sourceforge\.net/.*",
 ]
 
 # Setup redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)


### PR DESCRIPTION
Cherry-picks [a100d75](https://github.com/canonical/lxd/commit/a100d75c5b7ac31a15255a86591a714fe95c1cca), [0a5abb5](https://github.com/canonical/lxd/commit/0a5abb5dc2c9bfb6b21d191e0a0974781f118ce7), and [2e11304](https://github.com/canonical/lxd/commit/2e1130485ccae69b365489c112d217b15a3196ba) from main.

Adds `sphinx-sitemap` to generate `sitemap.xml` for `stable-5.0` docs version, including updating documentation test workflow to use `fetch-depth: 0` (needed by sitemap dependency `sphinx-last-updated-by-git`; this has the side effect of also fixing the "Last updated" date in docs footer)
Adds sourceforge domain to `linkcheck_ignore` list per recent 403 errors during spellcheck, likely linked to cloudflare bot rejection.

Note: The original changes targeted `custom_conf.py`, which does not exist in stable-5.0, so during cherry-picking, I manually adapted the logic into `conf.py` and `requirements.txt`. In stable-5.21+, `requirements.txt` is auto-generated from `custom_conf.py`, but in 5.0, it's static). Functionality remains equivalent.