### PR TITLE
devlxd: Add check for origin PID being in same PID NS as the container name in found process

### DIFF
--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -63,7 +63,7 @@ func load(s *state.State, args db.InstanceArgs, p api.Project) (instance.Instanc
 	case instancetype.VM:
 		inst, err = qemuLoad(s, args, p)
 	default:
-		return nil, fmt.Errorf("Invalid instance type for instance %s", args.Name)
+		return nil, fmt.Errorf("Invalid type for instance %q", args.Name)
 	}
 
 	if err != nil {

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -380,7 +380,7 @@ func LoadByProjectAndName(s *state.State, projectName string, instanceName strin
 
 	inst, err := Load(s, args, *p)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to load instance: %w", err)
+		return nil, fmt.Errorf("Failed loading instance: %w", err)
 	}
 
 	return inst, nil

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -1453,7 +1453,6 @@ func (s *Server) HandleMknodatSyscall(c Instance, siov *Iovec) int {
 	// built on 64bit userspace correctly.
 	if int32(siov.req.data.args[0]) != int32(C.AT_FDCWD) {
 		ctx["err"] = "Non AT_FDCWD mknodat calls are not allowed"
-		logger.Debug("bla", ctx)
 		if s.s.OS.SeccompListenerContinue {
 			ctx["syscall_continue"] = "true"
 			C.seccomp_notify_update_response(siov.resp, 0, C.uint32_t(seccompUserNotifFlagContinue))


### PR DESCRIPTION
If the process name looks like a lxc monitor process, but claims to be a different container than the origin process' PID namespace then continue walking up the process tree to find the real lxc monitor process.