### PR TITLE
tests: Test instance file push using strings.Reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ lxd-migrate/lxd-migrate
 lxd-user/lxd-user
 test/busybox.tar.xz.cache
 test/devlxd-client/devlxd-client
+test/lxd-client/lxd-client
 test/syscall/sysinfo/sysinfo
 test/mini-oidc/mini-oidc
 test/mini-oidc/user.data

--- a/test/lxd-client/main.go
+++ b/test/lxd-client/main.go
@@ -1,0 +1,79 @@
+package main
+
+/*
+ * A small LXD client used to test specific edge cases.
+ */
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	lxdClient "github.com/canonical/lxd/client"
+)
+
+type commandFunc func(client lxdClient.InstanceServer, args []string) error
+
+var commands = map[string]commandFunc{
+	"file-push": cmdInstanceFilePush,
+}
+
+// cmdInstanceFilePush creates a file on the instance with an optional string content.
+func cmdInstanceFilePush(client lxdClient.InstanceServer, args []string) error {
+	if len(args) < 2 || len(args) > 3 {
+		return fmt.Errorf("Usage: %s file-push <instName> <instFilePath> [<content>]", path.Base(os.Args[0]))
+	}
+
+	instName := args[0]
+	instFilePath := args[1]
+
+	contentString := ""
+	if len(args) == 3 {
+		contentString = args[2]
+	}
+
+	instFileArgs := lxdClient.InstanceFileArgs{
+		Content: strings.NewReader(contentString),
+		Mode:    0755,
+	}
+
+	return client.CreateInstanceFile(instName, instFilePath, instFileArgs)
+}
+
+func run(args []string) error {
+	client, err := lxdClient.ConnectLXDUnix("", nil)
+	if err != nil {
+		return err
+	}
+
+	defer client.Disconnect()
+
+	cmdName := ""
+	if len(args) > 1 {
+		cmdName = args[1]
+	}
+
+	// Find an run command.
+	for name, run := range commands {
+		if name == cmdName {
+			return run(client, args[2:])
+		}
+	}
+
+	// Command not found, show available commands.
+	names := make([]string, 0, len(commands))
+	for name := range commands {
+		names = append(names, name)
+	}
+
+	return fmt.Errorf("Unknown command %q\n\nAvailable commands:\n%s", cmdName, strings.Join(names, "\n"))
+}
+
+func main() {
+	err := run(os.Args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
+	}
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -492,6 +492,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_container_snapshot_config "container snapshot configuration"
     run_test test_server_config "server configuration"
     run_test test_filemanip "file manipulations"
+    run_test test_filemanip_req_content_type "request content-type header verification during file push"
     run_test test_network "network management"
     run_test test_network_acl "network ACL management"
     run_test test_network_forward "network address forwards"

--- a/test/suites/filemanip.sh
+++ b/test/suites/filemanip.sh
@@ -174,3 +174,20 @@ test_filemanip() {
   lxc project switch default
   lxc project delete test
 }
+
+test_filemanip_req_content_type() {
+  inst="c-file-push"
+
+  lxc launch testimage "${inst}"
+
+  # This ensures strings.Reader works correctly with the content-type check.
+  # The specific here is that the net/http package will configure the
+  # content-length on the request, which in LXD triggers content-type check.
+  (
+    cd lxd-client
+    go run . file-push "${inst}" /tmp/status.txt "success"
+    [ "$(lxc exec "${inst}" -- cat /tmp/status.txt)" = "success" ]
+  )
+
+  lxc delete "${inst}" --force
+}


### PR DESCRIPTION
Test file push using `strings.Reader` which causes the `Content-Length` to be set by `(net/http).NewRequest()`. This test is for https://github.com/canonical/lxd/pull/15974