### PR TITLE
doc: pin canonical-sphinx-extensions version

### DIFF
--- a/doc/.sphinx/build_requirements.py
+++ b/doc/.sphinx/build_requirements.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     requirements.extend(custom_required_modules)
 
     if IsAnyCanonicalSphinxExtensionUsed():
-        requirements.append("canonical-sphinx-extensions")
+        requirements.append("canonical-sphinx-extensions==0.0.27")
 
     if IsNotFoundExtensionUsed():
         requirements.append("sphinx-notfound-page")


### PR DESCRIPTION
Recent buggy update to canonical-sphinx-extensions causing build failures with "WARNING: more than one target found for 'myst' cross-reference" messages. This PR pins the extension to a previous version. 