### PR TITLE
lxd: Validate image fingerprint prefixes

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -159,6 +159,11 @@ func addImageDetailsToRequestContext(s *state.State, r *http.Request) error {
 		return err
 	}
 
+	err = validateImageFingerprintPrefix(imageFingerprintPrefix)
+	if err != nil {
+		return err
+	}
+
 	requestProjectName := request.ProjectParam(r)
 	effectiveProjectName := requestProjectName
 	var imageID int

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -119,6 +119,28 @@ var imageAliasCmd = APIEndpoint{
 	Put:    APIEndpointAction{Handler: imageAliasPut, AccessHandler: imageAliasAccessHandler(auth.EntitlementCanEdit)},
 }
 
+// validateImageFingerprintPrefix validates that the given string is at least 12 characters long contains only lowercase
+// hex characters.
+func validateImageFingerprintPrefix(prefix string) error {
+	// 12 characters is chosen because this is the length of the fingerprint as displayed in the CLI when listing images.
+	if len(prefix) < 12 {
+		return api.NewStatusError(http.StatusBadRequest, "Image fingerprint prefix must contain 12 characters or more")
+	}
+
+	if len(prefix) > 64 {
+		return api.NewStatusError(http.StatusBadRequest, "Image fingerprint cannot be longer than 64 characters")
+	}
+
+	// Prefixes containing non-hex or uppercase characters can never match an image.
+	for _, b := range []byte(prefix) {
+		if (b < '0' || b > '9') && (b < 'a' || b > 'f') {
+			return api.NewStatusError(http.StatusBadRequest, "Image fingerprint prefix must contain only lowercase hexadecimal characters")
+		}
+	}
+
+	return nil
+}
+
 const ctxImageDetails request.CtxKey = "image-details"
 
 // imageDetails contains fields that are determined prior to the access check. This is set in the request context when

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3154,6 +3154,11 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	err = validateImageFingerprintPrefix(fingerprint)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeImage, false)
 	if err != nil {
 		return response.SmartError(err)
@@ -4230,6 +4235,11 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 
 	projectName := request.ProjectParam(r)
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	err = validateImageFingerprintPrefix(fingerprint)
 	if err != nil {
 		return response.SmartError(err)
 	}


### PR DESCRIPTION
This PR enforces that requests to `/1.0/images/{fingerprint}` contain a fingerprint prefix that is longer than 12 characters, shorter than 64 characters, and contains only lowercase hexadecimal characters.

This prevents misuse. Clients should always be sending at least a short SHA in order to be certain they are operating on the correct image.