### PR TITLE
Correctly set project of private image remote on init/launch/refresh

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -499,6 +499,12 @@ func (r *ProtocolLXD) getSourceImageConnectionInfo(source ImageServer, image api
 		return nil, nil
 	}
 
+	// If the image source is a private LXD server, set the project of the client as the project for the instance source.
+	instanceServer, ok := source.(*ProtocolLXD)
+	if ok && instanceServer.project != "" {
+		instSrc.Project = instanceServer.project
+	}
+
 	// Minimal source fields for remote image
 	instSrc.Mode = "pull"
 

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -393,6 +393,16 @@ func getImgInfo(d lxd.InstanceServer, conf *config.Config, imgRemote string, ins
 		if err != nil {
 			return nil, nil, err
 		}
+
+		// Check if the image server is actually a private LXD server. If it is, tell it to use the project that is
+		// configured for that remote. This is because "GetImageServer" will overwrite the configured project with the
+		// --project flag, but for init, launch, and rebuild we don't want to apply the project override to the image
+		// remote. Contextually, the --project flag in this case is for the private LXD server where the instance is
+		// being created, not the image source.
+		instanceServer, ok := imgRemoteServer.(lxd.InstanceServer)
+		if ok {
+			imgRemoteServer = instanceServer.UseProject(conf.Remotes[imgRemote].Project)
+		}
 	}
 
 	// Optimisation for simplestreams

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -63,18 +63,19 @@ func ensureDownloadedImageFitWithinBudget(ctx context.Context, s *state.State, o
 	}
 
 	imgDownloaded, err := ImageDownload(ctx, s, op, &ImageDownloadArgs{
-		Server:       source.Server,
-		Protocol:     source.Protocol,
-		Certificate:  source.Certificate,
-		Secret:       source.Secret,
-		Alias:        imgAlias,
-		SetCached:    true,
-		Type:         imgType,
-		AutoUpdate:   autoUpdate,
-		Public:       false,
-		PreferCached: true,
-		ProjectName:  p.Name,
-		Budget:       budget,
+		Server:            source.Server,
+		Protocol:          source.Protocol,
+		Certificate:       source.Certificate,
+		Secret:            source.Secret,
+		Alias:             imgAlias,
+		SetCached:         true,
+		Type:              imgType,
+		AutoUpdate:        autoUpdate,
+		Public:            false,
+		PreferCached:      true,
+		ProjectName:       p.Name,
+		Budget:            budget,
+		SourceProjectName: source.Project,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In #15957 I disallowed creation of image secrets for images that are not in the default project. This turns out to be a mistake because it's possible to download a private image from any project (as exemplified by `lxc image copy`). In any case, the change caused a test failure in `clustering_groups` that took a little while to investigate.

The line that failed is https://github.com/canonical/lxd/blob/7c479927ae89ca218338abc9cdbf527725eeaef5/test/suites/clustering.sh#L4058

The command expects to initialise instance `c1` on remote `cluster` in project `foo`. The `testimage` is an alias of the busybox image that was imported earlier in the suite to the default remote; the image is private.

The only reason that this command currently succeeds is that the busybox image was imported into the `default` project in the `cluster` remote earlier in the suite. Here is a run down of what is happening:
1. Client queries `(local) GET /1.0`.
2. Client queries `(local) GET /1.0/images/aliases/testimage?project=foo` on the local remote. 
    - This is because the `--project` flag is being applied to both the image and instance remotes. 
    - In this context, the `--project` flag should only mean "where to put the instance", and not "where to get the image". 
    - Even though the image was not imported into project `foo`, this works because project `foo` has `features.images=false`.
4. Client queries `(local) GET /1.0/images/{fingerprint}?project=foo` using the fingerprint of the alias.
5. Client queries `(local) POST /1.0/images/{fingerprint}/secret?project=foo` because the image is private.
6. Client creates an `api.InstanceSource` using the `api.Image`, the image secret, and connection details from `GET /1.0`. Then queries `(cluster) POST /1.0/instances?project=foo`. Crucially, the `project` field is omitted from the instance source.
7. The `cluster` remote sees that it already has an image with the same fingerprint and continues with that image.

At step 7, if the `cluster` remote did not already have the image, it would make an untrusted call to `GET /1.0/images/{fingerprint}?secret={secret}`. This call would fail because the image token operation is defined in project `foo` (and not `default`, which is implicit from the lack of a `project` parameter).

When image secrets were disallowed for non-default projects, this failed at step 4.

This PR does three things to fix this:
1. Use the current project for the image remote when performing an `init`, `launch`, or `refresh`. We can later add a flag to override this (such as `--image-project` or `--source-project`) but crucially, the `--project` flag is not used for the image remote.
2. Set the project in the `api.InstanceSource` before performing the `POST /1.0/instances`.
3. Plumb the source project into the `ImageDownloadArgs` when creating or refreshing an instance.

I didn't add any API extensions for this because all the relevant fields were already in place, they just needed to be connected up. 

This is a change in behaviour for `init`/`launch`/`refresh` if the image remote is a private LXD server, but I don't think it's likely that anyone is relying on this behaviour.